### PR TITLE
changed %d to float to mitigate rounding issues in Shannon entropy

### DIFF
--- a/docs/rolls.py
+++ b/docs/rolls.py
@@ -26,7 +26,7 @@ if h.hex() == empty:
 # Warnings for short length
 if len(r) < 99:
     ae = 2.585 * len(r)
-    print('WARNING: Input is only %d bits of entropy\n' % ae)
+    print(f'WARNING: Input is only {ae:0.3f} bits of entropy')
 
 # Apply BIP39 to convert into seed words
 v = int.from_bytes(h, 'big') << 8

--- a/docs/rolls.py
+++ b/docs/rolls.py
@@ -26,7 +26,7 @@ if h.hex() == empty:
 # Warnings for short length
 if len(r) < 99:
     ae = 2.585 * len(r)
-    print(f'WARNING: Input is only {ae:0.3f} bits of entropy')
+    print(f'WARNING: Input is only {ae:0.3f} bits of entropy\n')
 
 # Apply BIP39 to convert into seed words
 v = int.from_bytes(h, 'big') << 8


### PR DESCRIPTION
Changed the way Shannon entropy was being presented.

Example:
echo 123 |python3 rolls.py was displaying 7 bits of entropy when the actual entropy was much closer to 8 (7.755...)

