### PR TITLE
NFC and Digest Check Improvements

### DIFF
--- a/shared/actions.py
+++ b/shared/actions.py
@@ -1324,6 +1324,10 @@ async def import_xprv(_1, _2, item):
         if ch == "3":
             force_vdisk = None
             extended_key = await NFC.read_extended_private_key()
+            if not extended_key:
+                # failed to get any data - exit
+                # error already displayed in nfc.py
+                return
         elif ch == "2":
             force_vdisk = True
         elif ch == "1":
@@ -1473,6 +1477,10 @@ async def import_tapsigner_backup_file(_1, _2, item):
         if ch == "3":
             force_vdisk = None
             data = await NFC.read_tapsigner_b64_backup()
+            if not data:
+                # failed to get any data - exit
+                # error already displayed in nfc.py
+                return
         elif ch == "2":
             force_vdisk = True
         elif ch == "1":

--- a/shared/nfc.py
+++ b/shared/nfc.py
@@ -696,7 +696,7 @@ class NFCHandler:
                 winner = msg.strip()
                 break
 
-        await verify_armored_signed_msg(winner)
+        await verify_armored_signed_msg(winner, digest_check=False)
 
     async def read_extended_private_key(self):
         data = await self.start_nfc_rx()

--- a/testing/test_msg.py
+++ b/testing/test_msg.py
@@ -659,6 +659,14 @@ def test_verify_signature_truncated(way, microsd_path, cap_story, verify_armored
             f.write(prob_file)
 
     title, story = verify_armored_signature(way, fname, prob_file)
-    assert title == ("CORRECT" if way == 'nfc' else 'WARNING')
+    if not truncation_len:
+        # warning for SD as file is not present on filesystem
+        # correct for NFC as it does not care (digest_check=False)
+        assert title == ("CORRECT" if way == 'nfc' else 'WARNING')
+    else:
+        assert title == "FAILURE"
+        assert "Armor text MUST be surrounded by exactly five (5) dashes" in story
+        assert "auth.py" in story
+
 
 # EOF


### PR DESCRIPTION
* tapsigner/xprv NFC import stop immediatly after no data received
* more verbose error message for malformed sig files
* skip digest check for NFC imported sig files
