### PR TITLE
repro: fix dns redirect issue in dockerfile.build

### DIFF
--- a/stm32/dockerfile.build
+++ b/stm32/dockerfile.build
@@ -11,7 +11,7 @@ WORKDIR /work
 
 RUN apk add --no-cache git python3 py-pip musl-dev make rsync autoconf automake libtool && \
     apk add gcc-arm-none-eabi newlib-arm-none-eabi --update-cache \
-        --repository http://dl-3.alpinelinux.org/alpine/edge/testing/
+        --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing/
 
 RUN ln -s /usr/bin/python3 /usr/bin/python
 


### PR DESCRIPTION
The dns redirect for the edge/testing seems unstable/broken.
This causes and error when building the repro.