### PR TITLE
fix signit setup.py - needs py_modules specified

### DIFF
--- a/cli/setup.py
+++ b/cli/setup.py
@@ -11,7 +11,7 @@ from setuptools import setup
 setup(
     name='signit',
     version='1.0',
-    #py_modules=['ckcc'],
+    py_modules=['signit'],
     install_requires=[
         'Click',
     ],


### PR DESCRIPTION
currently ERROR:
```
Obtaining file:///home/scg/PycharmProjects/secret_firmware/cli
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error
  
  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [14 lines of output]
      error: Multiple top-level modules discovered in a flat-layout: ['sigheader', 'signit'].
      
      To avoid accidental inclusion of unwanted files or directories,
      setuptools will not proceed with this build.
      
      If you are trying to create a single distribution with multiple modules
      on purpose, you should not rely on automatic discovery.
      Instead, consider the following options:
      
      1. set up custom discovery (`find` directive with `include` or `exclude`)
      2. use a `src-layout`
      3. explicitly set `py_modules` or `packages` with a list of names
      
      To find more information, look for "package discovery" on setuptools docs.
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
```
