### PR TITLE
Do not delete hsm policy when local escape pin is entered

### DIFF
--- a/shared/hsm.py
+++ b/shared/hsm.py
@@ -681,7 +681,6 @@ class HSMPolicy:
             if code == self.boot_to_hsm:
                 # let them out of jail
                 from hsm_ux import hsm_ux_obj
-                hsm_delete_policy()
                 hsm_ux_obj.test_restart = True
 
     def consume_local_code(self, psbt_sha):


### PR DESCRIPTION
Any interest in changing the behavior of when a local pin is entered during HSM mode (boot_to_hsm)? 

Deleting the HSM policy when a local pin was entered feels like a side-effect that is easy to forget as an operator of the device. It is not explicit that the HSM file is deleted, therefore a local operator can be convinced to enter their escape pin code without acknowledging the full impact of their actions (next boot of device will allow user to use the device freely). Another behavior quirk is that testing the escape pin will delete the policy file itself.

As an alternative, functionality to explicitly delete and/or replace the hsm policy file would be desirable. 