### PR TITLE
repro build improvements

### DIFF
--- a/stm32/repro-build.sh
+++ b/stm32/repro-build.sh
@@ -54,9 +54,9 @@ else
 fi
 cd ../stm32
 
-if [ -z "$SOURCE_DATE_EPOCH" ]; then
-    TAG=$(basename $PUBLISHED_BIN | cut -d "-" -f1,2,3,4)
-    export SOURCE_DATE_EPOCH=$(git show -s --format=%at $TAG | tail -n1)
+if [ -z "$SOURCE_DATE_EPOCH" ] && [ -n "$PUBLISHED_BIN" ]; then
+    DT=$(basename $PUBLISHED_BIN | cut -d "-" -f1,2,3)
+    export SOURCE_DATE_EPOCH=$(python -c 'import datetime, sys; sys.stdout.write(str(int(datetime.datetime.strptime(sys.argv[1], "%Y-%m-%dT%H%M").timestamp())))' "$DT")
 fi
 
 $MAKE setup


### PR DESCRIPTION
* get timestamp from filename instead from git
* if PUBLISHED_BIN is not defined do not try to get timestamp
I used python for datetime to epoch conversion as there are some differences between how `date` works in OSX and linux (https://stackoverflow.com/questions/10990949/convert-date-time-string-to-epoch-in-bash). I removed getting timestamp from git as it may not work for some people that have exotic way of getting firmware source. This just seem more natural to do as we have date string in filename - git is unnecessary here. 
