### PR TITLE
add repo root to path for pytest to find dice rolls code

### DIFF
--- a/testing/test_rolls.py
+++ b/testing/test_rolls.py
@@ -1,3 +1,5 @@
+import sys
+sys.path.append("..")
 from docs.rolls import entropy_to_mnemonic24
 from docs.rolls12 import entropy_to_mnemonic12
 


### PR DESCRIPTION
* broken tests if not run against specific module (or via test runner)

```
ImportError while importing test module '/home/meh/blabla/firmware/testing/test_rolls.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
../ENV/lib/python3.8/site-packages/_pytest/python.py:578: in _importtestmodule
    mod = import_path(self.fspath, mode=importmode)
../ENV/lib/python3.8/site-packages/_pytest/pathlib.py:524: in import_path
    importlib.import_module(module_name)
/usr/lib/python3.8/importlib/__init__.py:127: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
<frozen importlib._bootstrap>:1014: in _gcd_import
    ???
<frozen importlib._bootstrap>:991: in _find_and_load
    ???
<frozen importlib._bootstrap>:975: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:671: in _load_unlocked
    ???
../ENV/lib/python3.8/site-packages/_pytest/assertion/rewrite.py:170: in exec_module
    exec(co, module.__dict__)
test_rolls.py:1: in <module>
    from docs.rolls import entropy_to_mnemonic24
E   ModuleNotFoundError: No module named 'docs'
```