### PR TITLE
Pass previously chosen word target when starting over

### DIFF
--- a/shared/seed.py
+++ b/shared/seed.py
@@ -227,7 +227,7 @@ individual words if you wish.''')
 
         # begin again, empty but same settings
         self.words = []
-        the_ux.push(self.__class__(items=None))
+        the_ux.push(self.__class__(num_words=WordNestMenu.target_words))
 
     def late_draw(self, dis):
         # add an overlay with "word N" in small text, top right.


### PR DESCRIPTION
When choosing to start over, the target word length was being reset and causing an error. This change passes the target word count from the previous attempt.