### PR TITLE
Adds p2sh/p2wsh as valid AddressType

### DIFF
--- a/shared/multisig.py
+++ b/shared/multisig.py
@@ -99,6 +99,7 @@ class MultisigWallet:
         (AF_P2SH, 'p2sh'),
         (AF_P2WSH, 'p2wsh'),
         (AF_P2WSH_P2SH, 'p2wsh-p2sh'),
+        (AF_P2WSH_P2SH, 'p2sh-p2wsh'),
     ]
 
     def __init__(self, name, m_of_n, xpubs, addr_fmt=AF_P2SH, common_prefix=None, chain_type='BTC'):


### PR DESCRIPTION
This is inverted form most places I've seen and I ran into it while integrating Coldcard into [Caravan](https://github.com/unchained-capital/caravan). It's totally fine to define it this way, but it would be nice to seamlessly support the other order as well.