### PR TITLE
HSM Dynamic Whitelisting

### DIFF
--- a/releases/ChangeLog.md
+++ b/releases/ChangeLog.md
@@ -15,6 +15,9 @@
   not accept the main pin, but trick pins continued to work. This release adds a
   workaround to avoid getting into that situation, and new units from the factory will
   ship with an updated bootrom (version 3.1.5).
+- Enhancement: HSM dynamic whitelisting. Foreign outputs can be attested by being signed with a
+  private key corresponding to the address specified in whitelist section. Attestation signature
+  MUST be provided in PSBT.
 
 ## 5.0.6 - 2022-07-29
 

--- a/shared/chains.py
+++ b/shared/chains.py
@@ -93,6 +93,26 @@ class ChainsBase:
         return addr
 
     @classmethod
+    def pubkey_to_address(cls, pubkey, addr_fmt):
+        # - renders a pubkey to an address
+        # - works only with single-key addresses
+        assert not addr_fmt & AFC_SCRIPT
+
+        keyhash = ngu.hash.hash160(pubkey)
+        if addr_fmt == AF_CLASSIC:
+            script =  b'\x76\xA9\x14' + keyhash + b'\x88\xAC'
+        elif addr_fmt == AF_P2WPKH_P2SH:
+            redeem_script = b'\x00\x14' + keyhash
+            scripthash = ngu.hash.hash160(redeem_script)
+            script = b'\xA9\x14' + scripthash + b'\x87'
+        elif addr_fmt == AF_P2WPKH:
+            script = b'\x00\x14' + keyhash
+        else:
+            raise ValueError('bad address template: %s' % addr_fmt)
+
+        return cls.render_address(script)
+
+    @classmethod
     def address(cls, node, addr_fmt):
         # return a human-readable, properly formatted address
 


### PR DESCRIPTION
This PR introduces a new HSM mode that enables dynamic whitelisting.

### Why is this needed?

While the Coldcard can tell which outputs belong to itself, blocking malicious outputs in HSM mode is difficult. This is normally solved with whitelisting. But whitelisting works only with static addresses and is not practical in dynamic applications where destination addresses are unknown ahead of time. Sometimes we want "dynamic" whitelisting where a PSBT can prove to the Coldcard that foreign outputs are legitimate.

### How is this achieved?

Outputs can be attested by trusted keys, where a trusted key creates a signature (attestation) over a serialized txout and thereby says "I am OK with this scriptpubkey and its amount". Each foreign output's attestation is attached to a custom per-output proprietary PSBT entry (proprietary keys format is defined in [BIP174](https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki#proprietary-use-type)).

Public keys (addresses) used for verification are loaded into the HSM policy using the existing `whitelist` list.

### Usage
HSM policy example that uses attestation-based dynamic whitelisting:

```json
{
    "rules": [
        {
            "whitelist": [
                "17eet2ZwDT4PHvsYeTiWggMQUYfRfA3XYH",
                "1BQdJXHXao72kMWmDBppvEkR56EXxWSrnN"
            ],
            "whitelist_opts": {
                "mode": "ATTEST",
                "allow_zeroval_outs": true
            }
        }
    ]
}
```

`whitelist_opts` is a new structure that contains two fields:
- `mode: str`: `BASIC` or `ATTEST`. `BASIC` is the old behavior where whitelisting is based on address comparison. `ATTEST` is the new attestation mode.
- `allow_zeroval_outs: bool`: whether to always allow outputs with no value (OP_RETURN) without requiring attestation. This setting applies to either mode.

An output that has been attested will set the following key-value pair in its own PSBT entry.

- key:
-- keytype: ` 0xFC` -- stands for `proptietary`, defined by BIP174
-- identifier: `COINKITE` (global namespace used by Coldcard)
-- subtype: `0` (we define this as "attestation signature")
-- keydata: empty
- value:
-- 65 byte recoverable signature

### Verification process

A Coldcard with a policy designed to perform attestation-based whitelisting takes the following steps:

1. extracts attached attestation (signature) for each PSBT output entry
2. if output is foreign, its signature is verified and a public key is recovered from it
3. extracted public key is hashed, converted to an address and checked against addresses in the whitelist
4. if present in the whitelist pass, otherwise fail

### Testing

Existing tests are passing and no regressions have been introduced. New tests have been written that test the attestation mode by covering txouts with both valid and invalid signatures and assert the correct outcome. PSBT serialization/deserialization when attestation values are present has also been covered. Legacy OP_RETURN whitelist tests have been updated to take `allow_zeroval_outs` into account.

@doc-hex @scgbckbone 