### PR TITLE
change Key Origin Information export format of multisig addresses .csv according to BIP-0380

### DIFF
--- a/releases/ChangeLog.md
+++ b/releases/ChangeLog.md
@@ -1,5 +1,7 @@
 ## 5.1.3 - 2023-XX-XX
 
+- Enhancement: change Key Origin Information export format in multisig `addresses.csv` according to [BIP-0380](https://github.com/bitcoin/bips/blob/master/bip-0380.mediawiki#key-expressions)
+  `(m=0F056943)/m/48'/1'/0'/2'/0/0` --> `[0F056943/48'/1'/0'/2'/0/0]`
 - Bugfix: correct `scrptPubkey` parsing for segwit v1-v16
 - Bugfix: do not infer segwit just by availability of `PSBT_IN_WITNESS_UTXO` in PSBT
 

--- a/shared/multisig.py
+++ b/shared/multisig.py
@@ -451,7 +451,7 @@ class MultisigWallet:
             node = ch.deserialize_node(xpub, AF_P2SH)
             node.derive(change_idx, False)
             # indicate path used (for UX)
-            path = "(m=%s)/%s/%d/{idx}" % (xfp2str(xfp), deriv, change_idx)
+            path = "[%s/%s/%d/{idx}]" % (xfp2str(xfp), deriv[2:], change_idx)
             nodes.append(node)
             paths.append(path)
 
@@ -537,9 +537,9 @@ class MultisigWallet:
                 # Document path(s) used. Not sure this is useful info to user tho.
                 # - Do not show what we can't verify: we don't really know the hardeneded
                 #   part of the path from fingerprint to here.
-                here = '(m=%s)\n' % xfp2str(xfp)
+                here = '[%s]' % xfp2str(xfp)
                 if dp != len(path):
-                    here += 'm' + ('/_'*dp) + keypath_to_str(path[dp:], '/', 0)
+                    here = here[:-1] + ('/_'*dp) + keypath_to_str(path[dp:], '/', 0) + "]"
 
                 if found_pk != pubkey:
                     # Not a match but not an error by itself, since might be 
@@ -802,7 +802,7 @@ class MultisigWallet:
                 with stash.SensitiveValues() as sv:
                     chk_node = sv.derive_path(deriv)
                     assert node.pubkey() == chk_node.pubkey(), \
-                                "(m=%s)/%s wrong pubkey" % (xfp2str(xfp), deriv[2:])
+                                "[%s/%s] wrong pubkey" % (xfp2str(xfp), deriv[2:])
 
         # serialize xpub w/ BIP-32 standard now.
         # - this has effect of stripping SLIP-132 confusion away

--- a/testing/test_multisig.py
+++ b/testing/test_multisig.py
@@ -1905,9 +1905,9 @@ def test_ms_addr_explorer(descriptor, change, M, N, addr_fmt, make_multisig, cle
         assert "Press (6)" not in story
     # unwrap text a bit
     if change:
-        story = story.replace("=>\n", "=> ").replace('1/0\n =>', "1/0 =>")
+        story = story.replace("=>\n", "=> ").replace('1/0]\n =>', "1/0 =>")
     else:
-        story = story.replace("=>\n", "=> ").replace('0/0\n =>', "0/0 =>")
+        story = story.replace("=>\n", "=> ").replace('0/0]\n =>', "0/0 =>")
 
     maps = []
     for ln in story.split('\n'):


### PR DESCRIPTION
* current is non-standard
* this new one even saves us 2 byte per each derivation path in addresses.csv