### PR TITLE
Xor seedsave

### DIFF
--- a/shared/flow.py
+++ b/shared/flow.py
@@ -13,7 +13,7 @@ from address_explorer import address_explore
 from users import make_users_menu
 from drv_entro import drv_entro_start
 from backups import clone_start, clone_write_data
-from xor_seed import xor_split_start, xor_restore_start
+from xor_seed import xor_save_start, xor_split_start, xor_restore_start
 from countdowns import countdown_pin_submenu, countdown_chooser
 
 # Optional feature: HSM
@@ -230,7 +230,8 @@ DebugFunctionsMenu = [
 SeedXORMenu = [
     #         xxxxxxxxxxxxxxxx
     MenuItem("Split Existing", f=xor_split_start),
-    MenuItem("Restore Seed XOR", f=xor_restore_start),
+    MenuItem("Restore Seed XOR", menu=xor_restore_start),
+    MenuItem("Create XOR file", menu=xor_save_start)
 ]
 
 SeedFunctionsMenu = [

--- a/shared/manifest.py
+++ b/shared/manifest.py
@@ -53,6 +53,7 @@ freeze_as_mpy('', [
 	'version.py',
 	'xor_seed.py',
 	'ftux.py',
+	'xor_seedsave.py',
 ], opt=0)
 
 # Optimize data-like files, since no need to debug them.

--- a/shared/pincodes.py
+++ b/shared/pincodes.py
@@ -328,6 +328,9 @@ class PinAttempt:
     def has_brickme_pin(self):
         return bool(self.state_flags & PA_HAS_BRICKME)
 
+    def has_tmp_seed(self):
+        return not self.tmp_value == False
+
     def reset(self):
         # start over, like when you commit a new seed
         return self.setup(self.pin, self.is_secondary)

--- a/shared/xor_seed.py
+++ b/shared/xor_seed.py
@@ -156,8 +156,10 @@ class XORWordNestMenu(WordNestMenu):
             import_xor_parts.clear()          # concern: we are contaminated w/ secrets
             return None
         elif ch == '1':
-            # do another list of words
-            nxt = XORSourceMenu()
+            # do another list of words. 
+            # fast-track to manual entry if no secret set yet.
+            from pincodes import pa
+            nxt = XORWordNestMenu(num_words=24) if pa.is_secret_blank() else XORSourceMenu()
             the_ux.push(nxt)
         elif ch == '2':
             # done; import on temp basis, or be the main secret
@@ -188,7 +190,7 @@ class XORWordNestMenu(WordNestMenu):
 class XORSourceMenu(MenuSystem):
     def __init__(self):
         items = [
-            MenuItem('Manually Enter', menu=self.manual_entry),
+            MenuItem('Enter Manually', menu=self.manual_entry),
             MenuItem('From SDCard', f=self.from_sdcard)
         ]
         
@@ -255,6 +257,10 @@ Press (1) to include this Coldcard's seed words into the XOR seed set, or OK to 
                     if len(words) == 24:
                         import_xor_parts.append(words)
 
+    # fast-track to manual entry if no secret set yet.
+    if pa.is_secret_blank():
+        return XORWordNestMenu(num_words=24)
+    
     return XORSourceMenu()
 
 async def xor_save_start(*a):

--- a/shared/xor_seedsave.py
+++ b/shared/xor_seedsave.py
@@ -1,0 +1,113 @@
+# (c) Copyright 2020 by Coinkite Inc. This file is covered by license found in COPYING-CC.
+#
+# xor_seedsave.py - Save xor seedwords into encrypted file on MicroSD (if desired)
+#
+import sys, stash, ujson, os, ngu
+from actions import file_picker
+from files import CardSlot, CardMissingError
+from ux import ux_show_story
+
+class XORSeedSaver:
+    # Encrypts a 12-word seed very carefully, and appends
+    # to a file on MicroSD card.
+    # AES-256 CTR with key=SHA256(SHA256(salt + derived key off master + salt))
+    # where: salt=sha256(microSD serial # details)
+
+    def _calc_key(self, card):
+        # calculate the key to be used.
+        if getattr(self, 'key', None): return
+
+        try:
+            salt = card.get_id_hash()
+
+            with stash.SensitiveValues(bypass_pw=True) as sv:
+                self.key = bytearray(sv.encryption_key(salt))
+
+        except:
+            self.key = None
+
+    def _read(self, filename):
+        # Return 24 words from encrypted file, or empty list if fail.
+        # Fail silently in all cases.
+        decrypt = ngu.aes.CTR(self.key)
+
+        try:
+            msg = open(filename, 'rb').read()
+            txt = decrypt.cipher(msg)
+            val = ujson.loads(txt)
+
+            # If contents are not what we expect, return nothing
+            if not type(val) is list:
+                return []
+            if not len(val) == 24:
+                return []
+            
+            return val
+        except:
+            return []
+
+    def _write(self, filename, words):
+        # Encrypt and save words to file.
+        # Allow exceptions to throw as validation should 
+        # have been performed before calling.
+        encrypt = ngu.aes.CTR(self.key)
+        json = ujson.dumps(words)
+        contents = encrypt.cipher(json)
+        open(filename, 'wb').write(contents)
+
+    async def read_from_card(self): 
+        import pyb
+        if not pyb.SDCard().present():
+            await ux_show_story("Insert an SDCard and try again.")
+            return None
+
+        choices = await file_picker(None, suffix='xor')
+        filename = await file_picker('Choose your XOR file.', choices=choices)
+
+        if not filename:
+            return None
+        
+        # Read file, decrypt and make a menu to show; OR return None
+        # if any error hit.
+        try:
+            with CardSlot() as card:
+                self._calc_key(card)
+                if not self.key:
+                    await ux_show_story("Failed to read file!\n\nNo action has been taken.")
+                    return None
+
+                data = self._read(filename)
+                if not data:
+                    await ux_show_story("Failed to read file!\n\nNo action has been taken.")
+                    return None
+    
+                return data
+        except CardMissingError:
+            # not an error: they just aren't using feature
+            await ux_show_story("Failed to read file!\n\nNo action has been taken.")
+            return None
+
+    async def save_to_card(self, words):
+        msg = ('Confirm these %d secret words:\n') % len(words)
+        msg += '\n'.join('%2d: %s' % (i+1, w) for i,w in enumerate(words))
+        ch = await ux_show_story(msg, sensitive=True)
+        if ch == 'x': return
+
+        import pyb
+        while not pyb.SDCard().present():
+            ch = await ux_show_story('Please insert an SDCard!')
+            if ch == 'x': return
+
+        from glob import dis
+        # Show progress:
+        dis.fullscreen('Encrypting...')
+
+        with CardSlot() as card:
+            filename, nice = card.pick_filename('seedwords.xor')
+            self._calc_key(card)
+            self._write(filename, words)
+            await ux_show_story('XOR file written:\n\n%s' % nice)
+
+        return None
+
+# EOF

--- a/shared/xor_seedsave.py
+++ b/shared/xor_seedsave.py
@@ -95,7 +95,7 @@ class XORSeedSaver:
 
         import pyb
         while not pyb.SDCard().present():
-            ch = await ux_show_story('Please insert an SDCard!')
+            ch = await ux_show_story('Please insert an SDCard!\n\nPress OK to continue, X to cancel')
             if ch == 'x': return
 
         from glob import dis

--- a/testing/test_seed_xor.py
+++ b/testing/test_seed_xor.py
@@ -22,7 +22,7 @@ ones32 = ' '.join('zoo' for _ in range(23)) + ' vote'
     ( [ones32]*7, ones32),
     ( [ones32]*4, zero32),
 ])
-def test_import_xor(incl_self, parts, expect, goto_home, pick_menu_item, cap_story, need_keypress, cap_menu, word_menu_entry, get_secrets, reset_seed_words, set_seed_words):
+def test_import_xor_manual(incl_self, parts, expect, goto_home, pick_menu_item, cap_story, need_keypress, cap_menu, word_menu_entry, get_secrets, reset_seed_words, set_seed_words):
 
     # values from docs/seed-xor.md, and some easy cases
 
@@ -50,6 +50,8 @@ def test_import_xor(incl_self, parts, expect, goto_home, pick_menu_item, cap_sto
     else:
         need_keypress('y')
 
+    pick_menu_item('Enter Manually')
+
     #time.sleep(0.01)
 
     for n, part in enumerate(parts):
@@ -65,6 +67,7 @@ def test_import_xor(incl_self, parts, expect, goto_home, pick_menu_item, cap_sto
 
         if n != len(parts)-1:
             need_keypress('1')
+            pick_menu_item('Enter Manually')
         else:
             # correct anticipated checksum word
             chk_word = expect.split()[-1]
@@ -165,6 +168,7 @@ def test_import_zero_set(goto_home, pick_menu_item, cap_story, need_keypress, ca
     assert 'you have a seed already' in body
     assert '(1) to include this Coldcard' in body
     need_keypress('y')
+    pick_menu_item('Enter Manually')
 
     #time.sleep(0.01)
 
@@ -181,6 +185,8 @@ def test_import_zero_set(goto_home, pick_menu_item, cap_story, need_keypress, ca
             return
 
         need_keypress('1')
+        pick_menu_item('Enter Manually')
+
 
     raise pytest.fail("reached")
 

--- a/unix/work/MicroSD/.gitignore
+++ b/unix/work/MicroSD/.gitignore
@@ -6,4 +6,5 @@
 *.pdf
 *.dfu
 *.txn
+*.xor
 .tmp.tmp


### PR DESCRIPTION
Thanks for contributing to COLDCARD source code, please be as descriptive as possible.

- If you haven't yet, please check out our docs https://coldcardwallet.com/docs/
- Have you tested your work yet? You can do it with the simulator https://github.com/Coldcard/firmware/blob/master/unix/simulator.py

*By submitting this work you agree to the [Individual Contributor License Agreement (CLA)](https://raw.githubusercontent.com/Coldcard/firmware/master/CONTRIBUTING.md)*

---

I hope this is useful and not controversial, I am building on the seed xor work (love it btw).

TODO list:
[x] Implement loading from file
[x] Implement saving to file
[x] Manually test edge cases
[x] Make existing tests pass
[ ] Create new tests to cover new functionality

This PR will introduce saving and restoring XOR from sd cards.

The idea here, is that similar to passphrases, you can store one seed on the device, and another on an SD card.
When you wish to sign, you must log in using your pin, then you must restore the seed xor from file and you may then sign a transaction, bringing a more secure alternative to the passphrase.

Of course, this is not a replacement for backing up the XOR seed words.

When creating an XOR file, you are told to have your seed words ready, this is a hint to have an already valid seed word. As the ColdCard is not creating the words, there is no need for a quiz.

Loading from SD Card is not enabled if you have no existing seed words (eg. first time use). This makes no sense anyway as the file is encrypted using an existing xpriv, so if you don't have an existing xpriv, we can't decrypt the file anyway.

When you are restoring seed XOR words, you will be asked whether you wish to "enter manually" or load from sd card.

The code is defensive, and if reading, decrypting or parsing the file fails, then the user will see a message, no action was taken, and they will be able to continue where they left off.

One thing that is novel here, is that once the XOR has been applied, you cannot decrypt the file anymore as we will always use the currently in use private key to decrypt and parse any xor files.

A user can store multiple xor files on multiple sd cards and restore them, or they can put them all on one sd card.

You are NOT offered to save your XOR to file after creating one, that feels complicated. Instead, you are able to create XOR files at any time through a separate menu.