### PR TITLE
USB Encryption v2

### DIFF
--- a/shared/usb.py
+++ b/shared/usb.py
@@ -603,6 +603,11 @@ class USBHandler:
 
         #print("USB garbage: %s +[%d]" % (cmd, len(args)))
 
+        # Force logout if bound and unknown command received
+        if self.bound:
+            from utils import clean_shutdown, call_later_ms
+            call_later_ms(250, clean_shutdown)
+
         return b'err_Unknown cmd'
 
 


### PR DESCRIPTION
This introduces a new `ncry` version to close a potential attack vector:

A malicious program may re-initialize the connection encryption by sending the `ncry` command a second time during USB operation. This may prove particularly harmful in HSM mode.

Sending version `0x2` sets the new `bound` flag on the `USBHandler`, which changes the behavior in two ways:

- All future commands **must** be encrypted
- Returns an error if the `ncry` command is sent again for the duration of the power cycle