### PR TITLE
fix single address share over NFC bug

### DIFF
--- a/releases/ChangeLog-mk4.md
+++ b/releases/ChangeLog-mk4.md
@@ -3,6 +3,7 @@
 - Enhancement: multisig NFC import not offered if MicroSD card is installed. Now separate
   option provided Settings -> Multisig Wallets -> Import via NFC. NFC has to be enabled
   for this option to be visible.
+- Bugfix: share single address over NFC from address explorer menu
 
 ## 5.0.6 - 2022-07-29
 

--- a/shared/address_explorer.py
+++ b/shared/address_explorer.py
@@ -302,8 +302,8 @@ Press 3 if you really understand and accept these risks.
                 # share table over NFC
                 if n > 1:
                     await NFC.share_text('\n'.join(addrs))
-                else:
-                    await NFC.share_deposit_address(addrs[self.idx])
+                elif n == 1:
+                    await NFC.share_deposit_address(addrs[0])
                 continue
 
             elif ch == '4' and allow_change:

--- a/testing/test_address_explorer.py
+++ b/testing/test_address_explorer.py
@@ -358,6 +358,13 @@ def test_custom_path(path, which_fmt, addr_vs_path, pick_menu_item, goto_address
             assert qr == addr
 
         if is_mark4 and get_setting('nfc', 0):
+            # this is actually testing NFC export in qr code menu
+            need_keypress('3')
+            time.sleep(.1)
+            assert nfc_read_text() == addr
+            need_keypress("x")  # leave NFC animation
+            need_keypress("x")  # leave QR code display
+            # test NFC export in address explorer
             need_keypress('3')
             time.sleep(.1)
             assert nfc_read_text() == addr


### PR DESCRIPTION
Reproduction steps:
* go to "Address Explorer"
* press 4 (confirm display of sensitive data)
* choose "Custom Path"
* choose just 'm' (or whatever path that only generates one address)
* choose address format - doe not matter
* press 3 (much danger)
* press 3 to share via NFC
* result: **yikes**


![Screenshot from 2022-08-22 19-28-08](https://user-images.githubusercontent.com/25349625/185984613-8112944b-d097-4ee9-8df4-ce33b5ad9360.png)
![Screenshot from 2022-08-22 19-27-53](https://user-images.githubusercontent.com/25349625/185984620-b0052e1d-8f36-4239-9d3b-22278d463b08.png)


Tests would not catch it as it wasn't tested - instead pressing 3 on QR menu which works ok was tested - test case added.
