### PR TITLE
Code Spelling (Preserve Whitespace)

### DIFF
--- a/misc/obsolete-code/secel.py
+++ b/misc/obsolete-code/secel.py
@@ -344,7 +344,7 @@ class SecureElement:
             else:
                 delay = 20
 
-        # delay for chip to do it's maths
+        # delay for chip to do its maths
         sleep_ms(delay)
 
         while 1:

--- a/shared/backups.py
+++ b/shared/backups.py
@@ -329,7 +329,7 @@ async def restore_complete_doit(fname_or_fd, words):
     # build password
     password = ' '.join(words)
 
-    # filename already picked, taste it and maybe consider using it's data.
+    # filename already picked, taste it and maybe consider using its data.
     try:
         fd = open(fname_or_fd, 'rb') if isinstance(fname_or_fd, str) else fname_or_fd
     except:

--- a/shared/callgate.py
+++ b/shared/callgate.py
@@ -1,7 +1,7 @@
 # (c) Copyright 2018 by Coinkite Inc. This file is part of Coldcard <coldcardwallet.com>
 # and is covered by GPLv3 license found in COPYING.
 #
-# callgate.py - thin wrapper around modckcc and the bootloader and it's services.
+# callgate.py - thin wrapper around modckcc and the bootloader and its services.
 #
 import ckcc
 

--- a/shared/main.py
+++ b/shared/main.py
@@ -89,7 +89,7 @@ async def done_splash2():
 async def mainline():
     # Mainline of program, after startup
     #
-    # - Do not add to this function, it's vars are
+    # - Do not add to this function, its vars are
     #   in memory forever; instead, extend done_splash2 above.
     from ux import the_ux
 

--- a/stm32/COLDCARD/modckcc.c
+++ b/stm32/COLDCARD/modckcc.c
@@ -43,7 +43,7 @@ STATIC int callgate_lower(uint32_t method_num, uint32_t arg2, mp_buffer_info_t *
 
     // +4 because that's required by call gate for firewall
     // +1 to set LSB because we know a BLX instruction will be used to
-    // get there and we know it's thumb code
+    // get there and we know its thumb code
     // - also 0x100 aligned.
     assert((dest & 0xff) == 0x05);
 

--- a/stm32/bootloader/dispatch.c
+++ b/stm32/bootloader/dispatch.c
@@ -42,7 +42,7 @@ typedef struct {
 // reboot_seed_setup()
 //
 // We need to know when we are rebooted, so write some noise
-// into SRAM and lock it's value. Not secrets. One page = 1k bytes here.
+// into SRAM and lock its value. Not secrets. One page = 1k bytes here.
 //
     void
 reboot_seed_setup(void)

--- a/stm32/bootloader/keylayout.py
+++ b/stm32/bootloader/keylayout.py
@@ -121,7 +121,7 @@ def main():
     # - to change it, you need the primary pin
     cc[KEYNUM.firmware].secret_storage(KEYNUM.pin_1).no_read().require_auth(KEYNUM.pairing)
 
-    # Slot 8 is special because it's data area is larger and could hold a
+    # Slot 8 is special because its data area is larger and could hold a
     # certificate in DER format. All ther others are 36/72 bytes only
     # BTW: an errata limits this to just 224 bytes, which is not enough
     assert cc[8].kc.KeyType == 7

--- a/stm32/bootloader/storage.c
+++ b/stm32/bootloader/storage.c
@@ -2,7 +2,7 @@
 // and is covered by GPLv3 license found in COPYING.
 //
 // 
-// storage.c -- manage flash and it's sensitive contents.
+// storage.c -- manage flash and its sensitive contents.
 //
 // NOTE: ST's flash is different from others: it has ECC in effect, and can only
 // be programmed once. Writing ones is included in that. I'm used to flash that

--- a/testing/test_addr.py
+++ b/testing/test_addr.py
@@ -48,7 +48,7 @@ def test_addr_vs_bitcoind(bitcoind, match_key, need_keypress, example_addr, dev)
     # check our p2wpkh wrapped in p2sh is right
     
     # PROBLEM: your bitcoind probably needs same transaction history as mine, so it knows
-    # about this address and it's contents/key path.
+    # about this address and its contents/key path.
 
     assert example_addr[0] == '2'
     resp = bitcoind.getaddressinfo(example_addr)

--- a/testing/test_sign.py
+++ b/testing/test_sign.py
@@ -390,7 +390,7 @@ def test_real_signing(fake_txn, try_sign, dev, num_ins):
 def check_against_bitcoind(bitcoind, sim_exec, sim_execfile):
 
     def doit(hex_txn, fee, num_warn=0, change_outs=None):
-        # verify our understanding of a TXN (and esp it's outputs) matches
+        # verify our understanding of a TXN (and esp its outputs) matches
         # the same values as what bitcoind generates
 
         decode = bitcoind.decoderawtransaction(hex_txn)


### PR DESCRIPTION
Changes occurrences of "it's" to "its" where appropriate within the project code.