### PR TITLE
Support firmware limiting itself to specific hardware revs

### DIFF
--- a/cli/signit.py
+++ b/cli/signit.py
@@ -13,6 +13,9 @@ from ecdsa import SigningKey, VerifyingKey
 from ecdsa.curves import SECP256k1
 from sigheader import *
 
+# list of hardware we are presently supporting
+CURRENT_HARDWARE = MK_2_OK | MK_3_OK
+
 # more details about header
 header = namedtuple('header', FWH_PY_VALUES)
 packed_len = struct.calcsize(FWH_PY_FORMAT)
@@ -105,7 +108,8 @@ def show_version(fname):
 
 @main.command('check')
 @click.argument('fname', default='firmware-signed.bin')
-def readback(fname):
+@click.option('--no-patch', '-x', is_flag=True, help='Dont mask-out hw_compat field')
+def readback(fname, no_patch=False):
     "Verify pubkey and signature used in binary file"
     data = open(fname, 'rb').read()
 
@@ -129,6 +133,24 @@ def readback(fname):
             if v & FWHIF_HIGH_WATER:
                 nv += ' HIGH_WATER'
             v = nv
+        elif fld == 'hw_compat':
+            if v and not no_patch:
+                # mask it out for signature purposes
+                assert FWH_HWC_NUM_OFFSET == FW_HEADER_SIZE - 64 - 28 - 4
+                xo = FW_HEADER_OFFSET+FWH_HWC_NUM_OFFSET
+                data = bytearray(data)
+                data[xo:xo+4] = b'\0\0\0\0'
+
+            nv = '0x%x => ' % v
+            d = []
+            if v & MK_1_OK: d.append('Mk1')
+            if v & MK_2_OK: d.append('Mk2')
+            if v & MK_3_OK: d.append('Mk3')
+            if v & ~(MK_1_OK | MK_2_OK | MK_3_OK):
+                d.append('?other?')
+            v = nv + '+'.join(d)
+            if not no_patch:
+                v += "  (masked out of sig)"
         elif fld == 'timestamp':
             v = str(b2a_hex(v), 'ascii')
             nv = '20' + '-'.join(v[i:i+2] for i in range(0, 6, 2)) + ' '
@@ -158,17 +180,20 @@ def readback(fname):
 
 
 @main.command('sign')
-@click.argument('version', default='0.1a')
+@click.argument('version', required=True)
 @click.option('--pubkey-num', '-k', type=int, help='Which key # to use for signing', default=0)
 @click.option('--high_water', '-h', is_flag=True, help='Mark version as new highwater mark (no downgrades below this version)')
 @click.option('--verbose', '-v', default=False, is_flag=True, help='Show numbers related to signature')
+@click.option('--force-hw-compat', type=str, metavar='BITMASK', help="Override HW compat field (hex)")
 @click.option('--backdate', type=int, metavar='DAYS',
                             help='Make downgrade attack test version', default=0)
 @click.option('--resign_file', '-r', type=click.File('rb'),
                 help='Replace existing signature', default=None)
 @click.option('--outfn', '-o', type=click.Path(),
                 help='Output filename', default='firmware-signed.bin')
-def doit(outfn=None, build_dir='l-port/build-COLDCARD', high_water=False, 
+@click.option('--keydir', type=str, metavar='DIRPATH', help="Where to find priv keys for signing", default='keys')
+def doit(keydir, outfn=None, build_dir='l-port/build-COLDCARD', high_water=False,
+                        current=False, force_hw_compat=None,
                         version='0.1a', pubkey_num=0, backdate=0, verbose=False, resign_file=None):
     "Add signature into binary file before it becomes a DFU file."
 
@@ -186,6 +211,15 @@ def doit(outfn=None, build_dir='l-port/build-COLDCARD', high_water=False,
     assert len(vectors) <= FW_HEADER_OFFSET, "isr vectors area is too big!"
     assert len(body) >= FW_MIN_LENGTH, "main firmware is too small: %d" % len(body)
 
+    if version == '3.0.7':
+        # transition version: does not specify hw compact but can check it for future
+        hw_compat = 0
+    else:
+        hw_compat = CURRENT_HARDWARE
+    if force_hw_compat is not None:
+        hw_compat = int(force_hw_compat, 16)
+        click.echo("Overriding hw_compat field: 0x%02x" % hw_compat)
+
     body_len = align_to(len(body), 512)
     assert body_len % 512 == 0, body_len
 
@@ -198,6 +232,7 @@ def doit(outfn=None, build_dir='l-port/build-COLDCARD', high_water=False,
                     version_string=version,
                     firmware_length=FW_HEADER_OFFSET+FW_HEADER_SIZE+body_len,
                     install_flags=(FWHIF_HIGH_WATER if high_water else 0x0),
+                    hw_compat=0,        # see below
                     future=b'\0'*(4*FWH_NUM_FUTURE),
                     signature=b'\xff'*64,
                     pubkey_num=pubkey_num,
@@ -222,10 +257,17 @@ def doit(outfn=None, build_dir='l-port/build-COLDCARD', high_water=False,
         print('Hash: %s' % b2a_hex(fw_hash).decode('ascii'))
 
     # load key
-    sk = SigningKey.from_pem(open("keys/%02d.pem" % pubkey_num).read())
+    sk = SigningKey.from_pem(open(f"{keydir}/{pubkey_num:02d}.pem").read())
 
     from ecdsa.util import sigencode_string
     sig = sk.sign_digest(fw_hash, sigencode=sigencode_string)
+
+    # Final header has non-zero hw_compat field which will break
+    # signature, if it is ever seen by older code that did not clear
+    # that field (after checking compatibility)
+    if hw_compat != 0:
+        modhdr = hdr._replace(hw_compat=hw_compat)
+        binhdr = struct.pack(FWH_PY_FORMAT, *modhdr)
 
     assert len(sig) == 64
     final = binhdr[:-64] + sig

--- a/releases/ChangeLog.md
+++ b/releases/ChangeLog.md
@@ -1,3 +1,10 @@
+## 3.0.7 - Jan, 2020
+
+- IMPORTANT NOTE: You must upgrade to this version before any subsequent
+  version (regardless of your hardware).
+- Enhancement: Sending large PSBT files, and firmware upgrades over USB should be faster.
+- Final version to support Mk1 hardware.
+
 ## 3.0.6 - Dec 19, 2019
 
 - Security Bugfix: Fixed a multisig PSBT-tampering issue, that could allow a MitM to

--- a/shared/utils.py
+++ b/shared/utils.py
@@ -240,4 +240,56 @@ class Base64Streamer(DecodeStreamer):
     def a2b(self, x):
         return a2b_base64(x)
 
+
+def check_firmware_hdr(hdr, binary_size=None, bad_magic_ok=False):
+    # Check basics of new firmware being loaded. Return text of error msg if any.
+    # - basic checks only: for confused customers, not attackers.
+    # - hdr must be a bytearray(FW_HEADER_SIZE+more)
+    # - hdr will be updated in-place, and caller must get that into flash @ FW_HEADER_OFFSET
+
+    from sigheader import FW_HEADER_SIZE, FW_HEADER_MAGIC, FWH_PY_FORMAT
+    from sigheader import MK_1_OK, MK_2_OK, MK_3_OK, FWH_HWC_NUM_OFFSET
+    from ustruct import unpack_from
+    from version import hw_label
+
+    try:
+        assert len(hdr) >= FW_HEADER_SIZE
+
+        magic_value, timestamp, version_string, pk, fw_size, install_flags, hw_compat = \
+                        unpack_from(FWH_PY_FORMAT, hdr)[0:7]
+
+        if bad_magic_ok and magic_value != FW_HEADER_MAGIC:
+            # it's just not a firmware file, and that's ok
+            return None
+
+        assert magic_value == FW_HEADER_MAGIC, 'bad magic'
+        if binary_size is not None:
+            assert fw_size == binary_size, 'truncated'
+
+        # TODO: maybe show the version string? Warn them that downgrade doesn't work?
+
+    except Exception as exc:
+        return "That does not look like a firmware " \
+                    "file we would want to use: %s" % exc
+
+    if hw_compat != 0:
+        # check this hardware is compatible
+        ok = False
+        if hw_label == 'mk1':
+            ok = (hw_compat & MK_1_OK)
+        elif hw_label == 'mk2':
+            ok = (hw_compat & MK_2_OK)
+        elif hw_label == 'mk3':
+            ok = (hw_compat & MK_3_OK)
+        
+        if not ok:
+            return "New firmware doesn't support this version of Coldcard hardware (%s)."%hw_label
+
+        # Patch the header, so hw_compat field is zero
+        # - the signature value is based on those bytes being zero
+        hdr[FWH_HWC_NUM_OFFSET:FWH_HWC_NUM_OFFSET+4] = b'\0\0\0\0'
+
+    return None
+
+
 # EOF

--- a/stm32/Makefile
+++ b/stm32/Makefile
@@ -29,7 +29,7 @@ BOOTLOADER_BASE = 0x08000000
 FILESYSTEM_BASE = 0x080e0000
 
 # Our version for this release.
-VERSION_STRING = 3.0.6
+VERSION_STRING = 3.0.7
 
 #
 # Sign and merge various parts

--- a/stm32/bootloader/mk-sigheader.py
+++ b/stm32/bootloader/mk-sigheader.py
@@ -12,7 +12,7 @@ def doit(c_fname, py_file):
             lines.append(None)
 
     with open(py_file, 'wt') as o:
-        print("# Autogen'ed file, don't edit. See bootloader/mk-sigheader.h for original\n",file=o)
+        print("# Autogen'ed file, don't edit. See bootloader/sigheader.h for original\n",file=o)
 
         for ln in lines:
             if ln is None:

--- a/stm32/bootloader/sigheader.h
+++ b/stm32/bootloader/sigheader.h
@@ -30,14 +30,15 @@ typedef struct {
     uint32_t    pubkey_num;             // which pubkey was used to sign binary
     uint32_t    firmware_length;        // must be 512-aligned, and marks start of flash filesystem
     uint32_t    install_flags;          // flags about this release
-    uint32_t    future[8];              // reserved words
+    uint32_t    hw_compat;              // which hardware can run this release
+    uint32_t    future[7];              // reserved words
     uint8_t     signature[64];          // signature over secp256k1
 } coldcardFirmwareHeader_t;
 
 #define FW_HEADER_SIZE       128
 #define FW_HEADER_OFFSET     (0x4000-FW_HEADER_SIZE)
 
-#define FW_HEADER_MAGIC      0xCC001234
+#define FW_HEADER_MAGIC             0xCC001234
 
 // Firmware Image Size
 
@@ -49,13 +50,26 @@ typedef struct {
 #define FW_MAX_LENGTH        (0x100000 - 0x8000)
 
 // Arguments to be used w/ python's struct module.
-#define FWH_PY_FORMAT      "<I8s8sIII32s64s"
-#define FWH_PY_VALUES      "magic_value timestamp version_string pubkey_num firmware_length install_flags future signature"
-#define FWH_NUM_FUTURE      8
+#define FWH_PY_FORMAT      "<I8s8sIIII28s64s"
+#define FWH_PY_VALUES      "magic_value timestamp version_string pubkey_num firmware_length install_flags hw_compat future signature"
+#define FWH_NUM_FUTURE      7
+
+// offset of pubkey number
 #define FWH_PK_NUM_OFFSET   20
+
+// offset of hw_compat field (4 bytes)
+#define FWH_HWC_NUM_OFFSET  (128 - 64 - 32)
 
 // Bits in install_flags
 #define FWHIF_HIGH_WATER        0x01
+
+// Bits in hw_compat
+#define MK_1_OK                 0x01
+#define MK_2_OK                 0x02
+#define MK_3_OK                 0x04
+// RFU:
+#define MK_4_OK                 0x08
+#define MK_5_OK                 0x10
 
 // There is a copy of the header at this location in RAM, copied by bootloader
 // **after** it has been verified. If you write to this memory area, you will be reset!

--- a/stm32/bootloader/sigheader.py
+++ b/stm32/bootloader/sigheader.py
@@ -1,4 +1,4 @@
-# Autogen'ed file, don't edit. See bootloader/mk-sigheader.h for original
+# Autogen'ed file, don't edit. See bootloader/sigheader.h for original
 
 # (c) Copyright 2018 by Coinkite Inc. This file is part of Coldcard <coldcardwallet.com>
 # and is covered by GPLv3 license found in COPYING.
@@ -35,13 +35,26 @@ FW_MIN_LENGTH = (256*1024)
 FW_MAX_LENGTH = (0x100000 - 0x8000)
 
 # Arguments to be used w/ python's struct module.
-FWH_PY_FORMAT = "<I8s8sIII32s64s"
-FWH_PY_VALUES = "magic_value timestamp version_string pubkey_num firmware_length install_flags future signature"
-FWH_NUM_FUTURE = 8
+FWH_PY_FORMAT = "<I8s8sIIII28s64s"
+FWH_PY_VALUES = "magic_value timestamp version_string pubkey_num firmware_length install_flags hw_compat future signature"
+FWH_NUM_FUTURE = 7
+
+# offset of pubkey number
 FWH_PK_NUM_OFFSET = 20
+
+# offset of hw_compat field (4 bytes)
+FWH_HWC_NUM_OFFSET = (128 - 64 - 32)
 
 # Bits in install_flags
 FWHIF_HIGH_WATER = 0x01
+
+# Bits in hw_compat
+MK_1_OK = 0x01
+MK_2_OK = 0x02
+MK_3_OK = 0x04
+# RFU:
+MK_4_OK = 0x08
+MK_5_OK = 0x10
 
 # There is a copy of the header at this location in RAM, copied by bootloader
 # **after** it has been verified. If you write to this memory area, you will be reset!

--- a/stm32/keys/README.md
+++ b/stm32/keys/README.md
@@ -3,7 +3,7 @@
 Only the zero key is public, the others are ultra super secret.
 
 But if you had them, they would go in this directory, and be excluded
-by git by the .gitignore file.
+from git by the .gitignore file.
 
 Public keys listed here are also in the bootrom source and binary.
 

--- a/testing/sigheader.py
+++ b/testing/sigheader.py
@@ -1,0 +1,1 @@
+../shared/sigheader.py

--- a/testing/test_upgrades.py
+++ b/testing/test_upgrades.py
@@ -1,0 +1,139 @@
+# (c) Copyright 2018 by Coinkite Inc. This file is part of Coldcard <coldcardwallet.com>
+# and is covered by GPLv3 license found in COPYING.
+#
+# Various firmware upgrade things.
+#
+import pytest, os, struct, time
+from sigheader import *
+from ckcc_protocol.protocol import MAX_MSG_LEN, CCProtocolPacker, CCProtoError
+from collections import namedtuple
+
+Header = namedtuple('Header', FWH_PY_VALUES)
+packed_len = struct.calcsize(FWH_PY_FORMAT)
+assert packed_len == FW_HEADER_SIZE
+
+def parse_hdr(hdr):
+    return Header(**dict(zip(FWH_PY_VALUES.split(), struct.unpack(FWH_PY_FORMAT, hdr))))
+
+@pytest.fixture()
+def upload_file(dev):
+    def doit(data, pkt_len=2048):
+        
+        from hashlib import sha256
+        import os
+
+        for pos in range(0, len(data), pkt_len):
+            v = dev.send_recv(CCProtocolPacker.upload(pos, len(data), data[pos:pos+pkt_len]))
+            assert v == pos
+            chk = dev.send_recv(CCProtocolPacker.sha256())
+            assert chk == sha256(data[0:pos+pkt_len]).digest(), 'bad hash'
+    return doit
+
+@pytest.fixture()
+def make_firmware():
+    def doit(hw_compat, fname='../stm32/firmware-signed.bin', outname='tmp-firmware.bin'):
+        os.system(f'signit sign 3.0.99 --keydir ../stm32/keys -r {fname} -o {outname} --force-hw-compat=0x{hw_compat:02x}')
+
+        rv = open(outname, 'rb').read()
+
+        os.unlink(outname)
+
+        return rv
+    return doit
+
+@pytest.fixture
+def upgrade_by_sd(open_microsd, cap_story, pick_menu_item, goto_home, need_keypress, microsd_path, sim_exec):
+
+    # send a firmware file over the microSD card
+
+    def doit(data, expect_fail=None):
+
+        fname = 'tmp-firmware'
+
+        # stop it from reseting at end of process
+        sim_exec('import machine; machine.reset = lambda:None')
+
+        # create DFU file (wrapper)
+        open(f'{fname}.bin', 'wb').write(data)
+        dfu = microsd_path('tmp-firmware.dfu')
+        cmd = f'../external/micropython/tools/dfu.py -b 0x08008000:{fname}.bin {dfu}'
+        print(cmd)
+        os.system(cmd)
+
+        goto_home()
+        pick_menu_item('Advanced')
+        pick_menu_item('Upgrade')
+        pick_menu_item('From MicroSD')
+
+        time.sleep(.1)
+        _, story = cap_story()
+        assert 'Pick firmware image to use' in story
+        need_keypress('y')
+        time.sleep(.1)
+            
+        pick_menu_item(os.path.basename(dfu))
+
+        if expect_fail:
+            time.sleep(2)
+            title, story = cap_story()
+            assert title == 'Sorry!'
+            assert expect_fail in story
+
+    return doit
+
+
+@pytest.mark.parametrize('mode', ['nocheck', 'compat', 'incompat'])
+@pytest.mark.parametrize('transport', ['sd', 'usb'])
+def test_hacky_upgrade(mode, transport, dev, sim_exec, make_firmware, upload_file, sim_eval, upgrade_by_sd):
+
+    # manually: run this test on all Mark1 thru 3 simulators
+    hw_label = eval(sim_eval('version.hw_label'))
+    assert hw_label[0:2] == 'mk'
+    mkn = int(hw_label[2])
+
+    print(f"Simulator is {hw_label}")
+
+    if mode == 'nocheck':
+        data = make_firmware(0x00)
+    elif mode == 'compat':
+        data = make_firmware(1 << (mkn-1))
+    elif mode == 'incompat':
+        data = make_firmware(0xf ^ (1 << (mkn-1)))
+
+    hdr = data[FW_HEADER_OFFSET:FW_HEADER_OFFSET+FW_HEADER_SIZE]
+
+    cooked = parse_hdr(hdr)
+    #print(cooked)
+    assert cooked.magic_value == FW_HEADER_MAGIC
+    assert cooked.firmware_length == len(data)
+
+    patched = struct.pack(FWH_PY_FORMAT, *cooked._replace(hw_compat=0))
+    if mode == 'nocheck':
+        assert patched == hdr
+
+    if mode == 'incompat':
+        if transport == 'usb':
+            with pytest.raises(CCProtoError) as ee:
+                upload_file(data + hdr)
+            assert "doesn't support this version of Coldcard" in str(ee)
+        else:
+            upgrade_by_sd(data, expect_fail="doesn't support this version of Coldcard")
+
+        return
+
+    # file should be accepted
+    if transport == 'usb':
+        upload_file(data + hdr)
+    else:
+        upgrade_by_sd(data)
+
+    # check data was patched as uploading (2 spots)
+    for pos in range(0, cooked.firmware_length + 128, 128):
+        a = eval(sim_eval(f'main.sf.array[{pos}:{pos+128}]'))
+        if pos in [ FW_HEADER_OFFSET, cooked.firmware_length]:
+            assert a == patched, f"wrong @ {pos}"
+        else:
+            assert a == data[pos:pos+128], repr(pos)
+    
+
+# EOF

--- a/testing/test_usb.py
+++ b/testing/test_usb.py
@@ -125,13 +125,13 @@ def test_upload_short(dev, data_len):
     dev.send_recv(CCProtocolPacker.upload(256, 256, b''))
 
 @pytest.mark.parametrize('pkt_len', [256, 1024, 2048])
-def test_upload_long(dev, pkt_len, count=5):
+def test_upload_long(dev, pkt_len, count=5, data=None):
     # upload a larger "file"
     
     from hashlib import sha256
     import os
 
-    data = os.urandom(pkt_len * count)
+    data = data or os.urandom(pkt_len * count)
 
     for pos in range(0, len(data), pkt_len):
         v = dev.send_recv(CCProtocolPacker.upload(pos, len(data), data[pos:pos+pkt_len]))

--- a/unix/frozen-modules/bare_metal.py
+++ b/unix/frozen-modules/bare_metal.py
@@ -12,7 +12,7 @@
 #       (in xterm)
 #       import callgate; callgate.get_bl_version()
 # - you may need to get the (real) Coldcard into the REPL before starting this
-# - required exclusive use of USB emulated serial port, so quit other programs
+# - requires exclusive use of USB emulated serial port, so quit other programs
 #   before starting simulator
 #
 

--- a/unix/frozen-modules/sim_usb.py
+++ b/unix/frozen-modules/sim_usb.py
@@ -1,4 +1,4 @@
-import uio, sys, main
+import uio, sys, main, version
 
 def do_usb_command(cmd, args):
     # TESTING commands!


### PR DESCRIPTION
- add a new field to firmware header, which indicates which hardware versions it supports (`hw_compat`)
- designed to break the signature on the firmware image, so that fielded bootroms will not install those new versions
- it makes this version (3.0.7) a required upgrade, because no future version of the firmware will load without the patches it applies during firmware upgrade process
- difficult change, still somewhat WIP
