### PR TITLE
Fix for "bug141"

### DIFF
--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -94,7 +94,7 @@
 
 # Change Outputs
 
-We will hide transaction outputs if they are "change" back into same wallet, however:
+We will summarize transaction outputs as "change" back into same wallet, however:
 
 - PSBT must specify BIP32 path in corresponding output section for us to treat as change
 - for p2sh-wrapped segwit outputs, redeem script must be provided when needed
@@ -131,8 +131,8 @@ We will hide transaction outputs if they are "change" back into same wallet, how
 # Trick Pins (Mk4)
 
 - "deltamode" PIN must be same length as true pin, and differ only in final 4 positions.
-- there are 14 trick "slots" 
-- duress wallets consume 2 slots (or 3 slots for legacy duress wallet)
+- there are 14 trick "slots", but we avoid slot 10, so 13 available.
+- duress wallets consume 2 slots (or 3 slots for legacy duress wallet) which must be contiguous
 - when restoring trick pins from backup files, "forgotten" pins are not restored,
   and any trick pin which matches the true PIN of the restored system will be dropped
 - deltamode PIN requirements are checked during wallet restore, and if the new true PIN

--- a/releases/ChangeLog.md
+++ b/releases/ChangeLog.md
@@ -11,6 +11,10 @@
   Advanced/Tools > Enable HSM > Enable
 - Bugfix: Correct parsing of unknown fields in PSBT: they are now passed through.
 - Bugfix: Share single address over NFC from address explorer menu.
+- Bugfix: Using lots of trick pins (7+), could lead to a case where the Coldcard would
+  not accept the main pin, but trick pins continued to work. This release adds a
+  workaround to avoid getting into that situation, and new units from the factory will
+  ship with an updated bootrom (version 3.1.5).
 
 ## 5.0.6 - 2022-07-29
 

--- a/shared/trick_pins.py
+++ b/shared/trick_pins.py
@@ -163,6 +163,10 @@ class TrickPinMgmt:
         self.roundtrip(1, b)        # expects ENOENT=2
 
         blk = slot.blank_slots
+
+        # bug workaround: don't use slot 10, in bootrom 3.1.4 and earlier
+        blk &= ~(1<<10)
+
         return [i for i in range(NUM_TRICKS) if (1<<i & blk)]
 
     def find_empty_slots(self, qty_needed):

--- a/stm32/mk4-bootloader/releases/README.md
+++ b/stm32/mk4-bootloader/releases/README.md
@@ -11,3 +11,4 @@ Github is nearly free, so why not capture all the actual bits!
 - V3.0.0 - first release build for Mk4
 - V3.1.3 - impt bugfix w/ red light in mcu key changes
 - V3.1.4 - 12-word duress wallets
+- V3.1.5 - bugfix so slot 10 of trick pins is usable

--- a/stm32/mk4-bootloader/se2.c
+++ b/stm32/mk4-bootloader/se2.c
@@ -1287,14 +1287,14 @@ se2_pin_hash(uint8_t digest_io[32], uint32_t purpose)
             se2_write_buffer(rx+2, 32);
         }
 
-        // HMAC(key=secret-B (we dont know it, but set random), msg=secret-B+buffer+junk)
+        // HMAC(key=secret-B, msg=consts+easy_key+buffer+consts)
         // - result put in secret-S (ram)
-        CALL_CHECK(se2_write2(0x3c, (2<<6) | (1<<4) | PGN_SECRET_B, 0));
+        CALL_CHECK(se2_write2(0x3c, (2<<6) | (1<<4) | PGN_SE2_EASY_KEY, 0));
         CHECK_RIGHT(se2_read1() == RC_SUCCESS);
 
         // HMAC(key=S, msg=counter+junk), so we have something to read out
-        // - not clear what contents of 'buffer' are here, but seems to be deterministic
-        //   and probably unchanged from prev command
+        // - not 100% clear what contents of 'buffer' are here, but seems
+        //   to be deterministic and unchanged from prev command
         CALL_CHECK(se2_write1(0xa5, (2<<5) | PGN_DEC_COUNTER));
 
         CHECK_RIGHT(se2_read_n(sizeof(rx), rx) == RC_SUCCESS);

--- a/stm32/mk4-bootloader/version.h
+++ b/stm32/mk4-bootloader/version.h
@@ -5,7 +5,7 @@
 #include <stdint.h>
 
 // Public version number for humans. Lots more version data added by Makefile.
-#define RELEASE_VERSION     "3.1.4"
+#define RELEASE_VERSION     "3.1.5"
 
 extern const char version_string[];
 


### PR DESCRIPTION
Using lots of trick pins (7+), could lead to a case where the Coldcard would  not accept the main pin, but trick pins continued to work. This PR adds a  workaround to avoid getting into that situation, and new units from the factory will ship with an updated bootrom (version 3.1.5).