### PR TITLE
Documentation Spelling

### DIFF
--- a/docs/backup-files.md
+++ b/docs/backup-files.md
@@ -8,7 +8,7 @@ The file we create is a [standard 7z archive](https://en.wikipedia.org/wiki/7z)
 with AES-256 encryption, in CBC mode. The 256-bit key is a SHA256 hash of a passphrase,
 hashed in a particular way to support 7z compatibility. We know
 the passphrase has at least 128-bits of entropy because the Coldcard
-uses it's true random number generator (TRNG) to pick it.
+uses its true random number generator (TRNG) to pick it.
 
 Once decrypted, which is possible using any 7z archive tool, the
 contents are a simple text file with everything you could need to
@@ -54,7 +54,7 @@ easy to read.
 ### Encrypted File
 
 ```
-% hd backup.7z 
+% hd backup.7z
 00000000  37 7a bc af 27 1c 00 03  46 de 5e ba 30 02 00 00  |7z..'...F.^.0...|
 00000010  00 00 00 00 6e 00 00 00  00 00 00 00 e0 5c a0 0e  |....n........\..|
 00000020  68 1a 57 0a ed 5b 77 89  ea 4a 84 72 d4 75 d6 bd  |h.W..[w..J.r.u..|
@@ -112,7 +112,7 @@ a real Coldcard to make your own.
 ### Archive Contents
 
 ```
-% 7z l backup.7z 
+% 7z l backup.7z
 
 7-Zip [64] 15.09 beta : Copyright (c) 1999-2015 Igor Pavlov : 2015-10-16
 p7zip Version 15.09 beta (locale=utf8,Utf16=on,HugeFiles=on,64 bits,4 CPUs x64)
@@ -138,7 +138,7 @@ Blocks = 1
                                    559          560  1 files
 ```
 
-No passphrase is required to do this, and it does check CRC32 values, so 
+No passphrase is required to do this, and it does check CRC32 values, so
 simple truncation or unintentional corruption can be easily detected, without
 knowledge of the passphrase.
 
@@ -164,9 +164,9 @@ Method = 7zAES
 Solid = -
 Blocks = 1
 
-    
+
 Enter password (will not be echoed):
-Everything is Ok      
+Everything is Ok
 
 Size:       559
 Compressed: 702
@@ -178,7 +178,7 @@ This process creates a file `ckcc-backup.txt` in the current directory.
 ### Contents of ckcc-backup.txt
 
 ```
-% cat ckcc-backup.txt 
+% cat ckcc-backup.txt
 # Coldcard backup file! DO NOT CHANGE.
 
 # Private key details

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -37,7 +37,7 @@
 # Max Transaction Size
 
 - we support transactions up to 384k-bytes in size when serialized into PSBT format
-- bitcoin limits transactions to 100k, but there could be large input transactions 
+- bitcoin limits transactions to 100k, but there could be large input transactions
   inside the PSBT. Reduce this by using segwit signatures and provide only the
   individual UTXO ("out points").
 - we can handle transactions with up to 20 inputs to be signed at one time.
@@ -64,7 +64,7 @@
 
 # Policy Stuff
 
-- Coldcard will reject any txn that pays a fee of more than 10% of it's total value to miners.
+- Coldcard will reject any txn that pays a fee of more than 10% of its total value to miners.
   (Might become a setting someday.)
 
 # Developer / Source Code

--- a/docs/memory-map.md
+++ b/docs/memory-map.md
@@ -33,7 +33,7 @@ Flash above `0x0800 8000` can be examined directly from python programs.
 
 ## Security Measures
 
-- On entry the bootloader always wipes it's entire working SRAM2 area. You may change 
+- On entry the bootloader always wipes its entire working SRAM2 area. You may change
   it, or even use it for very temporary storage, but it will be destroyed once the callgate
   into the bootloader is accessed.
 - All of SRAM1 and SRAM2 is cleared on boot up, and when the "secure logout" feature is used.

--- a/docs/pin-entry.md
+++ b/docs/pin-entry.md
@@ -8,13 +8,13 @@
 word list. This two word response is unique to your Coldcard and pin combination.
 
 3) Look at the words. Are they right and what you expected? If not,
-press X and try again, and/or talk to your 
+press X and try again, and/or talk to your
 ["evil maid" about her activities](https://en.wikipedia.org/wiki/Rootkit#bootkit).
 Do not continue to enter more digits of your real PIN!
 
 4) If you want to proceed, and you have a secondary wallet enabled, press (2) to select
-   the secondary wallet, otherwise, just press OK to continue for primary wallet (1). 
-  
+   the secondary wallet, otherwise, just press OK to continue for primary wallet (1).
+
 5) Then enter the remaining digits of the PIN (between 2 and 6 digits). Press OK.
 
 6) Is it the user-defined "brick me" PIN? If so, it's used to wipe
@@ -101,7 +101,7 @@ But this approach doesn't work because:
 - You might not be able to directly touch the subject Coldcard at the critical moment.
 - You might be forced to give a PIN code via phone or text message
 - You can write down a duress or brickme PIN in places where it might be found by
-  bad actors, but you can't trick someone into pressing an undocumented key at a 
+  bad actors, but you can't trick someone into pressing an undocumented key at a
   specific time.
 - Special PIN codes are fully configurable for the same reason: we can't make 666-666
   do something special if a quick Google tells anyone that's a trap.
@@ -120,7 +120,7 @@ the main protection against replay attacks, and monitoring the bus passively.
 
 Furthermore:
 
-- you cannot separate the secure element from main micro, and then brute-force the PIN. 
+- you cannot separate the secure element from main micro, and then brute-force the PIN.
 - monitoring the connection to the secure element does not reveal the PIN (or any protected secrets)
 - there is no way to read (or change) the wallet seed without the PIN
 - there is no way to change the PIN without knowing the old PIN
@@ -294,7 +294,7 @@ Idea: Find or steal a Coldcard. Load your trojan firmware onto it. Profit.
 - so changing the firmware is not easy since it does little without the main PIN: you
   will have to crack the welded case, and do some difficult soldering.
 - regardless, once you change the firmware, red caution light will show
-- since you can't set the genuine light without the PIN, and your trojan is signed 
+- since you can't set the genuine light without the PIN, and your trojan is signed
   with key zero, when the victim gets back,
   they will see the big "unauthorized firmware" warning, plus the red light and probably
   some scratches on the case, etc.
@@ -304,7 +304,7 @@ Idea: Find or steal a Coldcard. Load your trojan firmware onto it. Profit.
 
 ## Four Types of wallets, one Coldcard
 
-The Coldcard effectively supports four independent wallets: 
+The Coldcard effectively supports four independent wallets:
 primary (main), secondary, main duress, secondary duress.
 
 The secondary wallet is a little less capable than the main one,
@@ -328,8 +328,8 @@ higher levels of software, operation proceeds normally.
 When creating the duress wallet, Coldcard derives the wallet root
 from the real wallet by a one-way process. This means when you
 backup the main wallet, you are also backing up the corresponding
-duress wallet and it's give-away funds. Writing down the main
-wallet's seed words, will include the duress wallet and it's funds.
+duress wallet and its give-away funds. Writing down the main
+wallet's seed words will include the duress wallet and its funds.
 
 The duress wallet operates like any other wallet on the Coldcard.
 Load value and sign transactions as normal. By design, it acts just
@@ -458,7 +458,7 @@ this limiting.
 We've made some bold claims above. How can you be sure we implemented it
 as described?
 
-First, please learn more about the secure element: the 
+First, please learn more about the secure element: the
 [Microchip ATECC508A](https://www.microchip.com/wwwproducts/en/ATECC508A)
 The full datasheet recently has been made public after being under NDA for
 years. To get further into our design, you will need to understand the chip's

--- a/stm32/bootloader/README.md
+++ b/stm32/bootloader/README.md
@@ -7,7 +7,7 @@ important part in that process.
 
 # Firewalled Code/Data
 
-This code is linked separately from other executables, and resides in it's own
+This code is linked separately from other executables, and resides in its own
 reserved area at the start of flash memory. That area is protected from readback
 using chip features: "Proprietary Code Read-Out Protection (PCROP)" aka. firewall.
 
@@ -36,7 +36,7 @@ your key storage per-system unique.
 - To clear flash with write protect on... FLASH regs at 0x40022000 base
     FLASH->CR = 0x40022014
     FLASH->WRP1AR = 0x4002202c
-    
+
     # have DFU active. doesn't work from running
     halt
     # expect 0x40000000, if it's 0xc0000000, can't work; reboot w/ DFU pressed, to fix
@@ -68,11 +68,11 @@ your key storage per-system unique.
 - working in RAM @ 0x10000000
 - need to encode the reset vector (into boot loader) and also be a valid sequence of thumb insts
 - best if it doesn't mangle R1-R4,LR so they can be used for callgate API
-- I require: 08000 xxxx where 
+- I require: 08000 xxxx where
         - LSB of x is one (thumb mode),
         - and (x) is less than 0x7800
         - preferably x is small
-    
+
     mwh 0x10000000 0x00b1
     mwh 0x10000002 0x0800
     stm32l4x.cpu arm disassemble 0x10000000 2 thumb


### PR DESCRIPTION
Changes occurrences of "it's" to "its" where appropriate within project documentation. One errant comma removed.

My editor removed whitespace from line endings as well.