### PR TITLE
New HSM policy rules

### DIFF
--- a/shared/hsm.py
+++ b/shared/hsm.py
@@ -114,7 +114,6 @@ def pop_float(j, fld_name, mn=0, mx=1000000):
     if v is None: return v
     assert float(v) == v, "%s: must be float" % fld_name
     v = float(v)
-    assert mn <= mx, '%s: cannot be specified' % fld_name
     assert mn <= v <= mx, "%s: must be in range: [%d..%d]" % (fld_name, mn, mx)
     return v
 
@@ -306,8 +305,8 @@ class ApprovalRule:
         if self.min_pct_self_transfer:
             own_in_value = sum([i.amount for i in psbt.inputs if i.num_our_keys > 0])
             own_out_value = sum([o.amount for o in psbt.outputs if o.num_our_keys > 0])
-            ratio = float(own_out_value) / own_in_value
-            assert ratio >= self.min_pct_self_transfer, 'does not meet self transfer threshold'
+            percentage = (float(own_out_value) / own_in_value) * 100.0
+            assert percentage >= self.min_pct_self_transfer, 'does not meet self transfer threshold, expected: %.2f, actual: %.2f' % (self.min_pct_self_transfer, percentage)
 
         # check various patterns
 

--- a/shared/hsm.py
+++ b/shared/hsm.py
@@ -199,7 +199,7 @@ class ApprovalRule:
             assert self.wallet in names, "unknown MS wallet: "+self.wallet
 
         # patterns must be valid
-        for p in patterns:
+        for p in self.patterns:
             assert p in TX_PATTERNS, "unknown pattern: " + p
 
         assert_empty_dict(j)
@@ -212,7 +212,7 @@ class ApprovalRule:
         # remote users need to know what's happening, and we save this
         # cleaned up data
         flds = [ 'per_period', 'max_amount', 'users', 'min_users',
-                    'local_conf', 'whitelist', 'wallet', 'min_pct_self_transfer' 'patterns' ]
+                    'local_conf', 'whitelist', 'wallet', 'min_pct_self_transfer', 'patterns' ]
         return dict((f, getattr(self, f, None)) for f in flds)
 
 
@@ -258,7 +258,7 @@ class ApprovalRule:
             rv += ' if local user confirms'
 
         if self.min_pct_self_transfer:
-            rv += ' if self-transfer percentage is at least %.2f' % self.min_pct_own_to_self
+            rv += ' if self-transfer percentage is at least %.2f' % self.min_pct_self_transfer
 
         if self.patterns:
             rv += ' with the following patterns: '
@@ -303,8 +303,8 @@ class ApprovalRule:
 
         # check the self-transfer percentage
         if self.min_pct_self_transfer:
-            own_in_value = sum([i.amount for i in psbt.inputs if i.num_our_keys > 0])
-            own_out_value = sum([o.amount for o in psbt.outputs if o.num_our_keys > 0])
+            own_in_value = sum([i.amount for i in psbt.inputs if i.num_our_keys])
+            own_out_value = sum([o.amount for o in psbt.outputs if o.num_our_keys])
             percentage = (float(own_out_value) / own_in_value) * 100.0
             assert percentage >= self.min_pct_self_transfer, 'does not meet self transfer threshold, expected: %.2f, actual: %.2f' % (self.min_pct_self_transfer, percentage)
 
@@ -314,8 +314,8 @@ class ApprovalRule:
             assert len(psbt.inputs) == len(psbt.outputs), 'unequal number of inputs and outputs'
 
         if "EQ_NUM_OWN_INS_OUTS" in self.patterns:
-            own_ins = sum([1 for i in psbt.inputs if i.num_our_keys > 0])
-            own_outs = sum([1 for o in psbt.outputs if o.num_our_keys > 0])
+            own_ins = sum([1 for i in psbt.inputs if i.num_our_keys])
+            own_outs = sum([1 for o in psbt.outputs if o.num_our_keys])
             assert own_ins == own_outs, 'unequal number of own inputs and outputs'
 
         if "EQ_OUT_AMOUNTS" in self.patterns:

--- a/shared/psbt.py
+++ b/shared/psbt.py
@@ -287,7 +287,7 @@ class psbtProxy:
 class psbtOutputProxy(psbtProxy):
     no_keys = { PSBT_OUT_REDEEM_SCRIPT, PSBT_OUT_WITNESS_SCRIPT }
     blank_flds = ('unknown', 'subpaths', 'redeem_script', 'witness_script',
-                    'is_change', 'num_our_keys')
+                    'is_change', 'num_our_keys', 'amount')
 
     def __init__(self, fd, idx):
         super().__init__()
@@ -347,6 +347,9 @@ class psbtOutputProxy(psbtProxy):
         # - full key derivation and validation is done during signing, and critical.
         # - we raise fraud alarms, since these are not innocent errors
         #
+
+        # assign output amount
+        self.amount = txo.nValue
 
         num_ours = self.parse_subpaths(my_xfp, parent.warnings)
 


### PR DESCRIPTION
The PR contains a number of additions to the HSM policy format.

There is a new rule called `min_pct_self_transfer`. This operates on own inputs and outputs, where "own" means "contains a derivation path" and can therefore be guaranteed to derive from the master key on the device. The rule accepts a percentage (0..100 float) and calculates the ratio of funds going to own outputs and funds coming from own inputs. For instance, `"min_pct_self_transfer": 99.0` would dictate that the value of outputs going back to the wallet has to meet at least 99% of the value of inputs coming from the wallet  (in other words, non-change outputs are confined to 1% or lower). Foreign inputs and outputs are ignored for the purposes of this rule.

Another addition is the `patterns` list which takes any number of predefined patterns. These patterns are rather simple heuristics that are applied against a PSBT. The following patterns have been defined thus far:

```json
{
    "EQ_NUM_INS_OUTS": "the number of inputs and outputs must be equal",
    "EQ_NUM_OWN_INS_OUTS": "the number of OWN inputs and outputs must be equal",
    "EQ_OUT_AMOUNTS": "all outputs must have equal amounts"
}
```
The definition of "own" in the second pattern is the same as the one described earlier.

This rule might be used like: ```"patterns": ["EQ_NUM_INS_OUTS", "EQ_OUT_AMOUNTS"]```.

The addition of these building blocks allows the creation of policies that suit more complex transactions (such as Chaumian coinjoin) while blocking everything else and ensuring that malicious software cannot drain a Coldcard using fraudulently crafted transactions. The pattern list is extensible and can accommodate further applications.