### PR TITLE
refresh menu after set_seed_extended_key

### DIFF
--- a/releases/ChangeLog.md
+++ b/releases/ChangeLog.md
@@ -1,6 +1,8 @@
 ## 5.1.2 - 2023-03-18
 
 - Enhancement: SeedXOR for 12 and 18 words mnemonics
+- Bugfix: After extended private key and TAPSIGNER backup import into blank wallet, users needed 
+  to manually reboot Coldcard. Fixed
 
 
 ## 5.1.1 - 2023-02-27

--- a/shared/seed.py
+++ b/shared/seed.py
@@ -473,6 +473,7 @@ async def ephemeral_seed_generate(nwords):
 async def set_seed_extended_key(extended_key):
     encoded, chain = xprv_to_encoded_secret(extended_key)
     set_seed_value(encoded=encoded, chain=chain)
+    goto_top_menu()
 
 async def set_ephemeral_seed_extended_key(extended_key):
     encoded, chain = xprv_to_encoded_secret(extended_key)


### PR DESCRIPTION
* no need to restart as in previous versions where `restore_from_dict` was used as in this menu seed must be cleared already
* push them to normal menu after set seed
