### PR TITLE
Tapleaf version is only 7 most significant bits

### DIFF
--- a/shared/chains.py
+++ b/shared/chains.py
@@ -7,7 +7,8 @@ from uhashlib import sha256
 from ubinascii import hexlify as b2a_hex
 from public_constants import AF_CLASSIC, AF_P2SH, AF_P2WPKH, AF_P2WSH, AF_P2WPKH_P2SH, AF_P2WSH_P2SH, AF_P2TR
 from public_constants import AFC_PUBKEY, AFC_SEGWIT, AFC_BECH32, AFC_SCRIPT
-from serializations import hash160, ser_compact_size, disassemble
+from public_constants import TAPROOT_LEAF_TAPSCRIPT, TAPROOT_LEAF_MASK
+from serializations import hash160, ser_compact_size, disassemble, ser_string
 from ucollections import namedtuple
 from opcodes import OP_RETURN, OP_1, OP_16
 
@@ -36,6 +37,12 @@ def taptweak(internal_key, tweak=None):
     xo_pubkey = ngu.secp256k1.xonly_pubkey(internal_key)
     xo_pubkey_tweaked = xo_pubkey.tweak_add(tweak)
     return xo_pubkey_tweaked.to_bytes()
+
+def tapleaf_hash(script, leaf_version=TAPROOT_LEAF_TAPSCRIPT):
+    # Tapleaf hash requires one to provide version, version consists
+    # of 7 msb
+    lv = leaf_version % TAPROOT_LEAF_MASK
+    return ngu.secp256k1.tagged_sha256(b"TapLeaf", bytes([lv]) + ser_string(script))
 
 
 class ChainsBase:

--- a/shared/multisig.py
+++ b/shared/multisig.py
@@ -16,7 +16,7 @@ from exceptions import FatalPSBTIssue
 from glob import settings
 from ubinascii import unhexlify as a2b_hex
 from ubinascii import hexlify as b2a_hex
-from serializations import ser_string, disassemble
+from serializations import disassemble
 
 
 # PSBT Xpub trust policies
@@ -560,7 +560,7 @@ class MultisigWallet:
                 # p2tr
                 script = make_redeem_script_tr(self.M, nodes, idx)
                 # leaf hash is also a merkle root in tree of depth 0 (only allowed now) - aka taptweak
-                leaf_hash = ngu.secp256k1.tagged_sha256(b"TapLeaf", bytes([0xc0]) + ser_string(script))
+                leaf_hash = chains.tapleaf_hash(script)
 
                 if isinstance(self.internal_key, str):
                     internal_key_bytes = a2b_hex(self.internal_key)


### PR DESCRIPTION
* PSBTs do not contain pk parity as it is only needed for witness stack
* bitcoin core correctly sends versions without parity in PSBT
* I have not seen other wallets (mostly because tapscript not implemented) doing it - BUT to be on safe side