### PR TITLE
Add note about rescanning blockchain after `importdescriptors` for Bitcoin Core

### DIFF
--- a/shared/export.py
+++ b/shared/export.py
@@ -186,6 +186,8 @@ in Bitcoin Core, or using bitcoin-cli:
 
 importdescriptors '{imp_desc}'
 
+> **NOTE** If your UTXO was created before running the previous `importdescriptors` command, you need to run `rescanblockchain` for the transaction to show in Bitcoin Core.
+
 ### Bitcoin Core before v0.21.0 
 
 This command can be used on older versions, but it is not as robust


### PR DESCRIPTION
Wanted to setup watch only wallet on Bitcoin Core.
Found this thread: https://bitcointalk.org/index.php?topic=5392824
Followed it but was confused because I didn't see any transactions for my watch only wallet.
Stumbled upon `rescanblockchain`.
Success!

Wanted to get this into the exported CC docs so another pleb in the future doesn't have to search the interwebs.

Thank you CC team!

*By submitting this work you agree to the [Individual Contributor License Agreement (CLA)](https://raw.githubusercontent.com/Coldcard/firmware/master/CONTRIBUTING.md)*

---
