### PR TITLE
Hardcode alpine version

### DIFF
--- a/stm32/dockerfile.build
+++ b/stm32/dockerfile.build
@@ -6,13 +6,7 @@
 #  <https://blog.feabhas.com/2017/12/introduction-docker-embedded-developers-part-4-reducing-docker-image-size/>
 #
 
-# PROBLEM: alpine has `gcc-arm-none-eabi` but it's not in main repo, instead its part of "edge"?
-#
-# - for firmware v4.0.2, I used alphine:3.13.2 as base, but that doesn't work now for
-#   some random reason, and I don't care to debug why.
-#
-#FROM alpine:3.13.2
-FROM alpine:edge
+FROM alpine:3.16.0
 
 WORKDIR /work
 


### PR DESCRIPTION

1. I wasn't able to reproduce until I purged my docker images and containers
```
docker rm $(docker ps -a -q)
docker rmi $(docker images -a -q)
```
2. after above run `make repro` and one should get the same issue as user
3. fix --> do not use `alpine:edge` I instead pinned it to 3.16.0 (currently latest) and it works. So it seems that release was done with this version, but current edge is now different

