### PR TITLE
Add progress bar to type passwords and add simple cache of length 1

### DIFF
--- a/docs/bip85-passwords.md
+++ b/docs/bip85-passwords.md
@@ -100,6 +100,6 @@ Although the Coldcard is emulating a keyboard at the lowest possible level,
 for some reason occasionally high-level applications have
 trouble with our high-speed typing.
 
-- KeePass 2.45 (under Ubuntu). Capital letters may be lost.
+- KeePass2 2.45 (under Ubuntu). Capital/lowercase letters may be incorrectly typed. Use KeePassXC instead.
 
 

--- a/shared/drv_entro.py
+++ b/shared/drv_entro.py
@@ -252,6 +252,10 @@ async def password_entry(*args, **kwargs):
     from glob import dis
     from usb import EmulatedKeyboard
 
+    # cache of length of 1
+    # (index, path, password)
+    cache = tuple()
+
     # TODO: maybe a way to kill this info dialog w/ a setting
     ch = await ux_show_story('''\
 Type Passwords (BIP-85)
@@ -270,9 +274,13 @@ The password will be sent as keystrokes via USB to the host computer.''')
             if index is None:
                 break
 
-            dis.fullscreen("Working...")
-            new_secret, _, _, path = bip85_derive(7, index)
-            pw = bip85_pwd(new_secret)
+            if cache and index == cache[0]:
+                path, pw = cache[1:]
+            else:
+                dis.fullscreen("Working...")
+                new_secret, _, _, path = bip85_derive(7, index)
+                pw = bip85_pwd(new_secret)
+                cache = (index, path, pw)
 
             await send_keystrokes(kbd, pw, path)
 

--- a/shared/usb.py
+++ b/shared/usb.py
@@ -909,6 +909,7 @@ class EmulatedKeyboard:
             enable_usb()
 
     async def send_keystrokes(self, keystroke_string):
+        from glob import dis
         # Send keystrokes to enter a password... only expected to support Base64 charset
         if is_simulator():
             print("Simulating keystrokes: " + repr(keystroke_string))
@@ -960,8 +961,10 @@ class EmulatedKeyboard:
             "\r": 0x28,
         }
         buf = bytearray(8)
+        pwd_len = len(keystroke_string)
+        dis.fullscreen('Typing...')
 
-        for ch in keystroke_string:
+        for i, ch in enumerate(keystroke_string, start=1):
             cap = False
             if ch in char_map:
                 to_press = char_map[ch]
@@ -984,4 +987,5 @@ class EmulatedKeyboard:
             while self.dev.send(buf) == 0:
                 await sleep_ms(5)
 
+            dis.progress_bar_show(i/pwd_len)
 # EOF 


### PR DESCRIPTION
* add progress bar for typing of passwords (better UX)
* cache one index,path,pw tuple during kbd emu
* adjust incompatibility part of BIP-85 doc
