### PR TITLE
Address explorer `Applications` and Single Signature Descriptor Export

### DIFF
--- a/releases/ChangeLog.md
+++ b/releases/ChangeLog.md
@@ -1,9 +1,17 @@
-## 5.0.8 - 2022-11-??
+## 5.0.8 - 2022-12-??
+
 - Enhancement: Add ability to import multisig wallet via Virtual Disk
 - Enhancement: Add ability to import extended private key via Virtual Disk and via NFC
-- Enhancement: Offer import/export from/to Virtual Disk in UI
+- Enhancement: Offer import/export from/to Virtual Disk in UI even if SD Card is inserted
 - Enhancement: Ability to import seed in compact/truncated form (max 4 letters of each word)
-- Enhancement: Add 'rolls12.py' script for verifying dice rolls math for 12 word seeds
+- Enhancement: Add `rolls12.py` script for verifying dice rolls math for 12 word seeds
+- Enhancement: Application specific addresses/derivation paths in `Address Explorer -> Applications`
+- Enhancement: Single signature wallet generic descriptor export `Advanced/Tools -> Export Wallet -> Descriptor`.
+  Both new format with internal/external in one descriptor `<0;1>` and standard with two descriptors exported 
+  are supported.
+- Enhancement: Samourai POST-MIX and PRE-MIX descriptor export options added to `Export Wallet`
+- Enhancement: Add ability to export all supported wallets via NFC
+- Bugfix: Change value was ignored when generating addresses file from address explorer - fixed
 - Bugfix: allow export of Wasabi skeleton for Bitcoin Regtest
 
 ## 5.0.7 - 2022-10-05

--- a/shared/drv_entro.py
+++ b/shared/drv_entro.py
@@ -7,7 +7,7 @@
 # wallet systems, which may expect seed phrases, XPRV, or other entropy.
 #
 import stash, seed, ngu, chains, bip39, version, glob
-from ux import ux_show_story, ux_enter_number, the_ux, ux_confirm, ux_dramatic_pause
+from ux import ux_show_story, ux_enter_bip32_index, the_ux, ux_confirm, ux_dramatic_pause
 from menu import MenuItem, MenuSystem
 from ubinascii import hexlify as b2a_hex
 from ubinascii import b2a_base64
@@ -112,7 +112,7 @@ async def drv_entro_step2(_1, picked, _2):
     if picked == 7:
         # Passwords
         msg = "Password Index?"
-    index = await ux_enter_number(msg, 9999)
+    index = await ux_enter_bip32_index(msg)
     if index is None:
         return
 
@@ -273,7 +273,7 @@ The password will be sent as keystrokes via USB to the host computer.''')
 
         while True:
             the_ux.pop()
-            index = await ux_enter_number("Password Index?", 9999, can_cancel=True)
+            index = await ux_enter_bip32_index("Password Index?", can_cancel=True)
             if index is None:
                 break
 

--- a/shared/flow.py
+++ b/shared/flow.py
@@ -159,6 +159,10 @@ WalletExportMenu = [
     MenuItem("Electrum Wallet", f=electrum_skeleton),
     MenuItem("Wasabi Wallet", f=wasabi_skeleton),
     MenuItem("Unchained Capital", f=unchained_capital_export),
+    MenuItem("Samourai Postmix", f=samourai_post_mix_descriptor_export),
+    MenuItem("Samourai Premix", f=samourai_pre_mix_descriptor_export),
+    # MenuItem("Samourai BadBank", f=samourai_bad_bank_descriptor_export),  # not released yet
+    MenuItem("Descriptor", f=ss_descriptor_skeleton),
     MenuItem("Generic JSON", f=generic_skeleton),
     MenuItem("Export XPUB", menu=XpubExportMenu),
     MenuItem("Dump Summary", predicate=has_secrets, f=dump_summary),

--- a/shared/ux.py
+++ b/shared/ux.py
@@ -363,6 +363,13 @@ async def show_qr_code(data, is_alnum):
     o = QRDisplaySingle([data], is_alnum)
     await o.interact_bare()
 
+async def ux_enter_bip32_index(prompt, can_cancel=False, unlimited=False):
+    if unlimited:
+        max_value = (2 ** 31) - 1  # we handle hardened
+    else:
+        max_value = 9999
+    return await ux_enter_number(prompt=prompt, max_value=max_value, can_cancel=can_cancel)
+
 async def ux_enter_number(prompt, max_value, can_cancel=False):
     # return the decimal number which the user has entered
     # - default/blank value assumed to be zero


### PR DESCRIPTION
* add "Applications" menu item to address explorer, where application specific derivations paths/addresses are accessible
* fix "change" bug in address file export in address explorer
* add NFC/VDISK options to `write_text_file` and `make_json_wallet` (all wallet exports covered)
* Samourai POST/PRE-MIX account export shortcut
* generic single sig descriptor export -> supports both new descriptor type <0;1> and old with two descriptors exported (internal,external)
* fix write char by char bug write_text_file
* add descriptors(single sig) and descriptor templates (multisig) to generic export json
* move change address switch in address explorer from key (5) to key (6) as you need (5) to move up
* add tests