### PR TITLE
Allow PSBTs with missing UTXOs

### DIFF
--- a/shared/psbt.py
+++ b/shared/psbt.py
@@ -1284,15 +1284,12 @@ class psbtObject(psbtProxy):
         # XXX scan witness data provided, and consider those ins signed if not multisig?
 
         if missing:
-            # Should probably be a fatal msg; so risky... but
             # - maybe we aren't expected to sign that input? (coinjoin)
-            # - assume for now, probably funny business so we should stop
-            raise FatalPSBTIssue('Missing UTXO(s). Cannot determine value being signed')
-            # self.warnings.append(('Missing UTXOs',
-            #        "We don't know enough about the inputs to this transaction to be sure "
-            #        "of their value. This means the network fee could be huge, or resulting "
-            #        "transaction's signatures invalid."))
-            #self.total_value_in = None
+            self.warnings.append(('Missing UTXOs',
+                    "We don't know enough about the inputs to this transaction to be sure "
+                    "of their value. This means the network fee could be huge, or resulting "
+                    "transaction's signatures invalid."))
+            self.total_value_in = None
         else:
             assert total_in > 0
             self.total_value_in = total_in


### PR DESCRIPTION
It appears that the firmware is unable to sign PSBTs where one or more inputs lack a UTXO. This is a problem in multi-party transactions (e.g. coinjoin) where each signer is expected to populate their own UTXO data and ignore other inputs for signing purposes.

This change simply deletes the line that raises a fatal error in that scenario and uncomments an older code block that creates a warning instead.