### PR TITLE
export dicts/wallets ordered

### DIFF
--- a/releases/ChangeLog.md
+++ b/releases/ChangeLog.md
@@ -15,6 +15,7 @@
 - Enhancement: During seed generation from dice rolls, enforce at least 50 rolls
   for 12 word seeds, and 99 rolls for 24 word seeds. Statistical distribution check
   added to prevent users from generating low-entropy seeds by rolling same value repeatedly.
+- Enhancement: Change electrum export file name from 'new-wallet.json' to 'new-electrum.json'
 - Bugfix: Offer import/export from/to Virtual Disk in UI even if SD Card is inserted.
 - Bugfix: Allow export of Wasabi skeleton for Bitcoin Regtest.
 - Docs: Add `docs/rolls12.py` script for verifying dice rolls math for 12 word seeds.

--- a/shared/actions.py
+++ b/shared/actions.py
@@ -1183,7 +1183,8 @@ async def electrum_skeleton_step2(_1, _2, item):
     import export
     addr_fmt, account_num = item.arg
     await export.make_json_wallet('Electrum wallet',
-                                    lambda: export.generate_electrum_wallet(addr_fmt, account_num))
+                                  lambda: export.generate_electrum_wallet(addr_fmt, account_num),
+                                  "new-electrum.json")
 
 async def generic_skeleton(*A):
     # like the Multisig export, make a single JSON file with


### PR DESCRIPTION
* add meaningful order to our json exports
* preserve order, so when user export more than once he/she is looking at the same thing (order-wise)
* rename electrum export file from `new-wallet.json` to `new-electrum.json`
