### PR TITLE
improve multisig tests - support bitcoin core 24.0

### DIFF
--- a/testing/api.py
+++ b/testing/api.py
@@ -109,6 +109,18 @@ class Bitcoind:
             self.bitcoind_proc.kill()
         shutil.rmtree(self.datadir)
 
+    def delete_wallet_files(self, pattern=None):
+        wallets_dir = os.path.join(self.datadir, "regtest/wallets")
+        wallet_files = os.listdir(wallets_dir)
+        for wf in wallet_files:
+            abs_path = os.path.join(wallets_dir, wf)
+            if pattern is None:
+                # remove all
+                shutil.rmtree(abs_path)
+            else:
+                if pattern in wf:
+                    shutil.rmtree(abs_path)
+
     @staticmethod
     def create(*args, **kwargs):
         c = Bitcoind(*args, **kwargs)

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -1,6 +1,6 @@
 # (c) Copyright 2020 by Coinkite Inc. This file is covered by license found in COPYING-CC.
 #
-import pytest, time, sys, random, re, ndef
+import pytest, os, time, sys, random, re, ndef
 from ckcc.protocol import CCProtocolPacker
 from helpers import B2A, U2SAT, prandom
 from api import bitcoind, match_key, bitcoind_finalizer, bitcoind_analyze, bitcoind_decode
@@ -596,6 +596,17 @@ def open_microsd(simulator, microsd_path):
     def doit(fn, mode='rb'):
         return open(microsd_path(fn), mode)
 
+    return doit
+
+@pytest.fixture(scope="module")
+def clean_microsd(microsd_path):
+    def doit():
+        dir = microsd_path("")
+        ls = os.listdir(dir)
+        for fname in ls:
+            if fname in ["README.md", ".gitignore", "messages", "psbt"]:
+                continue
+            os.remove(dir + fname)
     return doit
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
* fix `test_bitcoind_cosigning` to work with core 24.0
* update multisig tutorial test to test different M/N values
* remove unused imports and fixtures
