### PR TITLE
Implement multisig address explorer

### DIFF
--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -783,4 +783,14 @@ def is_mark3(request):
 from test_multisig import (import_ms_wallet, make_multisig, offer_ms_import,
                                 make_ms_address, clear_ms)
 
+@pytest.fixture
+def select_blockchain(goto_home, pick_menu_item):
+    def doit(coin=0):
+        assert coin in {0, 1}, 'Invalid coin'
+        goto_home()
+        pick_menu_item('Settings')
+        pick_menu_item('Blockchain')
+        pick_menu_item('Bitcoin' if coin == 0 else 'Testnet: BTC')
+        time.sleep(0.01)
+    return doit
 #EOF


### PR DESCRIPTION
This change required several steps:
- Add methods to create a redeem script and multisig address
- Refactor Address Explorer to use injected get_address_at_idx method
- Implement multisig address explorer menu
- Test for multisig address explorer

The test also required
- adding a fixture in conftest.py to select the blockchain on the device
- refactoring the make_multisig fixture to use multiple chains / addr_fmts

N.B. In order to generalize the make_multisig fixture, I set the last signer to be the simulator's actual extended private key as opposed to the one in the constants file. I don't believe this should have any backwards compatibility issues, but I wanted to make a note of it in case tests start breaking.