### PR TITLE
PSBT and HSM refactor

### DIFF
--- a/shared/auth.py
+++ b/shared/auth.py
@@ -628,12 +628,11 @@ class ApproveTransaction(UserAuthorizedAction):
 
         total = 0
         addrs = []
-        for idx, tx_out in self.psbt.output_iter():
-            outp = self.psbt.outputs[idx]
+        for outp in self.psbt.outputs:
             if not outp.is_change:
                 continue
-            total += tx_out.nValue
-            addrs.append(self.chain.render_address(tx_out.scriptPubKey))
+            total += outp.amount
+            addrs.append(outp.address)
 
         if not addrs:
             return

--- a/shared/hsm.py
+++ b/shared/hsm.py
@@ -284,9 +284,8 @@ class ApprovalRule:
         # check all destinations are in the whitelist
         if self.whitelist:
             dests = set()
-            # no need to apply whitelisting to scripts that don't consume sats as they're harmless (e.g. 0-value OP_RETURN)
             for o in psbt.outputs:
-                if o.amount > 0 and not o.is_change:
+                if not o.is_change:
                     dests.add(o.address or str(b2a_hex(o.scriptpubkey), 'ascii'))
             diff = dests - set(self.whitelist)
             assert not diff, "non-whitelisted address: " + diff.pop()

--- a/testing/test_hsm.py
+++ b/testing/test_hsm.py
@@ -1231,18 +1231,20 @@ def test_priv_over_ux(quick_start_hsm, hsm_status, load_hsm_users):
     b"Coldcard is the best signing device",  # to test with both pushdata opcodes
     b"Coldcard, the best signing deviceaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",  # len 80 max
 ])
-def test_op_return_output(op_return_data, start_hsm, attempt_psbt, bitcoind_d_sim_watch, bitcoind, hsm_reset):
-    cc = bitcoind_d_sim_watch
-    dest_address = cc.getnewaddress()
-    bitcoind.supply_wallet.generatetoaddress(101, dest_address)
-    psbt = cc.walletcreatefundedpsbt([], [{dest_address: 1.0}, {"data": op_return_data.hex()}], 0, {"fee_rate": 20})["psbt"]
-    policy = DICT(rules=[dict(max_amount=10)])
+@pytest.mark.parametrize("amount", [0, 1]) # both no burn and burn
+def test_op_return_output(op_return_data, start_hsm, attempt_psbt, fake_txn, amount):
+    dests = []
+    psbt = fake_txn(2, 2, invals = [1000, 1000], outvals = [1000, 1000 - amount], fee = 0,
+                        op_return = (amount, op_return_data), capture_scripts=dests)
+    # whitelist all output addresses but not the OP_RETURN
+    policy = DICT(rules=[dict(whitelist=[render_address(d) for d in dests[0:2]])])
     start_hsm(policy)
-    attempt_psbt(base64.b64decode(psbt))
-    policy = DICT(rules=[dict(whitelist=['131CnJGaDyPaJsb5P4NHFxcRi29zo3ZXw'])])
-    hsm_reset()
-    start_hsm(policy)
-    attempt_psbt(base64.b64decode(psbt), refuse="non-whitelisted address: 6a")  # 6a --> OP_RETURN
+
+    if amount:
+        # non-zero burns need to pass the whitelist, which this doesn't
+        attempt_psbt(psbt, refuse="non-whitelisted address: 6a")  # 6a --> OP_RETURN that burns sats
+    else:
+        attempt_psbt(psbt)
 
 # KEEP LAST -- can only be run once, will crash device
 @pytest.mark.onetime

--- a/testing/txn.py
+++ b/testing/txn.py
@@ -179,7 +179,7 @@ def render_address(script, testnet=True):
     # string... aka: the "payment address"
     from pycoin.encoding import b2a_hashed_base58
     from bech32 import encode as bech32_encode
-    from binascii import hexlify
+    from binascii import hexlify as b2a_hex
 
     ll = len(script)
 
@@ -212,7 +212,7 @@ def render_address(script, testnet=True):
 
     # OP_RETURN
     if script[0:1] == b'\x6a':
-        return hexlify(script)
+        return b2a_hex(script)
 
     raise ValueError('Unknown payment script', repr(script))
 


### PR DESCRIPTION
This PR is mainly a refactor along with some improvements. The changes are as follows:

1. OP_RETURN outputs that spend (burn) 0 sats are no longer subjected to whitelist testing. This is because they're harmless and don't consume value.

2. OP_RETURN tests used to require a running bitcoind instance. This is no longer the case because `fake_txn` has been updated to support arbitrary OP_RETURN data.

3. PSBT proxy objects were caching the `amount` value in `validate`. This wasn't the best place because that method is concerned with validating own outputs. This has been moved to `consider_outputs`. Scriptpubkey is now also cached there.

4. As a consequence of caching scriptpubkey in proxy objects, the expensive `output_iter` method which operates directly on the filesystem no longer needs to be called when doing whitelist checks. This should result in improved performance. There are probably other places that could benefit from a similar refactor.

5. Whitelist checks have been moved to a more appropriate place (`rule.matches_transaction`).

All tests have been run against the simulator and no regressions have been introduced.