### PR TITLE
macOs: add xquartz

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,12 +48,14 @@ Which looks like this:
 
 You'll probably need to install at least these packages:
 
+    brew cask install xquartz
     brew install sdl2
     brew tap PX4/px4
     brew search px4
-    brew cask install gcc-arm-embedded
     brew install px4/px4/gcc-arm-none-eabi-80 (latest gcc-arm-none-eabi-XX, currently 80)
-    
+
+You may need to reboot to avoid a `DISPLAY is not set` error.
+
 ### Linux
 
 You'll probably need to install these (Ubuntu 16):


### PR DESCRIPTION
`xterm` isn't installed on macOS by default