### PR TITLE
Improvements to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Coldcard is a Cheap, Ultra-secure & Verifiable Hardware Wallet for Bitcoin.
 Get yours at [Coldcard.com](http://coldcard.com)
 
 [Follow @COLDCARDwallet on Twitter](https://twitter.com/coldcardwallet) to keep up
-with the latest updates and security alerts. 
+with the latest updates and security alerts.
 
 ![coldcard logo](https://coldcard.com/static/images/coldcard-logo-nav.png)
 
@@ -16,15 +16,15 @@ To have confidence this source code tree is the same as the binary on your devic
 you can rebuild it from source and get **exactly the same bytes**. This process
 has been automated using Docker. Steps are as follows:
 
-1. Install Docker and start it.
+1. Install [Docker](https://www.docker.com) and start it.
 2. Install [make (GNUMake)](https://www.gnu.org/software/make/) if you don't already have it.
 3. Checkout the code, and start the process.
 
+    ```shell
     git clone https://github.com/Coldcard/firmware.git
-
     cd firmware/stm32
-
     make repro
+    ```
 
 4. At the end of the process a clear confirmation message is shown, or the differences.
 5. Build products can be found `firmware/stm32/built`.
@@ -36,30 +36,77 @@ See branch `v4-legacy` for firmware which supports only Mk3/Mk2 and earlier.
 
 Do a checkout, recursively to get all the submodules:
 
-    git clone --recursive https://github.com/Coldcard/firmware.git
+```shell
+git clone --recursive https://github.com/Coldcard/firmware.git
+```
 
 Already checked-out and getting git errors? Do this:
 
-    git fetch
-    git reset --hard origin/master
+```shell
+git fetch
+git reset --hard origin/master
+```
+
+Alternatively, to get the latest release, you checkout a tagged branch:
+
+```shell
+git clone https://github.com/Coldcard/firmware.git
+cd firmware
+git checkout $(git describe --match "20*" --abbrev=0)
+git submodule update --init --recursive
+```
 
 Do not use a path with any spaces in it. The Makefiles do not handle
 that well, and we're not planning to fix it.
 
+### macOS
+
+[Python 3.5 or higher](https://www.python.org) and [Homebrew](https://brew.sh) is required.
+
+#### Setup and run the desktop simulator
+
+You'll probably need to install at least these packages:
+
+```shell
+brew install sdl2 xterm swig
+brew install --cask xquartz gcc-arm-embedded
+```
+
+Used to be these were needed as well:
+
+```shell
+brew tap PX4/px4
+brew search px4/px4/gcc-arm-none-eabi
+```
+
+Then install the newest version, currently 83:
+
+```shell
+brew install px4/px4/gcc-arm-none-eabi-83
+```
+
+You may need to `brew upgrade gcc-arm-embedded` because we need 10.2 or higher.
+
 Then:
 
-- `cd firmware`
-- `git submodule update --init` _(if needed?)_
-- `brew install automake autogen virtualenv`
-- `virtualenv -p python3 ENV` (Python > 3.5 is required)
-- `source ENV/bin/activate` (or `source ENV/bin/activate.csh` based on shell preference)
-- `pip install -r requirements.txt`
+```shell
+brew install automake autogen virtualenv
+virtualenv -p python3 ENV
+source ENV/bin/activate (or source ENV/bin/activate.csh based on shell preference)
+pip install -r requirements.txt
+make -C external/micropython/mpy-cross
+cd unix; make setup && make ngu-setup && make && ./simulator.py
+```
 
-Setup and Run the Desktop-based Coldcard simulator:
+You may need to reboot to avoid a `DISPLAY is not set` error.
 
-- `cd unix; make setup && make && ./simulator.py`
+The next time you want to run the simulator, you can simply do
 
-Building the firmware:
+```shell
+source ENV/bin/activate && cd unix && ./simulator.py
+```
+
+#### Building the firmware
 
 - `cd ../cli; pip install --editable .`
 - `cd ../stm32; make setup && make; make firmware-signed.dfu`
@@ -69,42 +116,28 @@ Building the firmware:
 
 Which looks like this:
 
-    [ENV] [firmware/stm32 42] ckcc upgrade firmware-signed.dfu
-    675328 bytes (start @ 293) to send from 'firmware-signed.dfu'
-    Uploading  [##########--------------------------]   29%  0d 00:01:04
-
-
-### MacOS
-
-You'll probably need to install at least these packages:
-
-    brew install --cask xquartz
-    brew install sdl2 xterm
-    brew install --cask gcc-arm-embedded
-    brew install swig
-
-Used to be these were needed as well:
-
-    brew tap PX4/px4
-    brew search px4
-    brew install px4/px4/gcc-arm-none-eabi-80 (latest gcc-arm-none-eabi-XX, currently 80)
-
-You may need to reboot to avoid a `DISPLAY is not set` error.
-
-You may need to `brew upgrade gcc-arm-embedded` because we need 10.2 or higher.
+```shell
+[ENV] [firmware/stm32 42] ckcc upgrade firmware-signed.dfu  
+675328 bytes (start @ 293) to send from 'firmware-signed.dfu'
+Uploading  [##########--------------------------]   29%  0d 00:01:04
+```
 
 #### Big Sur Issues
 
-- `defaults write org.python.python ApplePersistenceIgnoreState NO` will supress a warning
-  about `Python[22580:10101559] ApplePersistenceIgnoreState: Existing state will not be touched. New state will be written to...` see <https://bugs.python.org/issue32909>
+`defaults write org.python.python ApplePersistenceIgnoreState NO` will suppress a warning about `Python[22580:10101559] ApplePersistenceIgnoreState: Existing state will not be touched. New state will be written to...`
+
+See <https://bugs.python.org/issue32909>
 
 ### Linux
 
 You'll need to install these (Ubuntu 20.04):
 
-    apt install build-essential git python3 python3-pip libudev-dev gcc-arm-none-eabi libffi-dev xterm swig libpcsclite-dev python-is-python3
+```shell
+apt install build-essential git python3 python3-pip libudev-dev gcc-arm-none-eabi libffi-dev xterm swig libpcsclite-dev python-is-python3
+```
 
 Install and run simulator on Ubuntu 20.04
+
 ```shell
 git clone --recursive https://github.com/Coldcard/firmware.git
 cd firmware
@@ -143,13 +176,12 @@ Top-level dirs:
 
 `unix`
 
-- unix (MacOS) version for testing/rapid dev
+- unix (macOS) version for testing/rapid dev
 - this is a simulator for the product
 
 `testing`
 
 - test cases and associated data
-
 
 `stm32`
 
@@ -180,13 +212,11 @@ Top-level dirs:
 
 `unix/work/...`
 
-- `/MicroSD/*` files on "simulated" microSD card 
+- `/MicroSD/*` files on "simulated" microSD card
 
 - `/VirtDisk/*` simulated emulated virtual Disk files.
 
-- `/settings/*.aes` persistant settings for Simulator
-
-
+- `/settings/*.aes` persistent settings for Simulator
 
 ## Support
 


### PR DESCRIPTION
* **Added instructions on how to clone the latest tagged release as an alternative to master**

In some case you’d want to run the simulator with the same version as on device.

* **Gathered information about macOS in one place**

The info was spread out and hard to follow.

* **Added instructions on how to build mpy-cross**

Got the following error message if not:

```
mpy-cross not found at /Users/redacted/Developer/coldcard/firmware/external/micropython/mpy-cross/mpy-cross, please build it first
make[2]: *** [build-standard/frozen_content.c] Error 1
make[1]: *** [tools] Error 2
make: *** [setup] Error 2
```

* **Added `make ngu-setup`**

Got the following error message if not when running `make`:

```
In file included from /Users/redacted/Developer/coldcard/firmware/external/c-modules/libngu/lib_secp256k1.c:9:
In file included from /Users/redacted/Developer/coldcard/firmware/external/libngu/libs/secp256k1/src/secp256k1.c:10:
In file included from /Users/redacted/Developer/coldcard/firmware/external/libngu/libs/secp256k1/src/assumptions.h:12:
/Users/redacted/Developer/coldcard/firmware/external/libngu/libs/secp256k1/src/util.h:11:10: fatal error: 'libsecp256k1-config.h' file not found
#include "libsecp256k1-config.h"
         ^~~~~~~~~~~~~~~~~~~~~~~
CC /Users/redacted/Developer/coldcard/firmware/external/c-modules/libngu/lib_segwit.c
1 error generated.
CC /Users/redacted/Developer/coldcard/firmware/external/c-modules/mpy-qr/moduqr.c
make[1]: *** [build-coldcard-mpy/libngu/lib_secp256k1.o] Error 1
make[1]: *** Waiting for unfinished jobs....
make: *** [all] Error 2
```

* **Added info on how to run the simulator the second time round.**
* **Using fenced code blocks for consistency**
* **Added links to Docker, Python and Homebrew**
* **Fixed some typos and spacing issues**
