### PR TITLE
Code Spelling

### DIFF
--- a/misc/obsolete-code/secel.py
+++ b/misc/obsolete-code/secel.py
@@ -90,7 +90,7 @@ def slot_layout(slot_num):
 
     raise ValueError(slot_num)
 
-    
+
 def crc16w(data, starting_value = 0):
     # CRC algo used by chip for error detect in communications
     data = bytearray(data)
@@ -344,7 +344,7 @@ class SecureElement:
             else:
                 delay = 20
 
-        # delay for chip to do it's maths
+        # delay for chip to do its maths
         sleep_ms(delay)
 
         while 1:
@@ -387,7 +387,7 @@ class SecureElement:
 
             if expect != resp[-2:]:
                 raise CRCError()
-            
+
             return resp[1:-2]
 
     def ae_cmd(self, **kws):
@@ -537,7 +537,7 @@ class SecureElement:
                                         [n for n in included if not self.d_slot[n]])
             assert all(len(self.d_slot[i]) == slot_layout(i)[1] for i in included), \
                         repr([len(i) for i in self.d_slot])
-    
+
             data = b''.join(data)
 
             # we're not supporting pre-loading OTP area yet, so better be blank
@@ -638,7 +638,7 @@ class SecureElement:
             # NOTE: response is the (old) contents of the RNG, not the TempKey value itself.
             assert len(rndout) == 32
 
-            # TempKey on the chip will be set to the output of SHA256 over 
+            # TempKey on the chip will be set to the output of SHA256 over
             # a message composed of my challenge, the RNG and 3 bytes of constants:
             return sha256(bytes(rndout) + ch2 + b'\x16\0\0').digest()
 
@@ -673,7 +673,7 @@ class SecureElement:
         skey = SigningKey.from_string(secret, curve=NIST256p, hashfunc=sha256)
 
         skey.verifying_key.verify_digest(sig_rs, mhash)
-        
+
 
     def write_ec_pubkey(self, slot_num, pubxy, signkey=None, do_lock=False):
         "Write a known public key, and verify it is right."
@@ -738,10 +738,10 @@ class SecureElement:
         "verify we know the SHA256 key in slot n"
         assert len(hkey) == 32
 
-        # Note: cannot read back while data zone is unlocked, but we 
+        # Note: cannot read back while data zone is unlocked, but we
         # can use the key right away in a CheckMac operation and that verifies
         # it real good.
-        
+
         challenge = self.load_nonce()
 
         # 32 bytes of "client challenge" and 13 bytes of "other data" are needed, but
@@ -830,13 +830,13 @@ class SecureElement:
 
         # "authorizing mac" is also required to be sent:
         # SHA-256(TempKey, Opcode, Param1, Param2, SN<8>, SN<0:1>, <25 bytes of zeros>, PlainTextData)
-        msg = (dig 
-                + ustruct.pack('<bbH', OP.Write, args['p1'], args['p2']) 
+        msg = (dig
+                + ustruct.pack('<bbH', OP.Write, args['p1'], args['p2'])
                 + b'\xee\x01\x23'
                 + (b'\0'*25)
                 + new_value)
         assert len(msg) == 32+1+1+2+1+2+25+32
-                                
+
         auth_mac = sha256(msg).digest()
 
         rv = self.ae_cmd1(body=enc+auth_mac, **args)

--- a/shared/backups.py
+++ b/shared/backups.py
@@ -15,7 +15,7 @@ from uio import StringIO
 num_pw_words = const(12)
 
 def render_backup_contents():
-    # simple text format: 
+    # simple text format:
     #   key = value
     # or #comments
     # but value is JSON
@@ -58,7 +58,7 @@ def render_backup_contents():
             dpk = sv.duress_root()
             ADD('duress_xprv', chain.serialize_private(dpk))
             ADD('duress_xpub', chain.serialize_public(dpk))
-    
+
     COMMENT('Firmware version (informational)')
     date, vers, timestamp = version.get_mpy_version()[0:3]
     ADD('fw_date', date)
@@ -256,7 +256,7 @@ async def write_complete_backup(words, fname_pattern, write_sflash):
                 msg = '''Backup file written:\n\n%s\n\n\
 To view or restore the file, you must have the full password.\n\n\
 Insert another SD card and press 2 to make another copy.''' % (nice)
-    
+
                 ch = await ux_show_story(msg, escape='2')
 
                 if ch == 'y': return
@@ -329,7 +329,7 @@ async def restore_complete_doit(fname_or_fd, words):
     # build password
     password = ' '.join(words)
 
-    # filename already picked, taste it and maybe consider using it's data.
+    # filename already picked, taste it and maybe consider using its data.
     try:
         fd = open(fname_or_fd, 'rb') if isinstance(fname_or_fd, str) else fname_or_fd
     except:
@@ -387,7 +387,7 @@ async def restore_complete_doit(fname_or_fd, words):
 def generate_public_contents():
     # Generate public details about wallet.
     #
-    # simple text format: 
+    # simple text format:
     #   key = value
     # or #comments
     # but value is JSON
@@ -413,7 +413,7 @@ For BIP44, this is coin_type '{ct}', and internally we use symbol {sym} for this
 Derived public keys, as may be needed for different systems:
 
 
-'''.format(nb=chain.name, xpub=chain.serialize_public(sv.node), 
+'''.format(nb=chain.name, xpub=chain.serialize_public(sv.node),
             sym=chain.ctype, ct=chain.b44_cointype))
 
         for name, path, addr_fmt in chains.CommonDerivations:
@@ -451,7 +451,7 @@ async def make_summary_file(fname_pattern='public.txt'):
     body = generate_public_contents()
 
     # choose a filename
-        
+
     try:
         with CardSlot() as card:
             fname, nice = card.pick_filename(fname_pattern)
@@ -503,7 +503,7 @@ def generate_electrum_wallet(is_segwit):
                             label='Coldcard Import 0x%08x' % xfp,
                             type='hardware',
                             derivation=derive, xpub=top)
-        
+
     return rv
 
 async def make_electrum_wallet(fname_pattern='new-wallet.json', is_segwit=False):
@@ -518,7 +518,7 @@ async def make_electrum_wallet(fname_pattern='new-wallet.json', is_segwit=False)
     body = generate_electrum_wallet(is_segwit)
 
     # choose a filename
-        
+
     try:
         with CardSlot() as card:
             fname, nice = card.pick_filename(fname_pattern)

--- a/shared/callgate.py
+++ b/shared/callgate.py
@@ -1,7 +1,7 @@
 # (c) Copyright 2018 by Coinkite Inc. This file is part of Coldcard <coldcardwallet.com>
 # and is covered by GPLv3 license found in COPYING.
 #
-# callgate.py - thin wrapper around modckcc and the bootloader and it's services.
+# callgate.py - thin wrapper around modckcc and the bootloader and its services.
 #
 import ckcc
 
@@ -12,13 +12,13 @@ def get_bl_version():
     ln = ckcc.gate(0, rv, 0)
     ver, *args = str(rv[0:ln], 'utf8').split(' ')
     return ver, [tuple(i.split('=', 1)) for i in args]
-    
+
 def get_bl_checksum(salt=0):
     # salted checksum over code
     rv = bytearray(32)
     ckcc.gate(1, rv, salt)
     return rv
-    
+
 def enter_dfu(msg=0):
     # enter DFU while showing a message
     #   0 = normal DFU
@@ -84,7 +84,7 @@ def get_highwater():
     ckcc.gate(21, arg, 0)
 
     return arg
-    
+
 def set_highwater(ts):
     arg = bytearray(ts)
     return ckcc.gate(21, arg, 2)

--- a/shared/main.py
+++ b/shared/main.py
@@ -60,7 +60,7 @@ settings = SettingsObject(loop)
 
 async def done_splash2():
     # Boot up code; after splash screen is done.
-                
+
     # MAYBE: check if we're a brick and die again? Or show msg?
 
     if version.is_factory_mode():
@@ -89,7 +89,7 @@ async def done_splash2():
 async def mainline():
     # Mainline of program, after startup
     #
-    # - Do not add to this function, it's vars are
+    # - Do not add to this function, its vars are
     #   in memory forever; instead, extend done_splash2 above.
     from ux import the_ux
 

--- a/stm32/COLDCARD/modckcc.c
+++ b/stm32/COLDCARD/modckcc.c
@@ -3,7 +3,7 @@
 // and is covered by GPLv3 license found in COPYING.
 //
 // modckcc.c - module for Coldcard hardware features and glue.
-// 
+//
 #include <stdio.h>
 #include <string.h>
 
@@ -43,7 +43,7 @@ STATIC int callgate_lower(uint32_t method_num, uint32_t arg2, mp_buffer_info_t *
 
     // +4 because that's required by call gate for firewall
     // +1 to set LSB because we know a BLX instruction will be used to
-    // get there and we know it's thumb code
+    // get there and we know its thumb code
     // - also 0x100 aligned.
     assert((dest & 0xff) == 0x05);
 
@@ -54,7 +54,7 @@ STATIC int callgate_lower(uint32_t method_num, uint32_t arg2, mp_buffer_info_t *
     // Call the gate; it will trash the normal function-call registers (r0-4)
     // but also r9 and r10. Does not use our stack.
     //
-    // references: 
+    // references:
     // - <http://www.ethernut.de/en/documents/arm-inline-asm.html>
     // - <https://gcc.gnu.org/onlinedocs/gcc/Extended-Asm.html>
     //
@@ -64,7 +64,7 @@ STATIC int callgate_lower(uint32_t method_num, uint32_t arg2, mp_buffer_info_t *
     register uint32_t tx_len asm("r2") = io_buf ? io_buf->len: 0;
     register uint32_t r_arg2 asm("r3") = arg2;
 
-    asm volatile(   "blx %[dest] \n" 
+    asm volatile(   "blx %[dest] \n"
                     "str r0, %[rv]"
         : [rv] "=m" (rv)
         : [dest] "r" (dest), "r" (tx), "r" (tx_len), "r" (r_arg2), "r" (r_method)
@@ -114,7 +114,7 @@ STATIC mp_obj_t sec_oneway_gate(mp_obj_t method_obj, mp_obj_t arg2_obj)
     register uint32_t tx_len asm("r2") = 0;
     register uint32_t r_arg2 asm("r3") = arg2;
 
-    asm volatile(   "blx %[dest] \n" 
+    asm volatile(   "blx %[dest] \n"
                     "str r0, %[rv]"
         : [rv] "=m" (rv)
         : [dest] "r" (dest), "r" (tx), "r" (tx_len), "r" (r_arg2), "r" (method_num)
@@ -194,7 +194,7 @@ STATIC mp_obj_t wipe_fs(void)
     // after, it will be remounted already
 
     // see initfs.c
-    extern bool init_flash_fs(uint reset_mode);     
+    extern bool init_flash_fs(uint reset_mode);
 
     return MP_OBJ_NEW_SMALL_INT(init_flash_fs(3));
 }

--- a/stm32/bootloader/dispatch.c
+++ b/stm32/bootloader/dispatch.c
@@ -42,7 +42,7 @@ typedef struct {
 // reboot_seed_setup()
 //
 // We need to know when we are rebooted, so write some noise
-// into SRAM and lock it's value. Not secrets. One page = 1k bytes here.
+// into SRAM and lock its value. Not secrets. One page = 1k bytes here.
 //
     void
 reboot_seed_setup(void)
@@ -151,7 +151,7 @@ system_startup(void)
     ae_setup();
     ae_set_gpio(0);         // not checking return on purpose
 
-    // protect our flash, and/or check it's protected 
+    // protect our flash, and/or check it's protected
     // - and pick pairing secret if we don't already have one
     // - may also do one-time setup of 508a
     // - note: ae_setup must already be called, since it can talk to that
@@ -174,7 +174,7 @@ system_startup(void)
     // - must be near end of boot process, ie: here.
     reboot_seed_setup();
 
-    // load a blank-ish screen, so that 
+    // load a blank-ish screen, so that
     // if the firmware crashes, we are showing
     // something reasonable
     oled_show(screen_blank);
@@ -240,7 +240,7 @@ enter_dfu(void)
 
     __HAL_FIREWALL_PREARM_ENABLE();
 
-    // Wipe all of memory SRAM, just in case 
+    // Wipe all of memory SRAM, just in case
     // there is some way to trick us into DFU
     // after sensitive content in place.
     memset4((void *)SRAM1_BASE, noise, SRAM1_SIZE_MAX);
@@ -280,7 +280,7 @@ good_addr(const uint8_t *b, int minlen, int len, bool readonly)
         if(!b) return EFAULT;               // gave no buffer
         if(len < minlen) return ERANGE;     // too small
     }
-        
+
 
     if((x >= SRAM1_BASE) && ((x-SRAM1_BASE) < SRAM1_SIZE_MAX)) {
         // inside SRAM1, okay
@@ -346,7 +346,7 @@ firewall_dispatch(int method_num, uint8_t *buf_io, int len_in,
     // - range check pointers so we aren't tricked into revealing our secrets
     // - check buf_io points to main SRAM, and not into us!
     // - range check len_in tightly
-    // - calling convention only gives me enough for 4 args to this function, so 
+    // - calling convention only gives me enough for 4 args to this function, so
     //   using read/write in place.
     // - use arg2 use when a simple number is needed; never a pointer!
     // - mpy may provide a pointer to flash if we give it a qstr or small value, and if
@@ -375,7 +375,7 @@ firewall_dispatch(int method_num, uint8_t *buf_io, int len_in,
         }
 
         case 1: {
-            // Perform SHA256 over ourselves, with 32-bits of salt, to imply we 
+            // Perform SHA256 over ourselves, with 32-bits of salt, to imply we
             // haven't stored valid responses.
             REQUIRE_OUT(32);
 
@@ -444,7 +444,7 @@ firewall_dispatch(int method_num, uint8_t *buf_io, int len_in,
 
         case 3:
             // logout: wipe all of memory and lock up. Must powercycle to recover.
-            switch(arg2) { 
+            switch(arg2) {
                 case 0:
                 case 2:
                     oled_show(screen_logout);
@@ -500,7 +500,7 @@ firewall_dispatch(int method_num, uint8_t *buf_io, int len_in,
             }
             break;
 
-        case 5:     
+        case 5:
             // Are we a brick?
             // if the pairing secret doesn't work anymore, that
             // means we've been bricked.
@@ -517,7 +517,7 @@ firewall_dispatch(int method_num, uint8_t *buf_io, int len_in,
             break;
 
         case 15: {
-            // Read a dataslot directly. Will fail on 
+            // Read a dataslot directly. Will fail on
             // encrypted slots.
             if(len_in != 4 && len_in != 32 && len_in != 72) {
                 rv = ERANGE;
@@ -529,7 +529,7 @@ firewall_dispatch(int method_num, uint8_t *buf_io, int len_in,
                     rv = EIO;
                 }
             }
-            
+
             break;
         }
 
@@ -622,7 +622,7 @@ firewall_dispatch(int method_num, uint8_t *buf_io, int len_in,
             }
             break;
         }
-            
+
 
         case 20:
             // Read a single byte of config dataspace
@@ -634,7 +634,7 @@ firewall_dispatch(int method_num, uint8_t *buf_io, int len_in,
             } else {
                 buf_io[0] = rv;
                 rv = 0;
-            } 
+            }
             break;
 
         case 21:
@@ -688,7 +688,7 @@ firewall_dispatch(int method_num, uint8_t *buf_io, int len_in,
                 rv = EPERM;
             } else {
                 system_startup();
-            }            
+            }
             break;
 
 
@@ -714,7 +714,7 @@ fail:
     __HAL_FLASH_INSTRUCTION_CACHE_DISABLE();
     __HAL_FLASH_INSTRUCTION_CACHE_RESET();
     __HAL_FLASH_INSTRUCTION_CACHE_ENABLE();
-    
+
 
     // authorize return from firewall into user's code
     __HAL_FIREWALL_PREARM_ENABLE();

--- a/stm32/bootloader/keylayout.py
+++ b/stm32/bootloader/keylayout.py
@@ -102,9 +102,9 @@ def main():
     # PIN and corresponding protected secrets
     # - if you know old value of PIN, you can write it (to change to new PIN)
     for kn, sec_num, lg_num in [
-            (KEYNUM.pin_1, KEYNUM.secret_1, KEYNUM.lastgood_1), 
-            (KEYNUM.pin_2, KEYNUM.secret_2, KEYNUM.lastgood_2), 
-            (KEYNUM.pin_3, KEYNUM.secret_3, None), 
+            (KEYNUM.pin_1, KEYNUM.secret_1, KEYNUM.lastgood_1),
+            (KEYNUM.pin_2, KEYNUM.secret_2, KEYNUM.lastgood_2),
+            (KEYNUM.pin_3, KEYNUM.secret_3, None),
             (KEYNUM.pin_4, KEYNUM.secret_4, None)
     ]:
         cc[kn].hash_key(write_kn=kn).require_auth(KEYNUM.pairing)
@@ -121,7 +121,7 @@ def main():
     # - to change it, you need the primary pin
     cc[KEYNUM.firmware].secret_storage(KEYNUM.pin_1).no_read().require_auth(KEYNUM.pairing)
 
-    # Slot 8 is special because it's data area is larger and could hold a
+    # Slot 8 is special because its data area is larger and could hold a
     # certificate in DER format. All ther others are 36/72 bytes only
     # BTW: an errata limits this to just 224 bytes, which is not enough
     assert cc[8].kc.KeyType == 7

--- a/stm32/bootloader/storage.c
+++ b/stm32/bootloader/storage.c
@@ -1,8 +1,8 @@
 // (c) Copyright 2018 by Coinkite Inc. This file is part of Coldcard <coldcardwallet.com>
 // and is covered by GPLv3 license found in COPYING.
 //
-// 
-// storage.c -- manage flash and it's sensitive contents.
+//
+// storage.c -- manage flash and its sensitive contents.
 //
 // NOTE: ST's flash is different from others: it has ECC in effect, and can only
 // be programmed once. Writing ones is included in that. I'm used to flash that
@@ -436,7 +436,7 @@ flash_setup(void)
     // implied by that are in place. If wrong, do the
     // appropriate lockdown, which might be one-way.
     // That's fine if we intend to ship units locked already.
-    
+
     // Do NOT do write every boot, as it might wear-out
     // the flash bits in OB.
 
@@ -448,7 +448,7 @@ flash_setup(void)
 // - ensure bootloader isn't overwritten easily.
 // - enable level 2 flash protect
 // - once level 2 is set, no going back.
-// 
+//
 // This is a one-way trip. Might need power cycle to (fully?) take effect.
 //
     void

--- a/testing/test_addr.py
+++ b/testing/test_addr.py
@@ -46,9 +46,9 @@ def test_show_addr_displayed(dev, need_keypress, addr_vs_path, path, addr_fmt, c
         '2N2VBntgcoY4wN7H6VfrhH8an1BwieRMZCF', '2N551pf65tPS7VthC1rvwFDbLA1EUDYkTg9'])
 def test_addr_vs_bitcoind(bitcoind, match_key, need_keypress, example_addr, dev):
     # check our p2wpkh wrapped in p2sh is right
-    
+
     # PROBLEM: your bitcoind probably needs same transaction history as mine, so it knows
-    # about this address and it's contents/key path.
+    # about this address and its contents/key path.
 
     assert example_addr[0] == '2'
     resp = bitcoind.getaddressinfo(example_addr)
@@ -61,6 +61,6 @@ def test_addr_vs_bitcoind(bitcoind, match_key, need_keypress, example_addr, dev)
     need_keypress('y')
 
     assert addr == example_addr
-        
+
 
 # EOF

--- a/testing/test_sign.py
+++ b/testing/test_sign.py
@@ -12,7 +12,7 @@ from pprint import pprint
 from decimal import Decimal
 from base64 import b64encode, b64decode
 
-    
+
 def U2SAT(v):
     return int(v * Decimal('1E8'))
 
@@ -152,7 +152,7 @@ def test_psbt_parse_good(try_sign, fn, accept):
                 or ('None of the keys' in msg) \
                 or ('completely signed already' in msg) \
                 or ('require subpaths' in msg), msg
-    
+
 
 # works, but annoying output
 def xxx_test_sign_truncated(dev):
@@ -208,7 +208,7 @@ def simple_fake_txn():
     def doit(num_ins, num_outs, fat=0):
         psbt = BasicPSBT()
         txn = Tx(2,[],[])
-        
+
         for i in range(num_ins):
             h = TxIn(pack('4Q', 0, 0, 0, i), i)
             txn.txs_in.append(h)
@@ -252,7 +252,7 @@ def fake_txn():
     def doit(num_ins, num_outs, master_xpub, subpath="0/%d", fee=10000):
         psbt = BasicPSBT()
         txn = Tx(2,[],[])
-        
+
         # we have a key; use it to provide "plausible" value inputs
         from pycoin.key.BIP32Node import BIP32Node
         mk = BIP32Node.from_wallet_key(master_xpub)
@@ -319,7 +319,7 @@ def fake_txn():
     (22, 1),
     #(23, 1),       # v1.0.0 max size (observed)
     #(30, 1),
-    #(50, 50),      
+    #(50, 50),
     #(100, 100),
     #(200, 200),
     #(400, 400),    # too big even for simulator
@@ -331,7 +331,7 @@ def test_io_size(io, fake_txn, try_sign, dev):
     ni, no = io
     psbt = fake_txn(ni, no, dev.master_xpub)
 
-    # PROBLEM: 
+    # PROBLEM:
     # - this "simple" txn fails validation because too simple
     # - this code isn't testing the display of txn details anymore
 
@@ -369,7 +369,7 @@ def XXX_test_txn_wait_for_confirm(simple_fake_txn, try_sign):
     #open('debug/last.psbt', 'wb').write(psbt)
 
     try_sign(psbt, None)
-    
+
 @pytest.mark.parametrize('num_ins', [ 2, 7, 15 ])
 def test_real_signing(fake_txn, try_sign, dev, num_ins):
     # create a TXN using actual addresses that are correct for DUT
@@ -384,13 +384,13 @@ def test_real_signing(fake_txn, try_sign, dev, num_ins):
 
     # too slow / connection breaks during process
     #decode = bitcoind.decoderawtransaction(B2A(txn))
-    
+
 
 @pytest.fixture()
 def check_against_bitcoind(bitcoind, sim_exec, sim_execfile):
 
     def doit(hex_txn, fee, num_warn=0, change_outs=None):
-        # verify our understanding of a TXN (and esp it's outputs) matches
+        # verify our understanding of a TXN (and esp its outputs) matches
         # the same values as what bitcoind generates
 
         decode = bitcoind.decoderawtransaction(hex_txn)
@@ -515,7 +515,7 @@ def test_vs_bitcoind(match_key, check_against_bitcoind, bitcoind, start_sign, en
 def test_sign_example(set_master_key, sim_execfile, start_sign, end_sign):
     # use the private key given in BIP 174 and do similar signing
     # as the examples.
-    
+
     exk = 'tprv8ZgxMBicQKsPdHrvvmuEXXZ7f5EheFqshqVmtPjeLLMjqwrWbSeuGDcgJU1icTHtLjYiGewa5zcMScbGSRR8AqB8A5wvB3XRdNYBDMhXpBS'
     set_master_key(exk)
 
@@ -567,7 +567,7 @@ def test_sign_example(set_master_key, sim_execfile, start_sign, end_sign):
 
     # PROBLEM: revised BIP174 has p2sh multisig cases which we don't support yet.
     raise pytest.skip('not ready for multisig')
-    
+
     # expect xfp=0x4f6a0cd9
     exk = 'tprv8ZgxMBicQKsPd9TeAdPADNnSyH9SSUUbTVeFszDE23Ki6TBB5nCefAdHkK8Fm3qMQR6sHwA56zqRmKmxnHk37JkiFzvncDqoKmPWubu7hDF'
     set_master_key(exk)
@@ -589,7 +589,7 @@ def test_sign_example(set_master_key, sim_execfile, start_sign, end_sign):
     assert aft == expect
 
 def test_change_case(start_sign, end_sign, check_against_bitcoind, cap_story):
-    # is change shown/hidden at right times. no fraud checks 
+    # is change shown/hidden at right times. no fraud checks
 
     # NOTE: out#1 is change:
     chg_addr = 'mvBGHpVtTyjmcfSsy6f715nbTGvwgbgbwo'


### PR DESCRIPTION
Changes occurrences of "it's" to "its" where appropriate within the project code.

My editor removed whitespace from line endings as well.