### PR TITLE
Dice seed generation more restrictive + distribution check

### DIFF
--- a/releases/ChangeLog.md
+++ b/releases/ChangeLog.md
@@ -1,4 +1,4 @@
-## 5.0.8 - 2022-12-??
+## 5.0.8 - 2023-02-??
 
 - Enhancement: Add ability to import multisig wallet via Virtual Disk
 - Enhancement: Add ability to import extended private key via Virtual Disk and via NFC
@@ -12,6 +12,9 @@
 - Enhancement: Samourai POST-MIX and PRE-MIX descriptor export options added to `Export Wallet`
 - Enhancement: Add ability to export all supported wallets via NFC
 - Bugfix: Change value was ignored when generating addresses file from address explorer - fixed
+- Enhancement: Added dice rolls distribution check to prevent users from generating low entropy seeds
+- Enhancement: During main seed generation from dice, it is no longer allowed to use fewer dice rolls.
+               Must be at least 50 dice rolls for 12 word seeds and at least 99 dice rolls for 24 word seeds
 - Bugfix: allow export of Wasabi skeleton for Bitcoin Regtest
 
 ## 5.0.7 - 2022-10-05

--- a/shared/paper.py
+++ b/shared/paper.py
@@ -182,7 +182,7 @@ class PaperWalletMaker:
         # Use lots of (D6) dice rolls to create privkey entropy.
         privkey = b''
         with imported('seed') as seed:
-            count, privkey = await seed.add_dice_rolls(0, privkey, True)
+            count, privkey = await seed.add_dice_rolls(0, privkey, True, enforce=True)
             if count == 0: return
 
         if privkey >= SECP256K1_ORDER or privkey == bytes(32):

--- a/testing/test_paper.py
+++ b/testing/test_paper.py
@@ -2,6 +2,8 @@
 #
 # Tests for paper-wallet feature
 #
+import random
+
 import pytest, time, struct, os, shutil, re
 from pycoin.key.Key import Key
 from pycoin.encoding import from_bytes_32
@@ -130,7 +132,80 @@ def test_generate(mode, pdf, dev, cap_menu, pick_menu_item, goto_home, cap_story
 
         os.unlink(path)
 
-@pytest.mark.parametrize('rolls', [ '123123', '123'*30, '123456'*17] )
+@pytest.mark.parametrize('rolls', [ '123123', '123'*30] )
+def test_dice_generate_failure_num_attempts(rolls, dev, cap_menu, pick_menu_item, goto_home, cap_story, need_keypress,
+                                            microsd_path):
+    # verify the math for dice rolling method
+
+    goto_home()
+    pick_menu_item('Advanced/Tools')
+    try:
+        pick_menu_item('Paper Wallets')
+    except:
+        raise pytest.skip('Feature absent')
+
+    time.sleep(0.1)
+    title, story = cap_story()
+
+    assert 'pick a random' in story
+    assert 'MANY RISKS' in story
+
+    need_keypress('y')
+
+    time.sleep(0.1)
+    pick_menu_item('Use Dice')
+
+    for ch in rolls:
+        time.sleep(0.01)
+        need_keypress(ch)
+
+    need_keypress('y')
+    time.sleep(0.1)
+    title, story = cap_story()
+    assert 'Not enough dice rolls!!!' in story
+    assert 'For 256-bit security you need at least 99 rolls' in story
+    assert 'Press OK to add more dice rolls. X to exit' in story
+    need_keypress('x')
+
+@pytest.mark.parametrize('rolls', ['123'*34, "1"*99, "64"*50])
+def test_dice_generate_failure_distribution(rolls, dev, cap_menu, pick_menu_item, goto_home, cap_story, need_keypress,
+                                            microsd_path):
+    # verify the math for dice rolling method
+
+    goto_home()
+    pick_menu_item('Advanced/Tools')
+    try:
+        pick_menu_item('Paper Wallets')
+    except:
+        raise pytest.skip('Feature absent')
+
+    time.sleep(0.1)
+    title, story = cap_story()
+
+    assert 'pick a random' in story
+    assert 'MANY RISKS' in story
+
+    need_keypress('y')
+
+    time.sleep(0.1)
+    pick_menu_item('Use Dice')
+
+    for ch in rolls:
+        time.sleep(0.01)
+        need_keypress(ch)
+
+    need_keypress('y')
+    time.sleep(0.1)
+    title, story = cap_story()
+    assert 'Distribution of dice rolls is not random' in story
+    assert 'Some number/s occurred more than 30% of all attempts' in story
+    # exit
+
+@pytest.mark.parametrize('rolls', [
+    '123456'*17,
+    "".join([str(random.SystemRandom().randint(1,6)) for _ in range(99)]),
+    "".join([str(random.SystemRandom().randint(1,6)) for _ in range(99)]),
+])
 def test_dice_generate(rolls, dev, cap_menu, pick_menu_item, goto_home, cap_story, need_keypress, microsd_path):
     # verify the math for dice rolling method
 

--- a/testing/test_ux.py
+++ b/testing/test_ux.py
@@ -321,7 +321,7 @@ def test_all_bip39_words(pos, goto_home, pick_menu_item, cap_story, need_keypres
     reset_seed_words()
 
 @pytest.mark.qrcode
-@pytest.mark.parametrize('count', [20, 51, 99, 104])
+@pytest.mark.parametrize('count', [20, 40, 51, 99, 104])
 @pytest.mark.parametrize('nwords', [12, 24])
 def test_import_from_dice(count, nwords, goto_home, pick_menu_item, cap_story, need_keypress, unit_test, cap_menu, word_menu_entry, get_secrets, reset_seed_words, cap_screen, cap_screen_qr, qr_quality_check, expect_ftux):
     import random
@@ -329,7 +329,6 @@ def test_import_from_dice(count, nwords, goto_home, pick_menu_item, cap_story, n
     
     unit_test('devtest/clear_seed.py')
 
-    m = cap_menu()
     pick_menu_item('New Seed Words')
     pick_menu_item(f'{nwords} Word Dice Roll')
 
@@ -342,21 +341,26 @@ def test_import_from_dice(count, nwords, goto_home, pick_menu_item, cap_story, n
         time.sleep(0.01)
         need_keypress(ch)
         gave += ch
-
-    title, body = cap_story()
         
     time.sleep(0.1)
     need_keypress('y')
 
     time.sleep(0.1)
     title, body = cap_story()
-    if count < 99:
-        assert 'Are you SURE' in body
+    threshold = 99 if nwords == 24 else 50
+    if count < threshold:
+        assert 'Not enough dice rolls' in body
         assert str(len(gave)) in body
 
         time.sleep(0.1)
-        need_keypress('y')
+        need_keypress('y')  # add more dice rolls
+        for i in range(threshold - count):
+            ch = chr(0x31 + (i % 6))
+            time.sleep(0.01)
+            need_keypress(ch)
+            gave += ch
 
+        need_keypress("y")
         time.sleep(0.1)
         title, body = cap_story()
 


### PR DESCRIPTION
* add dice rolls distribution check and enforce it in case of main seed generation
    * I tested distributions on both PRNG and with real dices - my conclusion is that expecting normal distribution in 50-100 rolls is not possible. I was not able to cross 30% (more like 28,8%) for single num in both real dices and PRNG. Therefore I decided to put distribution limit to 30% (to have some space for crazy non-normal distributions). If one number appears more than 30% of all rolls - failure
* enforce number of dice rolls for main seed generation
* improve story messages for dice rolls
* ephemeral seed is not enforced and adding dice rolls to generated seeds is not enforced too