### PR TITLE
Seed from TAPSIGNER backup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ __pycache__/
 
 .tags
 pp
+
+.idea/

--- a/docs/ephemeral.md
+++ b/docs/ephemeral.md
@@ -11,15 +11,19 @@ Make sure you know what you're doing!
 ## Usage
 
 - go to `Advanced/Tools -> Ephemeral Seed`
-- if ephemeral seed is already in use, the menu option `CLEAR [<xfp>]` is visible
+- if ephemeral seed is already in use, top menu item `[<xfp>]` is visible
   with fingerprint of ephemeral master secret
-- an ephemeral seed can be Imported or Generated at random 
-- `Generate`:
-  - `Advanced/Tools -> Ephemeral Seed -> Generate`
-  - same options as generating new seeds, dice rolls included
-- `Import`:
-  - `Advanced/Tools -> Ephemeral Seed -> Import`
-  - same options as importing seeds
+- an ephemeral seed can be Imported or Generated at random
+- go to `Advanced/Tools -> Ephemeral Seed`
+- `Generate Words`:
+  - same options as generating new seed words, dice rolls included
+  - Import words via NFC with `Import via NFC` option
+- `Import Words`:
+  - same options as importing seed words
+- `Import XPRV`:
+  - import extended private key
+- `Tapsigner Backup`
+  - import TAPSIGNER encrypted backup
 - an ephemeral seed can also be a BIP-85 derived value
 
 ## Trick PIN Notes

--- a/releases/ChangeLog.md
+++ b/releases/ChangeLog.md
@@ -1,5 +1,6 @@
 ## 5.1.0 - 2023-02-XX
 
+- New Feature: Load TAPSIGNER encrypted backup as main or ephemeral seed
 - New Feature: "MicroSD card as Second Factor". Specially marked MicroSD card must be
   already inserted when (true) PIN is entered, or else seed is wiped. Add, remove and check
   cards in menu: `Settings -> Login Settings -> MicroSD 2FA`
@@ -13,6 +14,7 @@
     - Add import multisig wallet via Virtual Disk
     - Add import extended private key via Virtual Disk and via NFC
     - Import seed in compact/truncated form (just 3-4 letters of each seed word)
+    - Import extended private key as ephemeral seed
 - Export Enhancements: 
     - Samourai POST-MIX and PRE-MIX descriptor export options added
     - Lily Wallet added

--- a/shared/flow.py
+++ b/shared/flow.py
@@ -329,7 +329,8 @@ ImportWallet = [
     MenuItem("12 Words", menu=start_seed_import, arg=12),
     MenuItem("Restore Backup", f=restore_everything),
     MenuItem("Clone Coldcard", menu=clone_start),
-    MenuItem("Import XPRV", f=import_xprv),
+    MenuItem("Import XPRV", f=import_xprv, arg=False),  # ephemeral=False
+    MenuItem("Tapsigner Backup", f=import_tapsigner_backup_file, arg=False),
     MenuItem("Seed XOR", f=xor_restore_start),
 ]
 

--- a/shared/multisig.py
+++ b/shared/multisig.py
@@ -4,7 +4,7 @@
 #
 import stash, chains, ustruct, ure, uio, sys, ngu, uos, ujson
 from utils import xfp2str, str2xfp, swab32, cleanup_deriv_path, keypath_to_str
-from utils import str_to_keypath, problem_file_line, export_prompt_builder
+from utils import str_to_keypath, problem_file_line, export_prompt_builder, parse_extended_key
 from ux import ux_show_story, ux_confirm, ux_dramatic_pause, ux_clear_keys, ux_enter_bip32_index
 from files import CardSlot, CardMissingError, needs_microsd
 from descriptor import MultisigDescriptor, multisig_descriptor_template
@@ -1445,28 +1445,6 @@ OK to continue. X to abort.'''.format(coin = chain.b44_cointype)
 
     msg = '''Multisig XPUB file written:\n\n%s''' % nice
     await ux_show_story(msg)
-
-def parse_extended_key(ln, private=False):
-    # read an xpub/ypub/etc and return BIP-32 node and what chain it's on.
-    # - can handle any garbage line
-    # - returns (node, chain, addr_fmt)
-    # - people are using SLIP132 so we need this
-    ln = ln.strip()
-    node, chain, addr_fmt = None, None, None
-    if private:
-        rgx = r'.prv[A-Za-z0-9]+'
-    else:
-        rgx = r'.pub[A-Za-z0-9]+'
-
-    pat = ure.compile(rgx)
-    found = pat.search(ln)
-    # serialize, and note version code
-    try:
-        node, chain, addr_fmt, is_private = chains.slip32_deserialize(found.group(0))
-    except:
-        pass
-
-    return node, chain, addr_fmt
 
 async def ondevice_multisig_create(mode='p2wsh', addr_fmt=AF_P2WSH, force_vdisk=False):
     # collect all xpub- exports on current SD card (must be >= 1) to make "air gapped" wallet

--- a/shared/nfc.py
+++ b/shared/nfc.py
@@ -11,7 +11,7 @@ import ngu, utime, ngu, ndef
 from uasyncio import sleep_ms
 from ustruct import pack, unpack
 from ubinascii import unhexlify as a2b_hex
-from ubinascii import b2a_base64
+from ubinascii import b2a_base64, a2b_base64
 
 from ux import ux_show_story, ux_poll_key
 from utils import cleanup_deriv_path, B2A, problem_file_line, parse_addr_fmt_str
@@ -696,6 +696,28 @@ class NFCHandler:
 
         if not winner:
             await ux_show_story('Unable to find extended private key in NDEF data')
+            return
+
+        return winner
+
+    async def read_tapsigner_b64_backup(self):
+        data = await self.start_nfc_rx()
+        if not data:
+            await ux_show_story('Unable to find data expected in NDEF')
+            return
+
+        winner = None
+        for urn, msg, meta in ndef.record_parser(data):
+            msg = bytes(msg).decode()  # from memory view
+            try:
+                if 150 <= len(msg) <= 280:
+                    winner = a2b_base64(msg)
+                    break
+            except:
+                pass
+
+        if not winner:
+            await ux_show_story('Unable to find base64 encoded TAPSIGNER backup in NDEF data')
             return
 
         return winner

--- a/shared/pincodes.py
+++ b/shared/pincodes.py
@@ -445,7 +445,7 @@ class PinAttempt:
 
         # does not call settings.save() but caller should!
 
-    def tmp_secret(self, encoded):
+    def tmp_secret(self, encoded, chain=None):
         # Use indicated secret and stop using the SE; operate like this until reboot
         self.tmp_value = bytes(encoded + bytes(AE_SECRET_LEN - len(encoded)))
 
@@ -459,7 +459,7 @@ class PinAttempt:
 
         # Copies system settings to new encrypted-key value, calculates
         # XFP, XPUB and saves into that, and starts using them.
-        self.new_main_secret(self.tmp_value)
+        self.new_main_secret(self.tmp_value, chain=chain)
 
     def trick_request(self, method_num, data):
         # send/recv a trick-pin related request (mk4 only)

--- a/testing/data/backup-4VMI3-2023-02-15T1645.aes
+++ b/testing/data/backup-4VMI3-2023-02-15T1645.aes
@@ -1,0 +1,2 @@
+Õo{;]íó®ªDf#Nôbê¶ŠÖ¯è¥b‡¹„¾Û~·eŽÏáXæ˜~€ÁRßc‹uíK=)Pºªc¿;q™´N+õvàR|Ø"!™	…v¾×±Jƒ‹
+Ð…lyABŠ±µäñV\~1,}º±ç‰j‚×Ô§

--- a/testing/data/backup-O4MZA-2023-02-15T2250.aes
+++ b/testing/data/backup-O4MZA-2023-02-15T2250.aes
@@ -1,0 +1,1 @@
+RAJwo¦: È…o+‚Á°ä ÷~ÝÁÁvysTàß·˜¬œ¹wÂ…¯Æ'15‡q0~ño˜w§¾Òž‰lèóIµ,gó½)1PV¹2L‘¸-þŠúã}‘»gRÐ—·`O{®sLô*Ä–™¿å¶--9<ä7²*Wd®g

--- a/testing/test_ephemeral.py
+++ b/testing/test_ephemeral.py
@@ -2,7 +2,7 @@
 #
 # Ephemeral Seeds tests
 #
-import pytest, time, re
+import pytest, time, re, os, shutil
 
 from constants import simulator_fixed_xpub
 from ckcc.protocol import CCProtocolPacker
@@ -15,6 +15,7 @@ def truncate_seed_words(words):
         words = words.split(" ")
     return ' '.join(w[0:4] for w in words)
 
+
 def seed_story_to_words(story: str):
     # filter those that starts with space, number and colon --> actual words
     words = [
@@ -23,6 +24,17 @@ def seed_story_to_words(story: str):
         if re.search(r"\s\d:", line) or re.search(r"\d{2}:", line)
     ]
     return words
+
+
+@pytest.fixture
+def ephemeral_seed_disabled(cap_menu):
+    def doit():
+        time.sleep(0.1)
+        menu = cap_menu()
+        # no ephemeral seed chosen (yet)
+        assert "[" not in menu[0]
+    return doit
+
 
 @pytest.fixture
 def get_seed_value_ux(goto_home, pick_menu_item, need_keypress, cap_story, nfc_read_text):
@@ -64,6 +76,7 @@ def get_identity_story(goto_home, pick_menu_item, cap_story):
         return story
     return doit
 
+
 @pytest.fixture
 def goto_eph_seed_menu(goto_home, pick_menu_item, cap_story, need_keypress):
     def doit():
@@ -78,10 +91,58 @@ def goto_eph_seed_menu(goto_home, pick_menu_item, cap_story, need_keypress):
             need_keypress("4")  # understand consequences
     return doit
 
+
+@pytest.fixture
+def verify_ephemeral_secret_ui(cap_story, need_keypress, cap_menu, dev, goto_home, pick_menu_item,
+                               fake_txn, try_sign, goto_eph_seed_menu, reset_seed_words,
+                               get_identity_story, get_seed_value_ux):
+    def doit(mnemonic=None, xpub=None):
+        time.sleep(0.3)
+        _, story = cap_story()
+        in_effect_xfp = story[1:9]
+        assert "key in effect until next power down." in story
+        need_keypress("y")  # just confirm new master key message
+
+        menu = cap_menu()
+        assert menu[0] == "Ready To Sign"  # returned to main menu
+
+        ident_story = get_identity_story()
+        assert "Ephemeral seed is in effect" in ident_story
+
+        ident_xfp = ident_story.split("\n\n")[1].strip()
+        assert ident_xfp == in_effect_xfp
+
+        if mnemonic:
+            seed_words = get_seed_value_ux()
+            assert mnemonic == seed_words
+
+        e_master_xpub = dev.send_recv(CCProtocolPacker.get_xpub(), timeout=5000)
+        assert e_master_xpub != simulator_fixed_xpub
+        if xpub:
+            assert e_master_xpub == xpub
+        psbt = fake_txn(2, 2, master_xpub=e_master_xpub, segwit_in=True)
+        try_sign(psbt, accept=True, finalize=True)  # MUST NOT raise
+        need_keypress("y")
+
+        goto_eph_seed_menu()
+        time.sleep(0.1)
+        menu = cap_menu()
+        # ephemeral seed chosen -> [xfp] will be visible
+        assert menu[0] == f"[{ident_xfp}]"
+
+        reset_seed_words()
+
+        goto_eph_seed_menu()
+        menu = cap_menu()
+        assert menu[0] != f"[{ident_xfp}]"
+    return doit
+
+
 @pytest.mark.parametrize("num_words", [12, 24])
 @pytest.mark.parametrize("dice", [False, True])
-def test_ephemeral_seed_generate(num_words, cap_menu, pick_menu_item, goto_home, cap_story, need_keypress,
-                                 reset_seed_words, get_seed_value_ux, get_identity_story, fake_txn, dev, try_sign, goto_eph_seed_menu, dice):
+def test_ephemeral_seed_generate(num_words, pick_menu_item, goto_home, cap_story, need_keypress,
+                                 reset_seed_words, goto_eph_seed_menu, dice, ephemeral_seed_disabled,
+                                 verify_ephemeral_secret_ui):
 
     reset_seed_words()
     try:
@@ -90,11 +151,8 @@ def test_ephemeral_seed_generate(num_words, cap_menu, pick_menu_item, goto_home,
         time.sleep(.1)
         goto_eph_seed_menu()
 
-    menu = cap_menu()
-
-    # no ephemeral seed chosen (yet)
-    assert len(menu) == 2
-    pick_menu_item("Generate Seed")
+    ephemeral_seed_disabled()
+    pick_menu_item("Generate Words")
     if not dice:
         pick_menu_item(f"{num_words} Words")
         time.sleep(0.1)
@@ -103,6 +161,7 @@ def test_ephemeral_seed_generate(num_words, cap_menu, pick_menu_item, goto_home,
         for ch in '123456yy':
             need_keypress(ch)
 
+    time.sleep(0.2)
     title, story = cap_story()
     assert f"Record these {num_words} secret words!" in story
     assert "Press (6) to skip word quiz" in story
@@ -115,49 +174,16 @@ def test_ephemeral_seed_generate(num_words, cap_menu, pick_menu_item, goto_home,
     need_keypress("y")  # yes - I'm sure
     time.sleep(0.1)
     need_keypress("4")  # understand consequences
-    time.sleep(0.1)
-    title, story = cap_story()
-    in_effect_xfp = story[1:9]
-    assert "key in effect until next power down." in story
-    need_keypress("y")  # just confirm new master key message
+    verify_ephemeral_secret_ui(mnemonic=e_seed_words)
 
-    menu = cap_menu()
-    assert menu[0] == "Ready To Sign"  # returned to main menu
-    seed_words = get_seed_value_ux()
-    assert e_seed_words == seed_words
-
-    ident_story = get_identity_story()
-    assert "Ephemeral seed is in effect" in ident_story
-
-    ident_xfp = ident_story.split("\n\n")[1].strip()
-    assert ident_xfp == in_effect_xfp
-
-    e_master_xpub = dev.send_recv(CCProtocolPacker.get_xpub(), timeout=5000)
-    assert e_master_xpub != simulator_fixed_xpub
-    psbt = fake_txn(3, 3, master_xpub=e_master_xpub, segwit_in=True)
-    try_sign(psbt, accept=True, finalize=True)  # MUST NOT raise
-    goto_home()
-    pick_menu_item("Advanced/Tools")
-    pick_menu_item("Ephemeral Seed")
-    menu = cap_menu()
-
-    # ephemeral seed chosen -> [xfp] will be visible
-    assert len(menu) == 3
-    assert menu[0] == f"[{ident_xfp}]"
-
-    reset_seed_words()
-
-    goto_eph_seed_menu()
-    menu = cap_menu()
-    assert len(menu) == 2
 
 @pytest.mark.parametrize("num_words", [12, 18, 24])
 @pytest.mark.parametrize("nfc", [False, True])
 @pytest.mark.parametrize("truncated", [False, True])
-def test_ephemeral_seed_import(nfc, num_words, cap_menu, pick_menu_item, goto_home, cap_story,
-            need_keypress, reset_seed_words, get_seed_value_ux, get_identity_story, fake_txn,
-            dev, try_sign, goto_eph_seed_menu, word_menu_entry, nfc_write_text, truncated
-):
+def test_ephemeral_seed_import_words(nfc, truncated, num_words, cap_menu, pick_menu_item, goto_home,
+                                     cap_story, need_keypress, reset_seed_words, goto_eph_seed_menu,
+                                     word_menu_entry, nfc_write_text, verify_ephemeral_secret_ui,
+                                     ephemeral_seed_disabled, get_seed_value_ux):
     if truncated and not nfc: return
 
     wordlists = {
@@ -174,11 +200,8 @@ def test_ephemeral_seed_import(nfc, num_words, cap_menu, pick_menu_item, goto_ho
         time.sleep(.1)
         goto_eph_seed_menu()
 
-    menu = cap_menu()
-
-    # no ephemeral seed chosen (yet)
-    assert len(menu) == 2
-    pick_menu_item("Import Seed")
+    ephemeral_seed_disabled()
+    pick_menu_item("Import Words")
 
     if not nfc:
         pick_menu_item(f"{num_words} Words")
@@ -199,38 +222,226 @@ def test_ephemeral_seed_import(nfc, num_words, cap_menu, pick_menu_item, goto_ho
 
     need_keypress("4")  # understand consequences
 
-    time.sleep(0.4)
-    title, story = cap_story()
-
-    in_effect_xfp = story[1:9]
-    assert "key in effect until next power down." in story
-    need_keypress("y")  # just confirm new master key message
-
-    menu = cap_menu()
-    assert menu[0] == "Ready To Sign"  # returned to main menu
-    seed_words = get_seed_value_ux()
-    assert words == " ".join(seed_words)
-
-    ident_story = get_identity_story()
-    assert "Ephemeral seed is in effect" in ident_story
-
-    ident_xfp = ident_story.split("\n\n")[1].strip()
-    assert ident_xfp == in_effect_xfp
-
-    e_master_xpub = dev.send_recv(CCProtocolPacker.get_xpub(), timeout=5000)
-    assert e_master_xpub != simulator_fixed_xpub
-    psbt = fake_txn(2, 2, master_xpub=e_master_xpub, segwit_in=True)
-    try_sign(psbt, accept=True, finalize=True)  # MUST NOT raise
-    goto_home()
-    pick_menu_item("Advanced/Tools")
-    pick_menu_item("Ephemeral Seed")
-    menu = cap_menu()
-
-    # ephemeral seed chosen -> [xfp] will be visible
-    assert len(menu) == 3
-    assert menu[0] == f"[{ident_xfp}]"
+    verify_ephemeral_secret_ui(mnemonic=words.split(" "))
 
     nfc_seed = get_seed_value_ux(nfc=True)  # export seed via NFC (always truncated)
+    seed_words = get_seed_value_ux()
     assert " ".join(nfc_seed) == truncate_seed_words(seed_words)
+
+
+@pytest.mark.parametrize("way", ["sd", "vdisk", "nfc"])
+@pytest.mark.parametrize('retry', range(3))
+@pytest.mark.parametrize("testnet", [True, False])
+def test_ephemeral_seed_import_tapsigner(way, retry, testnet, pick_menu_item, cap_story, enter_hex,
+                                         need_keypress, reset_seed_words, goto_eph_seed_menu,
+                                         verify_ephemeral_secret_ui, ephemeral_seed_disabled,
+                                         nfc_write_text, tapsigner_encrypted_backup):
+    reset_seed_words()
+
+    fname, backup_key_hex, node = tapsigner_encrypted_backup(way, testnet=testnet)
+
+    try:
+        goto_eph_seed_menu()
+    except:
+        time.sleep(.1)
+        goto_eph_seed_menu()
+
+    ephemeral_seed_disabled()
+    pick_menu_item("Tapsigner Backup")
+    time.sleep(0.1)
+    _, story = cap_story()
+    if way == "sd":
+        if "Press (1) to import TAPSIGNER encrypted backup file from SD Card" in story:
+            need_keypress("1")
+    elif way == "nfc":
+        if "press (3) to import via NFC" not in story:
+            pytest.xfail("NFC disabled")
+        else:
+            need_keypress("3")
+            time.sleep(0.2)
+            nfc_write_text(fname)
+            time.sleep(0.3)
+    else:
+        # virtual disk
+        if "press (2) to import from Virtual Disk" not in story:
+            pytest.xfail("Vdisk disabled")
+        else:
+            need_keypress("2")
+
+    if way != "nfc":
+        time.sleep(0.1)
+        _, story = cap_story()
+        assert "Pick TAPSIGNER encrypted backup file" in story
+        need_keypress("y")
+        pick_menu_item(fname)
+
+    time.sleep(0.1)
+    _, story = cap_story()
+    assert "your TAPSIGNER" in story
+    assert "back of the card" in story
+    need_keypress("y")  # yes I have backup key
+    enter_hex(backup_key_hex)
+    verify_ephemeral_secret_ui(xpub=node.hwif())
+
+
+@pytest.mark.parametrize("fail", ["wrong_key", "key_len", "plaintext", "garbage"])
+def test_ephemeral_seed_import_tapsigner_fail(cap_menu, pick_menu_item, goto_home, cap_story, fail,
+                                              need_keypress, reset_seed_words, enter_hex,
+                                              tapsigner_encrypted_backup, goto_eph_seed_menu,
+                                              microsd_path, ephemeral_seed_disabled):
+    reset_seed_words()
+    fail_msg = "Decryption failed - wrong key?"
+    fname, backup_key_hex, node = tapsigner_encrypted_backup("sd", testnet=False)
+    if fail == "plaintext":
+        with open(microsd_path(fname), "w") as f:
+            f.write(node.hwif(True) + "\n")
+    if fail == "garbage":
+        with open(microsd_path(fname), "wb") as f:
+            f.write(os.urandom(152))
+    try:
+        goto_eph_seed_menu()
+    except:
+        time.sleep(.1)
+        goto_eph_seed_menu()
+
+    ephemeral_seed_disabled()
+    pick_menu_item("Tapsigner Backup")
+    time.sleep(0.1)
+    _, story = cap_story()
+    if "Press (1) to import TAPSIGNER encrypted backup file from SD Card" in story:
+        need_keypress("1")
+
+    time.sleep(0.1)
+    _, story = cap_story()
+    assert "Pick TAPSIGNER encrypted backup file" in story
+    need_keypress("y")
+    pick_menu_item(fname)
+
+    time.sleep(0.1)
+    _, story = cap_story()
+    assert "Press OK to continue X to cancel." in story
+    need_keypress("y")  # yes I have backup key
+    if fail == "wrong_key":
+        backup_key_hex = os.urandom(16).hex()
+    if fail == "key_len":
+        backup_key_hex = os.urandom(15).hex()
+        fail_msg = "'Backup Key' length != 32"
+    enter_hex(backup_key_hex)
+    time.sleep(0.3)
+    title, story = cap_story()
+    assert title == "FAILURE"
+    assert fail_msg in story
+    need_keypress("x")
+    need_keypress("x")
+
+
+@pytest.mark.parametrize("data", [
+    (
+        "backup-4VMI3-2023-02-15T1645.aes",
+        "cb5bec9ddea4e85558bb54f41dcb1d2e",
+        "xpub661MyMwAqRbcFkTtUfByC6u46vJtdw6xFHUFhjc2AvA16BJCUPoeuwQcthN6yshHR34WZBT5gsHYVtha2QD9j9QozJf9ENeHS6TDgSAFBeX"
+    ),
+    (
+        "backup-O4MZA-2023-02-15T2250.aes",
+        "578efa5d6803e3c314a98a87d499ce97",
+        "xpub661MyMwAqRbcGBeMu9h1B222hQmc4XkXasbN4F3mDGTWRJ11UQ5orWv41FPVK7stXsS9UtR5DBTArBvcsHPiCE2E1PAdqq1UQiQTYmrEEaa"
+    ),
+])
+def test_ephemeral_seed_import_tapsigner_real(data, cap_menu, pick_menu_item, goto_home, cap_story,
+                                              need_keypress, reset_seed_words, enter_hex, microsd_path,
+                                              goto_eph_seed_menu, verify_ephemeral_secret_ui,
+                                              ephemeral_seed_disabled):
+    fname, backup_key_hex, pub = data
+    fpath = microsd_path(fname)
+    shutil.copy(f"data/{fname}", fpath)
+    reset_seed_words()
+    try:
+        goto_eph_seed_menu()
+    except:
+        time.sleep(.1)
+        goto_eph_seed_menu()
+
+    ephemeral_seed_disabled()
+    pick_menu_item("Tapsigner Backup")
+    time.sleep(0.1)
+    _, story = cap_story()
+    if "Press (1) to import TAPSIGNER encrypted backup file from SD Card" in story:
+        need_keypress("1")
+
+    time.sleep(0.1)
+    _, story = cap_story()
+    assert "Pick TAPSIGNER encrypted backup file" in story
+    need_keypress("y")
+    pick_menu_item(fname)
+
+    time.sleep(0.1)
+    _, story = cap_story()
+    assert "Press OK to continue X to cancel." in story
+    need_keypress("y")  # yes I have backup key
+    enter_hex(backup_key_hex)
+    verify_ephemeral_secret_ui(xpub=pub)
+    os.unlink(fpath)
+
+
+@pytest.mark.parametrize("way", ["sd", "vdisk", "nfc"])
+@pytest.mark.parametrize('retry', range(3))
+@pytest.mark.parametrize("testnet", [True, False])
+def test_ephemeral_seed_import_xprv(way, retry, testnet, cap_menu, pick_menu_item, goto_home,
+                                    cap_story, need_keypress, reset_seed_words, goto_eph_seed_menu,
+                                    nfc_write_text, enter_hex, microsd_path, virtdisk_path,
+                                    verify_ephemeral_secret_ui, ephemeral_seed_disabled):
+    reset_seed_words()
+    fname = "ek.txt"
+    from pycoin.key.BIP32Node import BIP32Node
+    node = BIP32Node.from_master_secret(os.urandom(32), netcode="XTN" if testnet else "BTC")
+    ek = node.hwif(as_private=True) + '\n'
+    if way =="sd":
+        fpath = microsd_path(fname)
+    elif way == "vdisk":
+        fpath = virtdisk_path(fname)
+    if way != "nfc":
+        with open(fpath, "w") as f:
+            f.write(ek)
+    if testnet:
+        assert "tprv" in ek
+    else:
+        assert "xprv" in ek
+
+    try:
+        goto_eph_seed_menu()
+    except:
+        time.sleep(.1)
+        goto_eph_seed_menu()
+
+    ephemeral_seed_disabled()
+    pick_menu_item("Import XPRV")
+    time.sleep(0.1)
+    _, story = cap_story()
+    if way == "sd":
+        if "Press (1) to import extended private key file from SD Card" in story:
+            need_keypress("1")
+    elif way == "nfc":
+        if "press (3) to import via NFC" not in story:
+            pytest.xfail("NFC disabled")
+        else:
+            need_keypress("3")
+            time.sleep(0.2)
+            nfc_write_text(ek)
+            time.sleep(0.3)
+    else:
+        # virtual disk
+        if "press (2) to import from Virtual Disk" not in story:
+            pytest.xfail("Vdisk disabled")
+        else:
+            need_keypress("2")
+
+    if way != "nfc":
+        time.sleep(0.1)
+        _, story = cap_story()
+        assert "Select file containing the extended private key" in story
+        need_keypress("y")
+        pick_menu_item(fname)
+
+    verify_ephemeral_secret_ui(xpub=node.hwif())
 
 # EOF


### PR DESCRIPTION
* main seed from Tapsigner backup
* ephemeral seed from Tapsigner backup
* ephemeral seed from extended private key (currently we only had main seed from extended private key)
* receiving via NFC is supported but not via binary support but instead base64 encoded backup contents are accepted.
* some refactor on how we import extended private keys -> do not use backup related code, use what is in `seed.py` and be able to specify chain in seed import
* UI change in `Ephemeral Seed` menu
    * `Generate Seed` --> `Generate Words`
    * `Import Seed` --> `Import Words`
