### PR TITLE
Menu wrapping (wrap around bottom/top)

### DIFF
--- a/releases/ChangeLog-mk4.md
+++ b/releases/ChangeLog-mk4.md
@@ -3,6 +3,8 @@
 - Enhancement: multisig NFC import not offered if MicroSD card is installed. Now separate
   option provided Settings -> Multisig Wallets -> Import via NFC. NFC has to be enabled
   for this option to be visible.
+- Enhancement: New menu wraparound settings which allow you to scroll over top and bottom.
+- Bugfix: correct parsing of unknown fields in PSBT
 - Bugfix: share single address over NFC from address explorer menu
 
 ## 5.0.6 - 2022-07-29

--- a/shared/flow.py
+++ b/shared/flow.py
@@ -132,6 +132,9 @@ The signed transaction will be named <TXID>.txn, so the file name does not leak 
 MS-DOS tools should not be able to find the PSBT data (ie. undelete), but forensic tools \
 which take apart the flash chips of the SDCard may still be able to find the \
 data or filenames.'''),
+    ToggleMenuItem('Menu Wrapping', 'wa', ['Default Off', 'Enable'],
+           story='''This mode, if enabled, allows to scroll past menu top/bottom. 
+By default, this is only possible in very large menus.'''),
     ToggleMenuItem('Keyboard EMU', 'emu', ['Default Off', 'Enable'],
            on_change=usb_keyboard_emulation,
            predicate=has_secrets,  # cannot generate BIP85 passwords without secret

--- a/shared/menu.py
+++ b/shared/menu.py
@@ -211,22 +211,34 @@ class MenuSystem:
 
         dis.show()
 
+    def get_wrap_length(self):
+        from glob import settings
+        # wa is boolean value from config
+        # True --> wrap around all menus with length greater than 1
+        # False --> wrap around is active only for menus with length > WRAP_IF_OVER
+        wrap = settings.get("wa", 0)
+        return 1 if wrap else WRAP_IF_OVER
+
     def down(self):
         if self.cursor < self.count-1:
             self.cursor += 1
 
             if self.cursor - self.ypos >= (PER_M-1):
                 self.ypos += 1
-        elif self.count > WRAP_IF_OVER:
-            self.goto_idx(0)
+        else:
+            wrap_length = self.get_wrap_length()
+            if self.count > wrap_length:
+                self.goto_idx(0)
 
     def up(self):
         if self.cursor > 0:
             self.cursor -= 1
             if self.cursor < self.ypos:
                 self.ypos -= 1
-        elif self.count > WRAP_IF_OVER:
-            self.goto_idx(self.count-1)
+        else:
+            wrap_length = self.get_wrap_length()
+            if self.count > wrap_length:
+                self.goto_idx(self.count - 1)
 
     def top(self):
         self.cursor = 0

--- a/shared/nvstore.py
+++ b/shared/nvstore.py
@@ -53,6 +53,7 @@ from glob import PSRAM
 #   vdsk = (bool) if set, enable the Virtual Disk features in pre 5.0.6 version; [OBSOLETE]
 #   vidsk = (bool) if set, enable the Virtual Disk features after v5.0.6
 #   emu = (bool) if set, enables the USB Keyboard emulation (BIP-85 password entry)
+#   wa = (bool) if set, enables menu wraparound
 # Stored w/ key=00 for access before login
 #   _skip_pin = hard code a PIN value (dangerous, only for debug)
 #   nick = optional nickname for this coldcard (personalization)

--- a/testing/test_ux.py
+++ b/testing/test_ux.py
@@ -698,6 +698,60 @@ def test_destroy_seed(goto_home, pick_menu_item, cap_story, need_keypress, sim_e
     time.sleep(0.01)
 
 
+def test_menu_wrapping(goto_home, pick_menu_item, cap_story, need_keypress, cap_menu):
+    UP = "5"
+    DOWN = "8"
+
+    goto_home()
+    # first try that infinite scroll is turned off
+    # home
+    for i in range(10):  # settings on 5th in home (10 is way past that)
+        need_keypress(DOWN)
+    need_keypress("y")
+    menu = cap_menu()
+    # assert we are in settings, meaning we found bottom of home menu
+    assert "Login Settings" in menu
+
+    for i in range(10):
+        need_keypress(UP)
+    need_keypress("y")
+    menu = cap_menu()
+    # assert we are in Login settings, meaning we found top of settings menu
+    assert "Change Main PIN" in menu
+    need_keypress("x")  # back to settings
+    pick_menu_item("Menu Wrapping")
+    need_keypress("y")
+    pick_menu_item("Enable")
+    # back in settings on InfiniteScroll
+    # go 2 positions down and should be on top on Login settings
+    time.sleep(1)
+    for i in range(2):
+        need_keypress(DOWN)
+    need_keypress("y")
+    menu = cap_menu()
+    assert "Change Main PIN" in menu
+    need_keypress("x")  # back to settings - on login settings
+    # now go over top and back to Login settings from bottom
+    for i in range(9):
+        need_keypress(UP)
+    need_keypress("y")
+    menu = cap_menu()
+    assert "Change Main PIN" in menu
+    # disable infinite scroll
+    goto_home()
+    pick_menu_item("Settings")
+    pick_menu_item("Menu Wrapping")
+    pick_menu_item("Default Off")
+    time.sleep(1)
+    # cannot scroll over top now - will land in Login Settings
+    for i in range(15):
+        need_keypress(UP)
+    need_keypress("y")
+    menu = cap_menu()
+    assert "Change Main PIN" in menu
+    goto_home()
+
+
 @pytest.mark.onetime
 def test_dump_menutree(sim_execfile):
     # saves to ../unix/work/menudump.txt


### PR DESCRIPTION
New option to allow menu wraparound (scroll over top/bottom). This setting can be ON which means that all menu systems have wrap around, or off (default) only menu systems with more than 16 items have wrap around.
