### PR TITLE
vdisk UX

### DIFF
--- a/releases/ChangeLog.md
+++ b/releases/ChangeLog.md
@@ -1,5 +1,8 @@
 ## 5.0.8 - 2022-11-??
-- tbd
+- Enhancement: Add ability to import multisig wallet via Virtual Disk
+- Enhancement: Add ability to import extended private key via Virtual Disk and via NFC
+- Enhancement: Offer import/export from/to Virtual Disk in UI
+- Bugfix: allow export of Wasabi skeleton for Bitcoin Regtest
 
 ## 5.0.7 - 2022-10-05
 

--- a/shared/auth.py
+++ b/shared/auth.py
@@ -546,9 +546,9 @@ class ApproveTransaction(UserAuthorizedAction):
                 tmsg = txid + '\n\n'
 
                 if has_fatram:
-                    tmsg += 'Press 1 for QR Code of TXID. '
+                    tmsg += 'Press (1) for QR Code of TXID. '
                 if NFC:
-                    tmsg += 'Press 3 to share signed txn over NFC.'
+                    tmsg += 'Press (3) to share signed txn via NFC.'
 
                 ch = await ux_show_story(tmsg, "Final TXID", escape='13')
 
@@ -949,7 +949,7 @@ OK to continue, X to cancel.''' % self._pw, title="Passphrase")
             else:
                 ch = await ux_show_story('''BIP-39 passphrase (%d chars long) has been provided over USB connection. Should we switch to that wallet now?
 
-Press 2 to view the provided passphrase.\n\nOK to continue, X to cancel.''' % len(self._pw), title="Passphrase", escape='2')
+Press (2) to view the provided passphrase.\n\nOK to continue, X to cancel.''' % len(self._pw), title="Passphrase", escape='2')
 
             if ch == '2':
                 showit = True
@@ -1013,9 +1013,9 @@ class ShowAddressBase(UserAuthorizedAction):
             msg = self.get_msg()
             msg += '\n\nCompare this payment address to the one shown on your other, less-trusted, software.'
             if NFC:
-                msg += ' Press 3 to share over NFC.'
+                msg += ' Press (3) to share via NFC.'
             if has_fatram:
-                msg += ' Press 4 to view QR Code.'
+                msg += ' Press (4) to view QR Code.'
 
             while 1:
                 ch = await ux_show_story(msg, title=self.title, escape='34')

--- a/shared/drv_entro.py
+++ b/shared/drv_entro.py
@@ -182,25 +182,31 @@ async def drv_entro_step2(_1, picked, _2):
     if new_secret:
         msg += '\n\nRaw Entropy:\n' + str(b2a_hex(new_secret), 'ascii')
 
-    prompt = '\n\nPress 1 to save to MicroSD card'
+    prompt = '\n\nPress (1) to save to MicroSD card'
     if encoded is not None:
-        prompt += ', 2 to switch to derived secret'
+        prompt += ', (2) to switch to derived secret'
     elif s_mode == 'pw':
-        prompt += ', 2 to type password over USB'
+        prompt += ', (2) to type password over USB'
     if (qr is not None) and version.has_fatram:
-        prompt += ', 3 to view as QR code'
+        prompt += ', (3) to view as QR code'
         if glob.NFC:
-            prompt += ', 4 to send by NFC'
+            prompt += ', (4) to share via NFC'
+    if glob.VD:
+        prompt += ", (5) to save to Virtual Disk"
 
     prompt += '.'
 
     while 1:
-        ch = await ux_show_story(msg+prompt, sensitive=True, escape='1234')
+        ch = await ux_show_story(msg+prompt, sensitive=True, escape='12345')
 
-        if ch == '1':
-            # write to SD card: simple text file
+        if ch in "15":
+            # write to SD card or Virtual Disk: simple text file
+            if ch == "1":
+                force_vdisk = False
+            else:
+                force_vdisk = True
             try:
-                with CardSlot() as card:
+                with CardSlot(force_vdisk=force_vdisk) as card:
                     fname, out_fn = card.pick_filename('drv-%s-idx%d.txt' % (s_mode, index))
 
                     with open(fname, 'wt') as fp:

--- a/shared/login.py
+++ b/shared/login.py
@@ -374,7 +374,7 @@ suffix break point is correct.'''
             ch = await ux_show_story('''\
 You gave two different PIN codes and they don't match.
 
-Press 2 to try the second one again, X or OK to give up for now.''',
+Press (2) to try the second one again, X or OK to give up for now.''',
                         title="PIN Mismatch", escape='2')
 
             if ch != '2':

--- a/shared/paper.py
+++ b/shared/paper.py
@@ -82,7 +82,7 @@ class PaperWalletMaker:
 
     async def doit(self, *a, have_key=None):
         # make the wallet.
-        from glob import dis
+        from glob import dis, VD
 
         try:
             import ngu
@@ -131,9 +131,23 @@ class PaperWalletMaker:
             # Use address as filename. clearly will be unique, but perhaps a bit
             # awkward to work with.
             basename = addr
-
+            force_vdisk = False
+            if VD:
+                prompt = "Press (1) to save paper wallet file to SD Card"
+                escape = "1"
+                if VD is not None:
+                    prompt += ", press (2) to save to VDisk"
+                    escape += "2"
+                prompt += "."
+                ch = await ux_show_story(prompt, escape=escape)
+                if ch == "2":
+                    force_vdisk = True
+                elif ch == '1':
+                    force_vdisk = False
+                else:
+                    return
             dis.fullscreen("Saving...")
-            with CardSlot() as card:
+            with CardSlot(force_vdisk=force_vdisk) as card:
                 fname, nice_txt = card.pick_filename(basename + 
                                         ('-note.txt' if self.template_fn else '.txt'))
 

--- a/shared/seed.py
+++ b/shared/seed.py
@@ -278,7 +278,7 @@ async def show_words(words, prompt=None, escape=None, extra='', ephemeral=False)
 
     if version.has_fatram:
         escape = (escape or '') + '1'
-        extra += 'Press 1 to view as QR Code. '
+        extra += 'Press (1) to view as QR Code. '
 
     if extra:
         msg += '\n\n'
@@ -438,10 +438,10 @@ async def approve_word_list(seed, nwords, ephemeral=False):
 
     words = bip39.b2a_words(seed).split(' ')
     assert len(words) == nwords
-    extra_msg = 'Press 4 to add some dice rolls into the mix. '
+    extra_msg = 'Press (4) to add some dice rolls into the mix. '
     if ephemeral:
         # document quiz skipping if generating ephemeral seed
-        extra_msg += "Press 6 to skip word quiz. "
+        extra_msg += "Press (6) to skip word quiz. "
 
     while 1:
         # show the seed words
@@ -704,7 +704,7 @@ async def make_ephemeral_seed_menu(*a):
         ch = await ux_show_story(
             "Ephemeral seed is a temporary secret stored solely in device RAM, persisted for only a single boot. "
             "This defeats all of the benefits of Coldcard's secure element design."
-            "\n\nPress 4 to prove you read to the end of this message and accept all consequences.",
+            "\n\nPress (4) to prove you read to the end of this message and accept all consequences.",
             title="WARNING",
             escape="4"
         )

--- a/shared/trick_pins.py
+++ b/shared/trick_pins.py
@@ -791,7 +791,7 @@ normal operation.''')
         if flags & TC_BRICK:
             msg += ' and bricks system at end of countdown'
 
-        msg += '.\n\nPress 4 to change time.'
+        msg += '.\n\nPress (4) to change time.'
         ch = await ux_show_story(msg, escape='4')
         if ch != '4': return
 
@@ -826,7 +826,7 @@ Wallet is XPRV-based and derived from a fixed path.''' % pin
         else:
             raise ValueError(hex(flags))
 
-        ch = await ux_show_story(msg + '\n\nPress 6 to view associated secrets.', escape='6')
+        ch = await ux_show_story(msg + '\n\nPress (6) to view associated secrets.', escape='6')
         if ch != '6': return
 
         b, s = tp.get_by_pin(pin)

--- a/testing/run_sim_tests.py
+++ b/testing/run_sim_tests.py
@@ -16,6 +16,7 @@ python run_sim_tests.py -m all                                 # run all tests b
 python run_sim_tests.py                                        # same as with '-m all' above --> most useful
 python run_sim_tests.py -m all --onetime --veryslow            # run all tests (cca 252 minutes)
 python run_sim_tests.py -m test_multisig.py -k cosigning       # run only tests that match expression from test_multisig.py
+python run_sim_tests.py -m test_export.py --pdb                # run only export tests and attach debugger
 
 
 Onetime/veryslow tests are completely separated form the rest of the test suite.
@@ -215,6 +216,12 @@ def main():
             print("Skipped", test_module)
             continue
         print("Started", test_module)
+        if test_module == "test_address_explorer.py":
+            test_args = DEFAULT_SIMULATOR_ARGS + ["--set", "vidsk=1"]
+        if test_module == "test_export.py":
+            test_args = DEFAULT_SIMULATOR_ARGS + ["--set", "vidsk=1"]
+        if test_module == "test_multisig.py":
+            test_args = DEFAULT_SIMULATOR_ARGS + ["--set", "vidsk=1"]
         if test_module == "test_vdisk.py":
             test_args = ["--eject"] + DEFAULT_SIMULATOR_ARGS + ["--set", "vidsk=1"]
         if test_module == "test_bip39pw.py":

--- a/testing/test_addr.py
+++ b/testing/test_addr.py
@@ -119,7 +119,7 @@ def test_show_addr_nfc(path, str_addr_fmt, nfc_write_text, nfc_read_text, pick_m
     split_story = story.split("\n\n")
     story_addr = split_story[0]
     story_path = split_story[1][2:]  # remove "= "
-    assert "Press 3 to share over NFC" in story
+    assert "Press (3) to share via NFC" in story
     assert story_path == path
     need_keypress("3")  # share over NFC
     addr = nfc_read_text()

--- a/testing/test_drv_entro.py
+++ b/testing/test_drv_entro.py
@@ -116,7 +116,7 @@ def test_bip_vectors(mode, index, entropy, expect,
         assert "Password:" in story
         assert f"m/83696968'/707764'/21'/{index}'" in story
         assert expect in story
-        assert "2 to type password over USB" in story
+        assert "(2) to type password over USB" in story
 
     else:
         raise ValueError(mode)
@@ -124,7 +124,7 @@ def test_bip_vectors(mode, index, entropy, expect,
     # write to SD
     msg = story.split('Press', 1)[0]
     if 1:
-        assert 'Press 1 to save' in story
+        assert 'Press (1) to save' in story
         need_keypress('1')
 
         time.sleep(0.1)
@@ -147,7 +147,7 @@ def test_bip_vectors(mode, index, entropy, expect,
 
 
     if do_import:
-        assert '2 to switch to derived secret' in story
+        assert '(2) to switch to derived secret' in story
 
         try:
             time.sleep(0.1)
@@ -157,7 +157,7 @@ def test_bip_vectors(mode, index, entropy, expect,
                 time.sleep(0.1)
                 title, story = cap_story()
                 assert title == "WARNING"
-                assert 'Press 4 to prove you read to the end of this message and accept all consequences.' in story
+                assert 'Press (4) to prove you read to the end of this message and accept all consequences.' in story
                 need_keypress("4")
 
             time.sleep(0.1)
@@ -188,7 +188,7 @@ def test_bip_vectors(mode, index, entropy, expect,
             reset_seed_words()
 
     else:
-        assert '3 to view as QR code' in story
+        assert '(3) to view as QR code' in story
 
     need_keypress('x')
 
@@ -266,7 +266,7 @@ def test_path_index(mode, pattern, index,
         assert hex(key.secret_exponent())[2:] in story
 
     if index == 0:
-        assert '3 to view as QR code' in story
+        assert '(3) to view as QR code' in story
         need_keypress('3')
 
         qr = cap_screen_qr().decode('ascii')

--- a/testing/test_ephemeral.py
+++ b/testing/test_ephemeral.py
@@ -60,7 +60,7 @@ def goto_eph_seed_menu(goto_home, pick_menu_item, cap_story, need_keypress):
         title, story = cap_story()
         if title == "WARNING":
             assert "temporary secret stored solely in device RAM" in story
-            assert "Press 4 to prove you read to the end of this message and accept all consequences." in story
+            assert "Press (4) to prove you read to the end of this message and accept all consequences." in story
             need_keypress("4")  # understand consequences
     return doit
 
@@ -87,7 +87,7 @@ def test_ephemeral_seed_generate(num_words, cap_menu, pick_menu_item, goto_home,
 
     title, story = cap_story()
     assert f"Record these {num_words} secret words!" in story
-    assert "Press 6 to skip word quiz" in story
+    assert "Press (6) to skip word quiz" in story
 
     # filter those that starts with space, number and colon --> actual words
     e_seed_words = seed_story_to_words(story)

--- a/testing/test_nfc.py
+++ b/testing/test_nfc.py
@@ -334,7 +334,7 @@ def test_nfc_after(num_outs, fake_txn, try_sign, nfc_read, need_keypress, cap_st
     title, story = cap_story()
     assert 'TXID' in title, story
     txid = a2b_hex(story.split()[0])
-    assert 'Press 3' in story
+    assert 'Press (3)' in story
     need_keypress('3')
 
     if too_big:

--- a/testing/test_se2.py
+++ b/testing/test_se2.py
@@ -474,7 +474,7 @@ def test_ux_duress_choices(with_wipe, subchoice, expect, xflags, xargs,
     _, story = cap_story()
     assert ('BIP-85 derived' in story) or ('The legacy' in story)
     assert (f'#{xargs}' in story) or ('XPRV-based' in story)
-    assert 'Press 6 to view associated' in story
+    assert 'Press (6) to view associated' in story
     need_keypress('6')
     time.sleep(.1)
     _, story = cap_story()


### PR DESCRIPTION
* make vdisk import/export public for most endpoints (now user can choose to use vdisk even if SD card is inserted):
    * write address files
    * derived entropy
    * export json
    * export txt
    * multisig different export format + xpub file (import/export)
    * paper wallets
    * import xprv
    
* These endpoints work with Vdisk only if SD ejected (can adjust them in next iteration, for now ignored)
    * write/restore backup
    * clone
    * pwsave
    * share file over NFC

* if vdisk and NFC are disabled - work like before (without another prompt asking which way to export/import - just do it with SD card)
* add NFC option to all export endpoints
* all prompt number are wrapped in parentheses 3 -> (3) so they look like buttons
* "share via NFC" standardized across the codebase (no more "over NFC")
* add vdisk/nfc tests
* adjust tests to work with all above
* BUG FIX: wasabi export would yikes for XRT (wasabi supports both testnet and regtest)
* add import extended private key both via NFC and Virtual Disk
* add import multisig wallet from Virtual Disk