### PR TITLE
NFC Tools

### DIFF
--- a/docs/nfc-coldcard.md
+++ b/docs/nfc-coldcard.md
@@ -66,7 +66,7 @@ The NFC traffic is not encrypted and is subject to eavesdropping.
 While the NFC feature is active, your Coldcard can be uniquely
 identified because the NFC protocol requires a unique ID (64 bits)
 that is defined by the NFC tag chip and shared automatically as
-part of the anti-collion protocol. Again, that happens only during
+part of the anti-collision protocol. Again, that happens only during
 active transfers, not when idle.
 
 ## Desktop Testing

--- a/releases/ChangeLog.md
+++ b/releases/ChangeLog.md
@@ -14,6 +14,12 @@
   private key corresponding to the address specified in HSM policy. Attestation signature
   MUST be provided in PSBT in a new proprietary field. Thanks to
   [@straylight-orbit](https://github.com/straylight-orbit) for this powerful new feature.
+- Enhancement: add ability to specify address format in text file to be signed
+- Enhancement: NFC message signing (Advanced/Tools -> NFC Tools -> Sign Message). Send message
+  in same format as Sign Text File over NFC, approve signing on Coldcard and send signed armored
+  message back over NFC.
+- Enhancement: Show address over NFC (Advanced/Tools -> NFC Tools -> Show Address).
+- Bugfix: Improved NFC commands exception handling 
 - Bugfix: Correct parsing of unknown fields in PSBT: they are now passed through.
 - Bugfix: Share single address over NFC from address explorer menu.
 - Bugfix: Using lots of trick pins (7+), could lead to a case where the Coldcard would

--- a/shared/actions.py
+++ b/shared/actions.py
@@ -1315,15 +1315,42 @@ Erases and reformats MicroSD card. This is not a secure erase but more of a quic
 async def nfc_share_file(*A):
     # Mk4: Share txt, txn and PSBT files over NFC.
     from glob import NFC
-    if NFC: 
-        await NFC.share_file()
+    if NFC:
+        try:
+            await NFC.share_file()
+        except Exception as e:
+            await ux_show_story(title="ERROR", msg="Failed to share file. %s" % str(e))
+
+
+async def nfc_show_address(*A):
+    from glob import NFC
+    if NFC:
+        try:
+            await NFC.address_show_and_share()
+        except Exception as e:
+            await ux_show_story(title="ERROR", msg="Failed to show address. %s" % str(e))
+
+
+async def nfc_sign_msg(*A):
+    # Mk4: Receive data over NFC (text - follow sign txt file format)
+    #      User approval on device
+    #      Send signature RFC armored format back over NFC
+    from glob import NFC
+    if NFC:
+        try:
+            await NFC.start_msg_sign()
+        except Exception as e:
+            await ux_show_story(title="ERROR", msg="Failed to sign message. %s" % str(e))
 
 
 async def nfc_recv_ephemeral(*A):
     # Mk4: Share txt, txn and PSBT files over NFC.
     from glob import NFC
     if NFC:
-        await NFC.import_ephemeral_seed_words_nfc()
+        try:
+            await NFC.import_ephemeral_seed_words_nfc()
+        except Exception as e:
+            await ux_show_story(title="ERROR", msg="Failed to import ephemeral seed via NFC. %s" % str(e))
 
 
 async def list_files(*A):

--- a/shared/auth.py
+++ b/shared/auth.py
@@ -4,6 +4,7 @@
 # and signing bitcoin transactions.
 #
 import stash, ure, ux, chains, sys, gc, uio, version, ngu
+from ubinascii import b2a_base64
 from public_constants import MSG_SIGNING_MAX_LENGTH, SUPPORTED_ADDR_FORMATS
 from public_constants import AFC_SCRIPT, AF_CLASSIC, AFC_BECH32, AF_P2WPKH, AF_P2WPKH_P2SH
 from public_constants import STXN_FLAGS_MASK, STXN_FINALIZE, STXN_VISUALIZE, STXN_SIGNED
@@ -157,18 +158,33 @@ def sign_message_digest(digest, subpath, prompt):
 class ApproveMessageSign(UserAuthorizedAction):
     def __init__(self, text, subpath, addr_fmt, approved_cb=None):
         super().__init__()
-        self.text = text
-        self.subpath = subpath
+        self.text = self.validate_text(text)
+        self.subpath = cleanup_deriv_path(subpath)
+        self.addr_fmt = self.parse_addr_fmt_str(addr_fmt)
         self.approved_cb = approved_cb
 
         from glob import dis
         dis.fullscreen('Wait...')
 
         with stash.SensitiveValues() as sv:
-            node = sv.derive_path(subpath)
-            self.address = sv.chain.address(node, addr_fmt)
+            node = sv.derive_path(self.subpath)
+            self.address = sv.chain.address(node, self.addr_fmt)
 
         dis.progress_bar_show(1)
+
+    @staticmethod
+    def parse_addr_fmt_str(addr_fmt):
+        if addr_fmt in [AF_P2WPKH_P2SH, AF_P2WPKH, AF_CLASSIC]:
+            return addr_fmt
+        if addr_fmt in ("p2sh-p2wpkh", "p2wpkh-p2sh"):
+            return AF_P2WPKH_P2SH
+        elif addr_fmt == "p2pkh":
+            return AF_CLASSIC
+        elif addr_fmt == "p2wpkh":
+            return AF_P2WPKH
+        else:
+            assert False, ('Invalid address format specified %s\n\n'
+                           'Choose from p2pkh, p2wpkh, p2sh-p2wpkh.' % addr_fmt)
 
     async def interact(self):
         # Prompt user w/ details and get approval
@@ -191,7 +207,7 @@ class ApproveMessageSign(UserAuthorizedAction):
 
             if self.approved_cb:
                 # for micro sd case
-                await self.approved_cb(self.result, self.address)
+                await self.approved_cb(self.result, self.address, self.text)
 
         if self.approved_cb:
             # don't kill menu depth for file case
@@ -201,103 +217,71 @@ class ApproveMessageSign(UserAuthorizedAction):
             self.done()
 
     @staticmethod
-    def validate(text):
+    def validate_text(text):
         # check for some UX/UI traps in the message itself.
 
         # Messages must be short and ascii only. Our charset is limited
         MSG_CHARSET = range(32, 127)
         MSG_MAX_SPACES = 4      # impt. compared to -=- positioning
 
-        assert len(text) >= 2, "too short"
-        assert len(text) <= MSG_SIGNING_MAX_LENGTH, "too long"
+        try:
+            result = str(text, 'ascii')
+        except UnicodeError:
+            raise AssertionError('must be ascii')
+
+        length = len(result)
+        assert length >= 2, "msg too short (min. 2)"
+        assert length <= MSG_SIGNING_MAX_LENGTH, "msg too long (max. %d)" % MSG_SIGNING_MAX_LENGTH
         run = 0
-        for ch in text:
-            assert ord(ch) in MSG_CHARSET, "bad char: 0x%02x" % ord(ch)
+        for ch in result:
+            assert ord(ch) in MSG_CHARSET, "bad char: 0x%02x in msg" % ord(ch)
 
             if ch == ' ':
                 run += 1
-                assert run < MSG_MAX_SPACES, 'too many spaces together'
+                assert run < MSG_MAX_SPACES, 'too many spaces together in msg(max. 4)'
             else:
                 run = 0
 
         # other confusion w/ whitepace
-        assert text[0] != ' ', 'leading space(s)'
-        assert text[-1] != ' ', 'trailing space(s)'
+        assert result[0] != ' ', 'leading space(s) in msg'
+        assert result[-1] != ' ', 'trailing space(s) in msg'
 
         # looks ok
-        return
+        return result
     
 
 def sign_msg(text, subpath, addr_fmt):
-    # Convert to strings
-    try:
-        text = str(text, 'ascii')
-    except UnicodeError:
-        raise AssertionError('must be ascii')
-
     subpath = cleanup_deriv_path(subpath)
-
-    try:
-        assert addr_fmt in SUPPORTED_ADDR_FORMATS
-        assert not (addr_fmt & AFC_SCRIPT)
-    except:
-        raise AssertionError('Unknown/unsupported addr format')
-
-    # Do some verification before we even show to the local user
-    ApproveMessageSign.validate(text)
-
     UserAuthorizedAction.check_busy()
     UserAuthorizedAction.active_request = ApproveMessageSign(text, subpath, addr_fmt)
-
     # kill any menu stack, and put our thing at the top
     abort_and_goto(UserAuthorizedAction.active_request)
+
 
 def sign_txt_file(filename):
     # sign a one-line text file found on a MicroSD card
     # - not yet clear how to do address types other than 'classic'
     from files import CardSlot, CardMissingError
-    from sram2 import tmp_buf
+    from ux import the_ux
 
     UserAuthorizedAction.cleanup()
-    addr_fmt = AF_CLASSIC
 
     # copy message into memory
     with CardSlot() as card:
         with card.open(filename, 'rt') as fd:
             text = fd.readline().strip()
             subpath = fd.readline().strip()
+            addr_fmt = fd.readline().strip()
 
-    if subpath:
-        try:
-            assert subpath[0:1] == 'm'
-            subpath = cleanup_deriv_path(subpath)
-        except:
-            await ux_show_story("Second line of file, if included, must specify a subkey path, like: m/44'/0/0")
-            return
-
-        # if they are following BIP-84 recommended derivation scheme,
-        # then they probably would prefer a segwit/bech32 formatted address
-        if subpath.startswith("m/84'/"):
-            addr_fmt = AF_P2WPKH
-            
-    else:
+    if not subpath:
         # default: top of wallet.
         subpath = 'm'
 
-    try:
-        try:
-            text = str(text, 'ascii')
-        except UnicodeError:
-            raise AssertionError('non-ascii characters')
+    if not addr_fmt:
+        addr_fmt = AF_CLASSIC
 
-        ApproveMessageSign.validate(text)
-    except AssertionError as exc:
-        await ux_show_story("Problem: %s\n\nMessage to be signed must be a single line of ASCII text." % exc)
-        return
-
-    def done(signature, address):
+    def done(signature, address, text):
         # complete. write out result
-        from ubinascii import b2a_base64
         orig_path, basename = filename.rsplit('/', 1)
         orig_path += '/'
         base = basename.rsplit('.', 1)[0]
@@ -338,7 +322,7 @@ def sign_txt_file(filename):
                 except OSError as exc:
                     prob = 'Failed to write!\n\n%s\n\n' % exc
                     sys.print_exception(exc)
-                    # fall thru to try again
+                    # fall through to try again
 
             # prompt them to input another card?
             ch = await ux_show_story(prob+"Please insert an SDCard to receive signed message, "
@@ -352,11 +336,13 @@ def sign_txt_file(filename):
         await ux_show_story(msg, title='File Signed')
 
     UserAuthorizedAction.check_busy()
-    UserAuthorizedAction.active_request = ApproveMessageSign(text, subpath, addr_fmt, approved_cb=done)
-
-    # do not kill the menu stack!
-    from ux import the_ux
-    the_ux.push(UserAuthorizedAction.active_request)
+    try:
+        UserAuthorizedAction.active_request = ApproveMessageSign(text, subpath, addr_fmt, approved_cb=done)
+        # do not kill the menu stack!
+        the_ux.push(UserAuthorizedAction.active_request)
+    except AssertionError as exc:
+        await ux_show_story("Problem: %s\n\nMessage to be signed must be a single line of ASCII text." % exc)
+        return
 
 
 class ApproveTransaction(UserAuthorizedAction):
@@ -1022,7 +1008,8 @@ def start_bip39_passphrase(pw):
 class ShowAddressBase(UserAuthorizedAction):
     title = 'Address:'
 
-    def __init__(self, *args):
+    def __init__(self, *args, **kwargs):
+        self.restore_menu = kwargs.get("restore_menu", False)
         super().__init__()
 
         from glob import dis
@@ -1033,27 +1020,33 @@ class ShowAddressBase(UserAuthorizedAction):
 
     async def interact(self):
         # Just show the address... no real confirmation needed.
-        from glob import hsm_active, dis
+        from glob import hsm_active, dis, NFC
 
         if not hsm_active:
             msg = self.get_msg()
             msg += '\n\nCompare this payment address to the one shown on your other, less-trusted, software.'
+            if NFC:
+                msg += ' Press 3 to share over NFC.'
             if has_fatram:
                 msg += ' Press 4 to view QR Code.'
 
             while 1:
-                ch = await ux_show_story(msg, title=self.title, escape='4')
+                ch = await ux_show_story(msg, title=self.title, escape='34')
 
                 if ch == '4' and has_fatram:
                     await show_qr_code(self.address, (self.addr_fmt & AFC_BECH32))
                     continue
-
+                if ch == '3' and NFC:
+                    await NFC.share_text(self.address)
+                    continue
                 break
         else:
             # finish the Wait...
             dis.progress_bar(1)     
-
-        self.done()
+        if self.restore_menu:
+            self.pop_menu()
+        else:
+            self.done()
         UserAuthorizedAction.cleanup()      # because no results to store
 
     
@@ -1130,7 +1123,7 @@ def start_show_p2sh_address(M, N, addr_format, xfp_paths, witdeem_script):
     # provide the value back to attached desktop
     return UserAuthorizedAction.active_request.address
 
-def start_show_address(addr_format, subpath):
+def show_address(addr_format, subpath, restore_menu=False):
     try:
         assert addr_format in SUPPORTED_ADDR_FORMATS
         assert not (addr_format & AFC_SCRIPT)
@@ -1144,14 +1137,17 @@ def start_show_address(addr_format, subpath):
     if hsm_active and not hsm_active.approve_address_share(subpath):
         raise HSMDenied
 
+    UserAuthorizedAction.cleanup()
     UserAuthorizedAction.check_busy(ShowAddressBase)
-    UserAuthorizedAction.active_request = ShowPKHAddress(addr_format, subpath)
+    UserAuthorizedAction.active_request = ShowPKHAddress(addr_format, subpath, restore_menu=restore_menu)
+    return UserAuthorizedAction.active_request
 
+def usb_show_address(addr_format, subpath):
+    active_request = show_address(addr_format, subpath)
     # kill any menu stack, and put our thing at the top
-    abort_and_goto(UserAuthorizedAction.active_request)
-
+    abort_and_goto(active_request)
     # provide the value back to attached desktop
-    return UserAuthorizedAction.active_request.address
+    return active_request.address
 
 
 class NewEnrollRequest(UserAuthorizedAction):

--- a/shared/flow.py
+++ b/shared/flow.py
@@ -8,7 +8,7 @@ from glob import settings
 
 from actions import *
 from choosers import *
-from multisig import make_multisig_menu
+from multisig import make_multisig_menu, import_multisig_nfc
 from seed import make_ephemeral_seed_menu
 from address_explorer import address_explore
 from users import make_users_menu
@@ -277,6 +277,13 @@ BackupStuffMenu = [
     MenuItem('Clone Coldcard', predicate=has_secrets, f=clone_write_data),
 ]
 
+NFCToolsMenu = [
+    MenuItem('Show Address', f=nfc_show_address),
+    MenuItem('Sign Message', f=nfc_sign_msg),
+    MenuItem('File Share', f=nfc_share_file),
+    MenuItem('Import Multisig', f=import_multisig_nfc),
+]
+
 AdvancedNormalMenu = [
     #         xxxxxxxxxxxxxxxx
     MenuItem("Backup", menu=BackupStuffMenu),
@@ -292,6 +299,7 @@ AdvancedNormalMenu = [
 By default these commands are disabled.",
                    predicate=lambda: version.has_fatram),
     MenuItem('User Management', menu=make_users_menu, predicate=lambda: version.has_fatram),
+    MenuItem('NFC Tools', predicate=nfc_enabled, menu=NFCToolsMenu),
     MenuItem("Danger Zone", menu=DangerZoneMenu),
 ]
 

--- a/shared/multisig.py
+++ b/shared/multisig.py
@@ -1639,7 +1639,10 @@ Default is P2WSH addresses (segwit) or press (1) for P2SH-P2WSH.''', escape='1')
 async def import_multisig_nfc(*a):
     from glob import NFC
     # this menu option should not be available if NFC is disabled
-    return await NFC.import_multisig_nfc()
+    try:
+        return await NFC.import_multisig_nfc()
+    except Exception as e:
+        await ux_show_story(title="ERROR", msg="Failed to import multisig. %s" % str(e))
 
 async def import_multisig(*a):
     # pick text file from SD card, import as multisig setup file

--- a/shared/ndef.py
+++ b/shared/ndef.py
@@ -157,8 +157,8 @@ def record_parser(msg):
         IL = hdr & 0x08
         TNF = hdr & 0x7
 
-        assert not CF                       # no chunks please
-        assert (pos == 0) == bool(MB)       # first one needs MB set
+        assert not CF, "no chunks please"
+        assert (pos == 0) == bool(MB), "first needs MB set"
 
         ty_len = msg[pos+1]
         pos += 2
@@ -182,7 +182,7 @@ def record_parser(msg):
         pos += ty_len
 
         if TNF == 0x0:      # empty
-            assert ty_len == pl_len == 0
+            assert ty_len == pl_len == 0, "ty_len = pl_len = 0"
             urn = None
         elif TNF == 0x1:        # WKT
             urn = 'urn:nfc:wkt:'
@@ -191,7 +191,7 @@ def record_parser(msg):
             if ty == b'T':
                 # unwrap Text
                 hdr2 = msg[pos]
-                assert hdr2 & 0xc0 == 0x00      # only UTF supported
+                assert hdr2 & 0xc0 == 0x00, "only UTF supported"
                 lang_len = hdr2 & 0x3f
 
                 meta['lang'] = msg[pos+1:pos+1 + lang_len].decode()
@@ -224,7 +224,7 @@ def record_parser(msg):
         if ME: return
 
         pos += pl_len
-        assert pos < len(msg)       # missing ME/truncated
+        assert pos < len(msg), "missing ME/truncated"
 
 
 # EOF

--- a/shared/nfc.py
+++ b/shared/nfc.py
@@ -9,10 +9,13 @@
 #
 import ngu, utime, ngu, ndef
 from uasyncio import sleep_ms
-from utils import B2A, problem_file_line
 from ustruct import pack, unpack
 from ubinascii import unhexlify as a2b_hex
+from ubinascii import b2a_base64
+
 from ux import ux_show_story, ux_poll_key
+from utils import cleanup_deriv_path, B2A, problem_file_line
+from public_constants import AF_P2WPKH, AF_P2WPKH_P2SH, AF_CLASSIC
 
 
 # practical limit for things to share: 8k part, minus overhead
@@ -563,15 +566,12 @@ class NFCHandler:
         if not data: return
 
         winner = None
-        try:
-            for urn, msg, meta in ndef.record_parser(data):
-                msg = bytes(msg).decode().strip()        # from memory view
-                split_msg = msg.split(" ")
-                if len(split_msg) in (12, 18, 24):
-                    winner = split_msg
-                    break
-        except Exception:
-            pass
+        for urn, msg, meta in ndef.record_parser(data):
+            msg = bytes(msg).decode().strip()        # from memory view
+            split_msg = msg.split(" ")
+            if len(split_msg) in (12, 18, 24):
+                winner = split_msg
+                break
 
         if not winner:
             await ux_show_story('Unable to find data expected in NDEF')
@@ -583,5 +583,102 @@ class NFCHandler:
         except Exception as e:
             #import sys; sys.print_exception(e)
             await ux_show_story('Failed to import.\n\n%s\n%s' % (e, problem_file_line(e)))
+
+    async def confirm_share_loop(self, string):
+        while True:
+            # added loop here as NFC send can fail, or not send the data
+            # and in that case one would have to start from beginning (send us cmd, approve, etc.)
+            # => get chance to check if you received the data and if something went wrong - retry just send
+            await self.share_text(string)
+            ch = await ux_show_story(title="Shared", msg="Press Y to share again, otherwise X to stop.")
+            if ch != "y":
+                break
+
+    async def address_show_and_share(self):
+        from auth import show_address, ApproveMessageSign
+
+        data = await self.start_nfc_rx()
+        if not data:
+            await ux_show_story('Unable to find data expected in NDEF')
+            return
+
+        winner = None
+        for urn, msg, meta in ndef.record_parser(data):
+            msg = bytes(msg).decode()  # from memory view
+            split_msg = msg.split("\n")
+            if 1 <= len(split_msg) <= 2:
+                winner = split_msg
+                break
+
+        if not winner:
+            await ux_show_story('Unable to find data expected in NDEF')
+            return
+
+        if len(winner) == 1:
+            subpath = winner[0]
+            addr_fmt = AF_CLASSIC
+        else:
+            subpath, addr_fmt_str = winner
+            try:
+                addr_fmt = ApproveMessageSign.parse_addr_fmt_str(addr_fmt_str)
+            except AssertionError as e:
+                await ux_show_story(str(e))
+                return
+
+        active_request = show_address(addr_fmt, subpath, restore_menu=True)
+        from ux import the_ux
+        the_ux.push(active_request)
+        await the_ux.interact()  # need this otherwise NFC animation takes over
+
+    async def start_msg_sign(self):
+        from auth import UserAuthorizedAction, ApproveMessageSign
+        from ux import the_ux
+
+        UserAuthorizedAction.cleanup()
+
+        data = await self.start_nfc_rx()
+        if not data:
+            await ux_show_story('Unable to find data expected in NDEF')
+            return
+
+        winner = None
+        for urn, msg, meta in ndef.record_parser(data):
+            msg = bytes(msg).decode()  # from memory view
+            split_msg = msg.split("\n")
+            if 1 <= len(split_msg) <= 3:
+                winner = split_msg
+                break
+
+        if not winner:
+            await ux_show_story('Unable to find data expected in NDEF')
+            return
+
+        if len(winner) == 1:
+            text = winner[0]
+            subpath = "m"
+            addr_fmt = AF_CLASSIC
+        elif len(winner) == 2:
+            text, subpath = winner
+            addr_fmt = AF_CLASSIC  # maybe default to native segwit?
+        else:
+            # len(winner) == 3
+            text, subpath, addr_fmt = winner
+
+        UserAuthorizedAction.check_busy(ApproveMessageSign)
+        try:
+            UserAuthorizedAction.active_request = ApproveMessageSign(
+                text, subpath, addr_fmt, approved_cb=self.msg_sign_done
+            )
+            the_ux.push(UserAuthorizedAction.active_request)
+        except AssertionError as exc:
+            await ux_show_story("Problem: %s\n\nMessage to be signed must be a single line of ASCII text." % exc)
+            return
+
+    async def msg_sign_done(self, signature, address, text):
+        from auth import RFC_SIGNATURE_TEMPLATE
+        sig = b2a_base64(signature).decode('ascii').strip()
+        armored_str = RFC_SIGNATURE_TEMPLATE.format(addr=address, msg=text,
+                                                    blockchain='BITCOIN', sig=sig)
+        await self.confirm_share_loop(armored_str)
 
 # EOF

--- a/shared/usb.py
+++ b/shared/usb.py
@@ -466,12 +466,10 @@ class USBHandler:
 
         if cmd == 'show':
             # simple cases, older code: text subpath
-            from auth import start_show_address
+            from auth import usb_show_address
 
             addr_fmt, = unpack_from('<I', args)
-            assert not (addr_fmt & AFC_SCRIPT)
-
-            return b'asci' + start_show_address(addr_fmt, subpath=args[4:])
+            return b'asci' + usb_show_address(addr_fmt, subpath=args[4:])
 
         if cmd == 'enrl':
             # Enroll new xpubkey to be involved in multisigs.

--- a/testing/constants.py
+++ b/testing/constants.py
@@ -14,13 +14,20 @@ simulator_fixed_xfp = 0x4369050f
 
 simulator_serial_number = 'F1F1F1F1F1F1'
 
-from ckcc_protocol.constants import AF_P2WSH, AF_P2SH, AF_P2WSH_P2SH
+from ckcc_protocol.constants import AF_P2WSH, AF_P2SH, AF_P2WSH_P2SH, AF_CLASSIC, AF_P2WPKH, AF_P2WPKH_P2SH
 
 unmap_addr_fmt = {
     'p2sh': AF_P2SH,
     'p2wsh': AF_P2WSH,
     'p2wsh-p2sh': AF_P2WSH_P2SH,
     'p2sh-p2wsh': AF_P2WSH_P2SH,
+}
+
+msg_sign_unmap_addr_fmt = {
+    'p2pkh': AF_CLASSIC,
+    'p2wpkh': AF_P2WPKH,
+    'p2sh-p2wpkh': AF_P2WPKH_P2SH,
+    'p2wpkh-p2sh': AF_P2WPKH_P2SH,
 }
 
 # all possible addr types, including multisig/scripts

--- a/testing/test_addr.py
+++ b/testing/test_addr.py
@@ -7,8 +7,9 @@
 #
 import pytest, time
 from pycoin.contrib.msg_signing import verify_message
-from ckcc_protocol.protocol import CCProtocolPacker, CCProtoError
+from ckcc_protocol.protocol import CCProtocolPacker
 from ckcc_protocol.constants import *
+from constants import msg_sign_unmap_addr_fmt
 
 @pytest.mark.parametrize('path', [ 'm', "m/1/2", "m/1'/100'"])
 @pytest.mark.parametrize('addr_fmt', [ AF_CLASSIC, AF_P2WPKH, AF_P2WPKH_P2SH ])
@@ -70,5 +71,63 @@ def test_addr_vs_bitcoind(use_regtest, match_key, need_keypress, dev, bitcoind_d
         addr = dev.send_recv(CCProtocolPacker.show_address(path, AF_P2WPKH_P2SH), timeout=None)
         need_keypress('y')
         assert addr == core_addr
+
+@pytest.mark.parametrize("body_err", [
+    ("m\np2wsh", "Invalid address format specified p2wsh"),
+    ("m\np2sh-p2wsh", "Invalid address format specified p2sh-p2wsh"),
+    ("m\np2tr", "Invalid address format specified p2tr"),
+    ("m/0/0/0/0/0/0/0/0/0/0/0/0/0\np2pkh", "too deep"),
+    ("m/0/0/0/0/0/q/0/0/0\np2pkh", "invalid characters"),
+])
+def test_show_addr_nfc_invalid(body_err, goto_home, pick_menu_item, nfc_write_text, cap_story):
+    body, err = body_err
+    goto_home()
+    pick_menu_item('Advanced/Tools')
+    pick_menu_item('NFC Tools')
+    pick_menu_item('Show Address')
+    nfc_write_text(body)
+    time.sleep(0.5)
+    _, story = cap_story()
+    assert err in story
+
+@pytest.mark.parametrize("path", ["m/84'/0'/0'/300/0", "m/800'", "m/0/0/0/0/1/1/1"])
+@pytest.mark.parametrize("str_addr_fmt", ["p2pkh", "", "p2wpkh", "p2wpkh-p2sh", "p2sh-p2wpkh"])
+def test_show_addr_nfc(path, str_addr_fmt, nfc_write_text, nfc_read_text, pick_menu_item, goto_home, cap_story,
+                         need_keypress, addr_vs_path):
+    # import pdb;pdb.set_trace()
+    for _ in range(5):
+        # need to wait for ApproveMessageSign to be popped from ux stack
+        try:
+            goto_home()
+            break
+        except:
+            time.sleep(0.5)
+
+    pick_menu_item('Advanced/Tools')
+    pick_menu_item('NFC Tools')
+    pick_menu_item('Show Address')
+    if str_addr_fmt != "":
+        addr_fmt = msg_sign_unmap_addr_fmt[str_addr_fmt]
+        body = "\n".join([path, str_addr_fmt])
+    else:
+        addr_fmt = AF_CLASSIC
+        body = path
+
+    nfc_write_text(body)
+    time.sleep(0.5)
+    _, story = cap_story()
+    split_story = story.split("\n\n")
+    story_addr = split_story[0]
+    story_path = split_story[1][2:]  # remove "= "
+    assert "Press 3 to share over NFC" in story
+    assert story_path == path
+    need_keypress("3")  # share over NFC
+    addr = nfc_read_text()
+    if addr == body:
+        # missed it - again
+        addr = nfc_read_text()
+    need_keypress("y")  # exit NFC animation
+    assert story_addr == addr
+    addr_vs_path(addr, path, addr_fmt)
 
 # EOF


### PR DESCRIPTION
New menu item `NFC Tools` containing: show address, sign message, share file and import multisig.

NFC message signing:
* general NFC message signing
       * share data as simple text in same format as with file signing over NFC (nfc-tools -> write -> text)
       * switch nfc-tools to read 
       * confirm signing on cc, signed armored text will be shared over NFC
* same validation applies to NFC as file msg sign
* refactor msg signing code to have validation inside ApproveMessageSign class (with this we can now only test USB signing and validation is tested for both NFC and USB)

NFC show address:

* send path (required) and address format (optional -> default AF_CLASSIC)
* address is displayed with same options as USB
* only single-sig support
* at the end of address show - address is shared back via NFC

* share file and import multisig are duplicated and also kept in their original positions in menu tree
* exception handling for NFC commands