### PR TITLE
Document unix socket address format when on linux

### DIFF
--- a/unix/frozen-modules/pyb.py
+++ b/unix/frozen-modules/pyb.py
@@ -24,6 +24,9 @@ class USB_HID:
         fn = b'/tmp/ckcc-simulator.sock'
         self.pipe = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
         addr = bytes([len(fn)+2, socket.AF_UNIX] + list(fn))
+        # If on linux, try uncommenting the following two lines
+        #import struct
+        #addr = struct.pack('H108s', socket.AF_UNIX, fn)
         while 1:
             try:
                 self.pipe.bind(addr)


### PR DESCRIPTION
Linux and MacOS use different formats apparently.

It would be better if a switch or autodetection could be used to switch between formats, but I don't know how to do that here. The format used comes from https://github.com/micropython/micropython/issues/2464#issuecomment-250452170