### PR TITLE
Increase BOOT_LOCKOUT_TIME to escape HSM.

### DIFF
--- a/shared/hsm.py
+++ b/shared/hsm.py
@@ -30,7 +30,7 @@ ABSOLUTE_MAX_REFUSALS = const(100)
 
 # you have this many seconds after boot to escape HSM
 # mode, if you enable the boot_to_hsm feature
-BOOT_LOCKOUT_TIME = const(30)
+BOOT_LOCKOUT_TIME = const(45)
 
 def hsm_policy_available():
     # Is there an HSM policy ready to go? Offer the menu item then.


### PR DESCRIPTION
Justification
30 seconds is insufficient when using features that consume time (Scrambled Keypad, setting a Nickname, and especially Login Timeout)

Consider this scenario with a nickname and scrambled pin entry
The following all needs to be accomplished within the first 30 seconds (not physically possible)
1. wait for green light. click yes
2. wait for custom label. click yes
3. enter pin prefix on scrambled pad. click yes
4. wait for anti-phishing words. click yes
5. enter pin suffix on scrambled pad. click yes
6. wait for HSM policy prompt. click yes
7. then enter 6 digit pin. click yes