### PR TITLE
Fix unix/variant/ffilib.py to detect linux systems correctly

### DIFF
--- a/unix/variant/ffilib.py
+++ b/unix/variant/ffilib.py
@@ -14,7 +14,7 @@ def open(name, maxver=10, extra=()):
     except KeyError:
         pass
     def libs():
-        if sys.platform == "linux":
+        if "unix" in sys.platform:
             yield '%s.so' % name
             for i in range(maxver, -1, -1):
                 yield '%s.so.%u' % (name, i)


### PR DESCRIPTION
It appears that sys.platform on linux systems report as "coldcard-unix" so ffilib.py needs to search for the string "unix" in order for the simulator to work on linux.