### PR TITLE
`swig` is missing when starting on macOS from scratch

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ You'll probably need to install at least these packages:
     brew install --cask xquartz
     brew install sdl2 xterm
     brew install --cask gcc-arm-embedded
+    brew install swig
 
 Used to be these were needed as well:
 


### PR DESCRIPTION
Thanks for contributing to COLDCARD source code, please be as descriptive as possible.

- If you haven't yet, please check out our docs https://coldcardwallet.com/docs/
- Have you tested your work yet? You can do it with the simulator https://github.com/Coldcard/firmware/blob/master/unix/simulator.py

*By submitting this work you agree to the [Individual Contributor License Agreement (CLA)](https://raw.githubusercontent.com/Coldcard/firmware/master/CONTRIBUTING.md)*

---
