### PR TITLE
1of1 multisig correct UI

### DIFF
--- a/shared/multisig.py
+++ b/shared/multisig.py
@@ -1067,7 +1067,7 @@ class MultisigWallet:
 
         if M == N == 1:
             exp = 'The one signer must approve spends.'
-        if M == N:
+        elif M == N:
             exp = 'All %d co-signers must approve spends.' % N
         elif M == 1:
             exp = 'Any signature from %d co-signers will approve spends.' % N


### PR DESCRIPTION
In case of 1of1 multisig (rare to non-existent) we show `All 1 co-signers must approve spends.` instead of correct special case `The one signer must approve spends.`