### PR TITLE
Save BIP39 passphrase to SDCard

### DIFF
--- a/releases/ChangeLog.md
+++ b/releases/ChangeLog.md
@@ -1,6 +1,11 @@
-## 3.1.3 - Mar , 2020
+## 3.1.3 - April , 2020
+- New feature: Export deterministically-derived entropy in the form of
+  seed phrases (BIP39), XPRV, private key (WIF), or hex digits. Useful for seeding
+  other wallets from your Coldcard, so you don't need to backup "yet another" seed phrase.
+  Derived values (all types) can be easly recreated from Coldcard later, or the backup of
+  the Coldcard. Does not expose the Coldcard's master secret, should new wallet be compromised.
+- Save BIP39 passphrases, encrypted, to specific SDCard
 - Code cleanups.
-
 
 ## 3.1.2 - Feb 27, 2020
 

--- a/releases/ChangeLog.md
+++ b/releases/ChangeLog.md
@@ -1,11 +1,13 @@
-## 3.1.3 - April , 2020
-- New feature: Export deterministically-derived entropy in the form of
-  seed phrases (BIP39), XPRV, private key (WIF), or hex digits. Useful for seeding
-  other wallets from your Coldcard, so you don't need to backup "yet another" seed phrase.
-  Derived values (all types) can be easly recreated from Coldcard later, or the backup of
-  the Coldcard. Does not expose the Coldcard's master secret, should new wallet be compromised.
-- Save BIP39 passphrases, encrypted, to specific SDCard
+## 3.1.3 - April 30, 2020
+
+- New feature: Option to save your BIP39 passphrases, encrypted, to specific SDCard. Recall
+  them later, if you have that same card, with just a few clicks. Passphrases are encrypted 
+  with AES256 (CTR mode) using a key derived from master secret and a hash of the serial number
+  details of the SDCard, so you cannot copy the file to another card. To use this feature,
+  press (1) after you've successfully entered your passphrase. 'Restore Saved' menu item
+  will appear if corrected-encrypted file is detected.
 - Code cleanups.
+
 
 ## 3.1.2 - Feb 27, 2020
 

--- a/shared/actions.py
+++ b/shared/actions.py
@@ -29,7 +29,7 @@ async def start_selftest(*args):
 
 async def needs_microsd():
     # Standard msg shown if no SD card detected when we need one.
-    await ux_show_story("Please insert a MicroSD card before attempting this operation.")
+    return await ux_show_story("Please insert a MicroSD card before attempting this operation.")
 
 async def needs_primary():
     # Standard msg shown if action can't be done w/o main PIN

--- a/shared/auth.py
+++ b/shared/auth.py
@@ -875,12 +875,9 @@ Press 2 to view the provided passphrase.\n\nOK to continue, X to cancel.''' % le
                 from seed import set_bip39_passphrase
 
                 # full screen message shown: "Working..."
-                err = set_bip39_passphrase(self._pw)
+                set_bip39_passphrase(self._pw)
 
-                if err:
-                    await self.failure(err)
-                else:
-                    self.result = settings.get('xpub')
+                self.result = settings.get('xpub')
 
 
         except BaseException as exc:

--- a/shared/backups.py
+++ b/shared/backups.py
@@ -42,7 +42,7 @@ def render_backup_contents():
 
     COMMENT('Private key details: ' + chain.name)
 
-    with stash.SensitiveValues(for_backup=True) as sv:
+    with stash.SensitiveValues(bypass_pw=True) as sv:
 
         if sv.mode == 'words':
             ADD('mnemonic', tcc.bip39.from_data(sv.raw))

--- a/shared/dev_helper.py
+++ b/shared/dev_helper.py
@@ -61,49 +61,10 @@ async def usb_keypad_emu():
                 from machine import soft_reset
                 soft_reset()
 
-            if 0:
-                if k == 'd':
-                    numpad.debug = (numpad.debug + 1) % 3
-                    continue
-
-                if k == 'n':
-                    if numpad.disabled:
-                        numpad.start()
-                    else:
-                        numpad.stop()
-
-                    print("npdis = %d" % numpad.disabled)
-                    continue
-
-            if k == 'U':
-                # enter DFU
-                import callgate
-                callgate.enter_dfu()
-                # not reached
-
             if k == 'T':
                 ckcc.vcp_enabled(True)
-                print("Repl enabled")
+                print("Repl")
                 continue
-
-            if k == 'M':
-                import gc
-                print("Memory: %d" % gc.mem_free())
-                continue
-
-            # word menus: shortcut for first letter
-            top = the_ux.top_of_stack()
-            if top and isinstance(top, WordNestMenu) and len(top.items) > 6:
-                pos = min(len(i.label) for i in top.items)
-                if pos >= 2:
-                    for n, it in enumerate(top.items):
-                        if it.label[pos-2] == k:
-                            top.goto_idx(n)
-                            top.show()
-                            k = None
-                            break
-
-                    if k is None: continue
 
             if k in remap:
                 k = remap[k]
@@ -111,7 +72,5 @@ async def usb_keypad_emu():
             if k in '0123456789xy':
                 numpad.inject(k)
                 continue
-            
-            print('? %r' % k)
 
 # EOF

--- a/shared/files.py
+++ b/shared/files.py
@@ -256,7 +256,7 @@ class CardSlot:
 
         return [root]
 
-    def card_hash(self):
+    def get_id_hash(self):
         # hash over card config and serial # details
         import tcc
         info = pyb.SDCard().info()

--- a/shared/files.py
+++ b/shared/files.py
@@ -256,6 +256,13 @@ class CardSlot:
 
         return [root]
 
+    def card_hash(self):
+        # hash over card config and serial # details
+        import tcc
+        info = pyb.SDCard().info()
+        assert info and len(info) >= 5       # need micropython changes
+        return tcc.sha256(repr(info)).digest()
+
     def pick_filename(self, pattern, path=None):
         # given foo.txt, return a full path to filesystem, AND
         # a nice shortened version of the filename for display to user

--- a/shared/h.py
+++ b/shared/h.py
@@ -6,5 +6,3 @@
 
 from ubinascii import hexlify as b2a_hex
 from ubinascii import unhexlify as a2b_hex
-
-BA = bytearray

--- a/shared/hmac.py
+++ b/shared/hmac.py
@@ -29,35 +29,21 @@ class HMAC:
         """
 
         if not isinstance(key, (bytes, bytearray)):
-            raise TypeError("key: expected bytes or bytearray, but got %r" % type(key).__name__)
+            raise TypeError()
 
-        assert callable(digestmod)
-        self.digest_cons = digestmod
-
-        self.outer = self.digest_cons()
-        self.inner = self.digest_cons()
+        self.outer = digestmod()
+        self.inner = digestmod()
         self.digest_size = self.inner.digest_size
 
-        if hasattr(self.inner, 'block_size'):
-            blocksize = self.inner.block_size
-            assert blocksize >= 16
-            #if blocksize < 16:
-            #    _warnings.warn('block_size of %d seems too small; using our '
-            #                   'default of %d.' % (blocksize, self.blocksize),
-            #                   RuntimeWarning, 2)
-            #    blocksize = self.blocksize
-        else:
-            #_warnings.warn('No block_size attribute on given digest object; '
-            #               'Assuming %d.' % (self.blocksize),
-            #               RuntimeWarning, 2)
-            blocksize = self.blocksize
+        blocksize = self.inner.block_size
+        assert blocksize >= 16
 
         # self.blocksize is the default blocksize. self.block_size is
         # effective block size as well as the public API attribute.
         self.block_size = blocksize
 
         if len(key) > blocksize:
-            key = self.digest_cons(key).digest()
+            key = digestmod(key).digest()
 
         def translate(d, t):
             return bytes(t[x] for x in d)

--- a/shared/pwsave.py
+++ b/shared/pwsave.py
@@ -130,17 +130,13 @@ class PassphraseSaver:
 
         async def doit(menu, idx, item):
             # apply the password immediately and drop them at top menu
-
-            err = set_bip39_passphrase(data[idx].get('pw'))
-            if err:
-                # kinda very late: but if not BIP39 based key, ends up here.
-                return await ux_show_story(err, title="Fail")
+            set_bip39_passphrase(data[idx].get('pw'))
 
             from main import settings
             from utils import xfp2str
             xfp = settings.get('xfp')
 
-            # they are big boys now, and don't need to have BIP39 explained everytime.
+            # they are big boys now, and won't need to have BIP39 explained everytime.
             if not settings.get('b39skip', False):
                 settings.set('b39skip', True)
 

--- a/shared/pwsave.py
+++ b/shared/pwsave.py
@@ -1,0 +1,158 @@
+# (c) Copyright 2020 by Coinkite Inc. This file is part of Coldcard <coldcardwallet.com>
+# and is covered by GPLv3 license found in COPYING.
+#
+# pwsave.py - Save bip39 passphrases into encrypted file on MicroSD (if desired)
+#
+import sys, tcc, stash, ujson, os
+from files import CardSlot, CardMissingError
+from ubinascii import hexlify as b2a_hex
+
+class PassphraseSaver:
+    # Encrypts BIP39 passphrase very carefully, and appends
+    # to a file on MicroSD card. Order is preserved.
+    # AES-256; key=sha256(microSD serial # hash + some derived key off master)
+
+    def filename(self, card):
+        # Construct actual filename to use.
+        # - some very minor obscurity, but we aren't relying on that.
+        return card.get_sd_root() + '/.fseventsd.'
+
+    def _calc_key(self, card):
+        # calculate the key to be used.
+        if getattr(self, 'key', 0): return
+
+        try:
+            salt = card.get_id_hash()
+
+            with stash.SensitiveValues(bypass_pw=True) as sv:
+                key = sv.encryption_key(salt)
+                assert len(key) == 32
+
+                self.key = bytearray(key)
+        except:
+            self.key = None
+
+    def _read(self, card):
+        # Return a list of saved passphrases, or empty list if fail.
+        # Fail silently in all cases. Expect to see lots of noise here.
+        decrypt = tcc.AES(tcc.AES.CTR | tcc.AES.Decrypt, self.key)
+
+        try:
+            msg = open(self.filename(card), 'rb').read()
+            txt = decrypt.update(msg)
+            return ujson.loads(txt)
+        except:
+            return []
+
+
+    async def append(self, xfp, bip39pw):
+        # encrypt and save; always appends.
+        from ux import ux_dramatic_pause
+        from main import dis
+        from actions import needs_microsd
+
+        while 1:
+            dis.fullscreen('Saving...')
+
+            try:
+                with CardSlot() as card:
+                    self._calc_key(card)
+
+                    data = self._read(card) if self.key else []
+
+                    data.append(dict(xfp=xfp, pw=bip39pw))
+
+                    encrypt = tcc.AES(tcc.AES.CTR | tcc.AES.Encrypt, self.key)
+
+                    msg = encrypt.update(ujson.dumps(data))
+
+                    with open(self.filename(card), 'wb') as fd:
+                        fd.write(msg)
+
+                await ux_dramatic_pause("Saved.", 2)
+                return
+
+            except CardMissingError:
+                ch = await needs_microsd()
+                if ch == 'x':       # undocumented, but needs escape route
+                    break
+
+            
+    def make_menu(self):
+        from menu import MenuItem, MenuSystem
+        from actions import goto_top_menu
+        from ux import ux_show_story
+        from seed import set_bip39_passphrase
+
+        # Read file, decrypt and make a menu to show; OR return None
+        # if any error hit.
+        try:
+            with CardSlot() as card:
+                try:
+                    # check file exists before doing expensive crypto steps
+                    os.stat(self.filename(card))
+                except:     # OSError for ENOENT
+                    return None
+
+                self._calc_key(card)
+                if not self.key: return None
+
+                data = self._read(card)
+
+                if not data: return None
+
+        except CardMissingError:
+            # not an error: they just aren't using feature
+            return None
+
+        # We have a list of xfp+pw fields. Make a menu.
+
+        # challenge: we need to hint at which is which, but don't want to
+        # show the password on-screen.
+        # - simple algo: 
+        #   - show either first N or last N chars only
+        #   - pick which set which is all-unique, if neither, try N+1
+        #
+        pws = []
+        for i in data:
+            p = i.get('pw') 
+            if p not in pws:
+                pws.append(p)
+
+        for N in range(1, 8):
+            parts = [i[0:N] + ('*'*(len(i)-N if len(i) > N else 0)) for i in pws]
+            if len(set(parts)) == len(pws): break
+            parts = [('*'*(len(i)-N if len(i) > N else 0)) + i[-N:] for i in pws]
+            if len(set(parts)) == len(pws): break
+        else:
+            # give up: show it all!
+            parts = pws
+
+        async def doit(menu, idx, item):
+            # apply the password immediately and drop them at top menu
+
+            err = set_bip39_passphrase(data[idx].get('pw'))
+            if err:
+                # kinda very late: but if not BIP39 based key, ends up here.
+                return await ux_show_story(err, title="Fail")
+
+            from main import settings
+            from utils import xfp2str
+            xfp = settings.get('xfp')
+
+            # they are big boys now, and don't need to have BIP39 explained everytime.
+            if not settings.get('b39skip', False):
+                settings.set('b39skip', True)
+
+            # verification step; I don't see any way for this to go wrong
+            assert xfp == data[idx].get('xfp')
+
+            # feedback that it worked
+            await ux_show_story("Passphrase restored.", title="[%s]" % xfp2str(xfp))
+
+            goto_top_menu()
+
+
+        return MenuSystem((MenuItem(label, f=doit) for label in parts))
+        
+# EOF

--- a/shared/seed.py
+++ b/shared/seed.py
@@ -440,23 +440,25 @@ def set_seed_value(words):
 
 def set_bip39_passphrase(pw):
     # apply bip39 passphrase for now (volatile)
-    import stash
-
-    stash.bip39_passphrase = pw
 
     # takes a bit, so show something
     from main import dis
     dis.fullscreen("Working...")
 
+    # set passphrase
+    import stash
+    stash.bip39_passphrase = pw
+
+    # capture updated XFP
     with stash.SensitiveValues() as sv:
-        # can't do it without original seed woods
+        # can't do it without original seed words (late, but caller has checked)
         assert sv.mode == 'words'
 
         sv.capture_xpub()
 
     # Might need to bounce the USB connection, because our pubkey has changed,
     # altho if they have already picked a shared session key, no need, and
-    # only affects MitM testing.
+    # would only affect MitM test, which has already been done.
 
 async def remember_bip39_passphrase():
     # Compute current xprv and switch to using that as root secret.

--- a/shared/seed.py
+++ b/shared/seed.py
@@ -440,7 +440,6 @@ def set_seed_value(words):
 
 def set_bip39_passphrase(pw):
     # apply bip39 passphrase for now (volatile)
-    # - return None or error msg
     import stash
 
     stash.bip39_passphrase = pw
@@ -450,9 +449,8 @@ def set_bip39_passphrase(pw):
     dis.fullscreen("Working...")
 
     with stash.SensitiveValues() as sv:
-        if sv.mode != 'words':
-            # can't do it without original seed woods
-            return 'No BIP39 seed words'
+        # can't do it without original seed woods
+        assert sv.mode == 'words'
 
         sv.capture_xpub()
 
@@ -715,10 +713,7 @@ class PassphraseMenu(MenuSystem):
         from stash import bip39_passphrase
         old_pw = str(bip39_passphrase)
 
-        err = set_bip39_passphrase(pp_sofar)
-        if err:
-            # kinda very late: but if not BIP39 based key, ends up here.
-            return await ux_show_story(err, title="Fail")
+        set_bip39_passphrase(pp_sofar)
 
         from main import settings
         xfp = settings.get('xfp')

--- a/shared/selftest.py
+++ b/shared/selftest.py
@@ -40,11 +40,11 @@ def set_genuine():
     if not pa.is_successful():
         # assume blank pin during factory selftest
         pa.setup(b'')
-        assert not pa.is_delay_needed(), "PIN failures?"
+        assert not pa.is_delay_needed()     # "PIN failures?"
 
         if not pa.is_successful():
             pa.login()
-            assert pa.is_successful(), "PIN not blank?"
+            assert pa.is_successful()       # "PIN not blank?"
 
     # do verify step
     pa.greenlight_firmware()
@@ -53,15 +53,15 @@ def set_genuine():
 
 async def test_secure_element():
 
-    assert not get_is_bricked(), "SE is bricked"
+    assert not get_is_bricked()         # bricked already
 
     # test right chips installed
     is_fat = ckcc.is_stm32l496()
     if is_fat:
-        assert version.has_608, "expect 608a"
+        assert version.has_608          # expect 608a
         assert version.hw_label == 'mk3'
     else:
-        assert not version.has_608, "expect 508a"
+        assert not version.has_608      # expect 508a
         assert version.hw_label != 'mk3'
 
     if ckcc.is_simulator(): return
@@ -77,7 +77,7 @@ async def test_secure_element():
 
         dis.show()
         k = await ux_wait_keyup('xy')
-        assert k == 'y', "LED bust"
+        assert k == 'y'     # "LED bust"
 
         if ph and gg:
             # stop once it's on and we've tested both states
@@ -94,7 +94,7 @@ async def test_secure_element():
             ux_clear_keys()
 
         ng = get_genuine()
-        assert ng != gg, "Could not invert LED"
+        assert ng != gg     # "Could not invert LED"
             
 async def test_sd_active():
     # Mark 2: SD Card active light.
@@ -113,7 +113,7 @@ async def test_sd_active():
 
         dis.show()
         k = await ux_wait_keyup('xy')
-        assert k == 'y', "SD Active LED bust"
+        assert k == 'y'     # "SD Active LED bust"
 
 async def test_multipress():
     dis.clear()
@@ -147,7 +147,7 @@ async def test_sflash():
             await sleep_ms(250)
             if not sf.is_busy(): break
 
-        assert not sf.is_busy(), "didn't finish"
+        assert not sf.is_busy()     # "didn't finish"
 
         # leave chip blank
         if phase == 1: break
@@ -156,12 +156,12 @@ async def test_sflash():
         buf = bytearray(32)
         for addr in range(0, msize, 1024):
             sf.read(addr, buf)
-            assert set(buf) == {255}, "not blank"
+            assert set(buf) == {255}        # "not blank"
 
             rnd = tcc.sha256(pack('I', addr)).digest()
             sf.write(addr, rnd)
             sf.read(addr, buf)
-            assert buf == rnd, "write failed"
+            assert buf == rnd           #  "write failed"
 
             dis.progress_bar_show(addr/msize)
 
@@ -169,7 +169,7 @@ async def test_sflash():
         for addr in range(0, msize, 1024):
             expect = tcc.sha256(pack('I', addr)).digest()
             sf.read(addr, buf)
-            assert buf == expect, "readback failed"
+            assert buf == expect        # "readback failed"
 
             dis.progress_bar_show(addr/msize)
 
@@ -227,7 +227,7 @@ async def test_microsd():
         dis.show()
 
         # card inserted
-        assert sd.present(), "SD not present?"
+        assert sd.present()     #, "SD not present?"
 
         # power up?
         sd.power(1)
@@ -237,7 +237,7 @@ async def test_microsd():
             blks, bsize, ctype = sd.info()
             assert bsize == 512
         except:
-            assert 0, "card info"
+            assert 0        # , "card info"
 
         # just read it a bit, writing would prove little
         buf = bytearray(512)
@@ -247,7 +247,7 @@ async def test_microsd():
             dis.progress_bar_show(addr/msize)
 
             if addr == 0:
-                assert buf[-2:] == b'\x55\xaa', "Bad read"
+                assert buf[-2:] == b'\x55\xaa'      # "Bad read"
 
         # force removal, so cards don't get stuck in finished units
         await wait_til_state(False)

--- a/shared/stash.py
+++ b/shared/stash.py
@@ -244,7 +244,7 @@ class SensitiveValues:
         node = self.derive_path("m/2147431408'/0'")     # plan: 0' will be an index for other apps
 
         acc = tcc.sha256(salt)
-        acc.update(tcc.sha256(node.private_key()).digest())
+        acc.update(node.private_key())
         acc.update(salt)
 
         pk = tcc.sha256(acc.digest()).digest()

--- a/stm32/Makefile
+++ b/stm32/Makefile
@@ -183,6 +183,11 @@ OBJDUMP = arm-none-eabi-objdump
 firmware.lss: $(PORT_TOP)/build-COLDCARD/firmware.elf
 	$(OBJDUMP) -h -S $< > $@
 
+# dump sizes of compiled py files
+.PHONY: sizes
+sizes:
+	wc -c l-port/build-COLDCARD/frozen_mpy/*.mpy | sort -n
+
 # one time setup, after repo checkout
 setup:
 	cd $(MPY_TOP) ; git submodule update --init lib/stm32lib

--- a/testing/test_pwsave.py
+++ b/testing/test_pwsave.py
@@ -1,0 +1,143 @@
+# (c) Copyright 2020 by Coinkite Inc. This file is part of Coldcard <coldcardwallet.com>
+# and is covered by GPLv3 license found in COPYING.
+#
+# tests for ../shared/pwsave.py
+#
+import pytest, time, os
+from test_ux import word_menu_entry, enter_complex
+from binascii import b2a_hex, a2b_hex
+from constants import simulator_fixed_xprv
+
+SIM_FNAME = '../unix/work/MicroSD/.fseventsd.'
+
+@pytest.fixture
+def set_pw_phrase(pick_menu_item, word_menu_entry):
+    def doit(words):
+        for w in words.split():
+            pick_menu_item('Add Word')
+            word_menu_entry([w.lower()])
+            pick_menu_item(w)
+
+    return doit
+
+
+@pytest.fixture
+def get_to_pwmenu(cap_story, need_keypress, goto_home, pick_menu_item):
+    # drill to the enter passphrase menu
+    def doit():
+        goto_home()
+        pick_menu_item('Passphrase')
+
+        _, story = cap_story()
+        if 'your BIP39 seed words' in story:
+            time.sleep(.01); need_keypress('y'); time.sleep(.01)      # skip warning
+
+    return doit
+
+
+@pytest.mark.parametrize('pws', [
+        'aBc1 aBc2 aBc3', 
+        'abcd defg',
+        '1aaa 2aaa',
+        'ab'*25,
+    ])
+def test_first_time(pws, need_keypress, cap_story, pick_menu_item, goto_home, enter_complex, cap_menu, get_to_pwmenu):
+
+    try:    os.unlink(SIM_FNAME)
+    except: pass
+
+    pws = pws.split()
+    xfps = []
+
+    for pw in pws:
+        get_to_pwmenu()
+
+        enter_complex(pw)
+
+        pick_menu_item('APPLY')
+
+        time.sleep(.01)
+        title, story = cap_story()
+        xfp = title[1:-1]
+        assert '1 to save to MicroSD' in story
+
+        need_keypress('1')
+        xfps.append(xfp)
+
+
+    for n, pw in enumerate(pws):
+        get_to_pwmenu()
+
+        pick_menu_item('Restore Saved')
+
+        m = cap_menu()
+        print(m)
+        assert len(m) == len(pws)
+        assert all(('*' in i) for i in m)
+
+        assert m[n][0] == pw[0] or m[n][-1] == pw[-1]
+
+        pick_menu_item(m[n])
+
+        time.sleep(.01)
+        title, story = cap_story()
+        xfp = title[1:-1]
+
+        assert xfp == xfps[n]
+        need_keypress('y'); 
+
+
+def test_crypto_unittest(sim_eval, sim_exec):
+    # unit test for AES key generation from SDCard and master secret
+    card = sim_exec('import files; from h import b2a_hex; cs = files.CardSlot().__enter__(); RV.write(b2a_hex(cs.get_id_hash())); cs.__exit__()')
+
+    # known value for simulator, generally unknown on random SD cards
+    assert card == '95a60b9ff0c944ec2c23a28e599f794e95bb376a451b6037b054f8230b405fb0'
+    salt = a2b_hex(card)
+
+    # read key simulator calculates
+    key = sim_exec('''\
+import files; from h import b2a_hex; \
+from pwsave import PassphraseSaver; \
+cs = files.CardSlot().__enter__(); \
+p=PassphraseSaver(); p._calc_key(cs); RV.write(b2a_hex(p.key)); cs.__exit__()''')
+
+    assert len(key) == 64
+    #assert key == '234af2aa2ab43af83667dfc6e11d08223e0f486ef34539b41a045dd9eb3ea664'
+
+    from pycoin.key.BIP32Node import BIP32Node
+    from pycoin.encoding import from_bytes_32, to_bytes_32
+    from hashlib import sha256
+
+    mk = BIP32Node.from_wallet_key(simulator_fixed_xprv)
+
+    sk = mk.subkey_for_path('2147431408p/0p')
+
+    md = sha256()
+    md.update(salt)
+    md.update(to_bytes_32(sk.secret_exponent()))
+    md.update(salt)
+
+    expect = sha256(md.digest()).hexdigest()
+
+    assert expect == key
+
+    # check that key works for decrypt / that the file was actually encrypted
+
+    with open(SIM_FNAME, 'rb') as fd:
+        raw = fd.read()
+
+    import pyaes
+    d = pyaes.AESModeOfOperationCTR(a2b_hex(expect), pyaes.Counter(0)).decrypt
+    txt = str(bytearray(d(raw)), 'utf8')
+
+    print(txt)
+    assert txt[0] == '[' and txt[-1] == ']'
+    import json
+    j = json.loads(txt)
+    assert isinstance(j, list)
+    assert j[0]['pw']
+    assert j[0]['xfp']
+
+
+# EOF

--- a/unix/README.md
+++ b/unix/README.md
@@ -38,6 +38,7 @@ wallet (on testnet, always with the same seed). But there are other options:
 - `--users` => preset a few users: "totp", "hotp" and "pw"
 - `--user-mgmt` => go to the User Management menu inside settings
 - `--pin 123456-123456` => set PIN code to indicated value
+- `--secret 01abababab...` => directly set contents of SE secret, see SecretStash.encode()
 
 See `frozen-modules/sim-settings.py` for the details of settings-related options.
 

--- a/unix/frozen-modules/pyb.py
+++ b/unix/frozen-modules/pyb.py
@@ -104,6 +104,13 @@ class SDCard:
             time.sleep(0.100)       # drama
         return False
 
+    @classmethod
+    def info(cls):
+        # num blocks, block size, "card type", CSD, CID registers
+        return (493879296, 512, 0,
+                    b'2\x00^\x00\xd6\x81Y[\x8f\xff\xb7\xed\x94\x00@\x16',
+                    b'APA\tDU F\xd9\x92\x11\x10\x9a\x1a\x01\xdf')
+
 class Pin:
     PULL_NONE =1
     PULL_UP =2

--- a/unix/frozen-modules/sim_settings.py
+++ b/unix/frozen-modules/sim_settings.py
@@ -1,4 +1,5 @@
 # do NOT import main from this file.
+# do NOT 'from main import settings' either
 
 import os, sys
 from sim_secel import SECRETS
@@ -22,7 +23,7 @@ elif '-l' in sys.argv:
     
 else:
     # default values for simulator
-    # CAUTION: some test cases will rely on these
+    # CAUTION: many test cases will rely on these
     sim_defaults = {
         '_age': 42,
         #'chain': 'BTC',
@@ -81,7 +82,7 @@ if '--xfp' in sys.argv:
     print("Override XFP: " + xfp2str(sim_defaults['xfp']))
 
 if '--seed' in sys.argv:
-    # --xfp aabbccdd   => pretend we know that key (won't be able to sign)
+    # --seed word1 word2 .. word24  => import seed phrase
     from ustruct import unpack
     from utils import xfp2str
     from seed import set_seed_value
@@ -95,6 +96,28 @@ if '--seed' in sys.argv:
     settings.set('_skip_pin', '12-12')
     settings.set('chain', 'XTN')
     print("Seed phrase set, resulting XFP: " + xfp2str(settings.get('xfp')))
+
+if '--secret' in sys.argv:
+    # --secret 01a1a1a....   Set SE master secret directly. See SecretStash.encode
+    from ubinascii import unhexlify as a2b_hex
+    from ubinascii import hexlify as b2a_hex
+
+    val = sys.argv[sys.argv.index('--secret') + 1]
+    val = a2b_hex(val)
+    assert val[0] in { 0x01, 0x80, 0x81, 0x82} or 16 <= val[0] <= 64, "bad first byte"
+    val += bytes(72 - len(val))
+
+    SECRETS.update({
+        '_pin1_secret': b2a_hex(val),
+    })
+
+    sim_defaults['terms_ok'] = 1
+    sim_defaults['_skip_pin'] = '12-12'
+    sim_defaults['chain'] = 'XTN'
+    sim_defaults['words'] = bool(val[0] & 0x80)
+    sim_defaults.pop('xfp')
+    sim_defaults.pop('xpub')
+
 
 if '-g' in sys.argv:
     # do login


### PR DESCRIPTION
New feature: Option to save your BIP39 passphrases, encrypted, to specific SDCard. Recall
  them later, if you have that same card, with just a few clicks. Passphrases are encrypted 
  with AES256 (CTR mode) using a key derived from master secret and a hash of the serial number
  details of the SDCard, so you cannot copy the file to another card. To use this feature,
  press (1) after you've successfully entered your passphrase. 'Restore Saved' menu item
  will appear if corrected-encrypted file is detected.
