### PR TITLE
add patch to fix build on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,12 @@ Then:
 brew install automake autogen virtualenv
 virtualenv -p python3 ENV
 source ENV/bin/activate (or source ENV/bin/activate.csh based on shell preference)
+pip install -U pip
 pip install -r requirements.txt
+# apply micropython patch
+pushd external/micropython
+git apply ../../macos-mpy.patch
+popd
 make -C external/micropython/mpy-cross
 cd unix; make setup && make ngu-setup && make && ./simulator.py
 ```

--- a/macos-mpy.patch
+++ b/macos-mpy.patch
@@ -1,0 +1,26 @@
+diff --git a/mpy-cross/Makefile b/mpy-cross/Makefile
+index 971f2f81a..b175c4dc7 100644
+--- a/mpy-cross/Makefile
++++ b/mpy-cross/Makefile
+@@ -17,7 +17,7 @@ INC += -I$(BUILD)
+ INC += -I$(TOP)
+ 
+ # compiler settings
+-CWARN = -Wall -Werror
++CWARN = -Wall -Werror -Wno-error=unused-but-set-variable -Wno-error=array-bounds
+ CWARN += -Wextra -Wno-unused-parameter -Wpointer-arith
+ CFLAGS = $(INC) $(CWARN) -std=gnu99 $(CFLAGS_MOD) $(COPT) $(CFLAGS_EXTRA)
+ CFLAGS += -fdata-sections -ffunction-sections -fno-asynchronous-unwind-tables
+diff --git a/ports/unix/Makefile b/ports/unix/Makefile
+index 6a936a242..6b4900561 100644
+--- a/ports/unix/Makefile
++++ b/ports/unix/Makefile
+@@ -38,7 +38,7 @@ INC +=  -I$(TOP)
+ INC += -I$(BUILD)
+ 
+ # compiler settings
+-CWARN = -Wall -Werror
++CWARN = -Wall -Werror -Wno-error=unused-but-set-variable -Wno-error=array-bounds
+ CWARN += -Wextra -Wno-unused-parameter -Wpointer-arith -Wdouble-promotion -Wfloat-conversion
+ CFLAGS += $(INC) $(CWARN) -std=gnu99 -DUNIX $(CFLAGS_MOD) $(COPT) -I$(VARIANT_DIR) $(CFLAGS_EXTRA)
+ 


### PR DESCRIPTION
my machine: macOS Monterey 12.5

Cannot build mpy-cross and micropython without adjusting makefiles. Need to ignore some warnings and do not consider them as an errors.

this has to be added to both `external/micropython/mpy-cross/Makefile` and `external/micropython/ports/unix/Makefile`:
```
-Wno-error=unused-but-set-variable -Wno-error=array-bounds
```
