### PR TITLE
Fix SQL2 ImportError on ubuntu 20.04

### DIFF
--- a/unix/requirements.txt
+++ b/unix/requirements.txt
@@ -4,4 +4,4 @@
 #
 PySDL2
 Pillow
-
+pysdl2-dll


### PR DESCRIPTION
Tried installing simulator on plain ubuntu 20.04, it gave me `ImportError: could not find any library for SDL2 (PYSDL2_DLL_PATH: unset)`. Installing pysdl-dll fixes this.