### PR TITLE
Add workflow for repro build on github actions

### DIFF
--- a/.github/workflows/ccfw-repro-build.yml
+++ b/.github/workflows/ccfw-repro-build.yml
@@ -1,0 +1,44 @@
+name: CCFW Reproducible Build
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Git Checkout
+      uses: actions/checkout@v2
+      with:
+        submodules: true
+        
+    - name: Setup Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: "3.10"
+        
+    - name: Setup Environment
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y gcc-arm-none-eabi
+        python -m pip install virtualenv
+        virtualenv -p python3 ENV
+        source ENV/bin/activate
+        
+    - name: Build Firmware
+      run: |
+        cd $GITHUB_WORKSPACE/stm32
+        VERSION_STRING=$(awk -F ' = ' '/^VERSION_STRING = /{ print $2 }' Makefile)
+        chmod +x repro-build.sh
+        ./repro-build.sh $VERSION_STRING $GITHUB_WORKSPACE $GITHUB_WORKSPACE/built
+        
+    - name: Upload Build Artifacts
+      uses: actions/upload-artifact@v2.2.4
+      with:
+        name: ccfw-repro-build-artifacts
+        path: built/
+        retention-days: 0

--- a/.github/workflows/ccfw-repro-build.yml
+++ b/.github/workflows/ccfw-repro-build.yml
@@ -2,9 +2,8 @@ name: CCFW Reproducible Build
 
 on:
   push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+    tags:        
+      - '*'
 
 jobs:
   build:

--- a/.github/workflows/ccfw-repro-build.yml
+++ b/.github/workflows/ccfw-repro-build.yml
@@ -1,11 +1,13 @@
 name: CCFW Reproducible Build
 
 on:
-  create
+  push:
+    tags:
+      - '**'
+      - '!**bootstrap*'
   
 jobs:
   build:
-    if: ${{ (github.ref_type == 'tag') && (contains(github.ref, 'bootloader') == 'false') }}
     runs-on: ubuntu-latest
     
     steps:

--- a/.github/workflows/ccfw-repro-build.yml
+++ b/.github/workflows/ccfw-repro-build.yml
@@ -1,12 +1,11 @@
 name: CCFW Reproducible Build
 
 on:
-  push:
-    tags:        
-      - '*'
-
+  create
+  
 jobs:
   build:
+    if: ${{ (github.ref_type == 'tag') && (contains(github.ref, 'bootloader') == 'false') }}
     runs-on: ubuntu-latest
     
     steps:


### PR DESCRIPTION
Hi guys,

I made this workflow for the repro build of the Coldcard firmware that is automatically triggered when a commit or pull request is merged into master.

It runs on Github runners with Ubuntu but it's easy to add other OSes if you want or even run on Docker with your dockerfile (though a bit slower and imho it's better to avoid another layer).

[Github Actions](https://docs.github.com/en/actions/learn-github-actions/usage-limits-billing-and-administration) is free for public repos, so you get a basic CI without any cost. It even gets you a badge if you want to stamp it on your readme like this:

[![CCFW Reproducible Build](https://github.com/JS1010111/firmware/actions/workflows/ccfw-repro-build.yml/badge.svg?branch=master)](https://github.com/JS1010111/firmware/actions/workflows/ccfw-repro-build.yml)

Unfortunately the reproducible build from master is failing because you have commited new code that is not in the latest released firmware v4.1.3, so the diff fails.

It's better to keep your master branch reflecting your production state and use branches for everything else if the reproducible build comes from the master. It's also possible to trigger the CI from tags or release/\<version\> branches if you will.

Please feel free to modify this PR or ask me for any changes / enhancements. I hope it'll be useful!