### PR TITLE
remove label from bitcoin core export

### DIFF
--- a/releases/ChangeLog.md
+++ b/releases/ChangeLog.md
@@ -6,6 +6,8 @@
 - Bugfix: correct `scriptPubkey` parsing for segwit v1-v16
 - Bugfix: do not infer segwit just by availability of `PSBT_IN_WITNESS_UTXO` in PSBT. Improves
   compatibility with Bitcoin Core.
+- Bugfix: remove label from Bitcoin Core `importdescriptors` export as it is no longer supported
+  with ranged descriptors in version `24.1`
 
 ## 5.1.2 - 2023-04-07
 

--- a/shared/export.py
+++ b/shared/export.py
@@ -258,7 +258,7 @@ def generate_bitcoin_core_wallet(account_num, example_addrs):
         for internal in [False, True]
     ]
     # for importdescriptors
-    imd_list = desc_obj.bitcoin_core_serialize(external_label="Coldcard %s" % txt_xfp)
+    imd_list = desc_obj.bitcoin_core_serialize()
     return imm_list, imd_list
 
 def generate_wasabi_wallet():

--- a/testing/test_export.py
+++ b/testing/test_export.py
@@ -133,12 +133,17 @@ def test_export_core(way, dev, use_regtest, acct_num, pick_menu_item, goto_home,
         assert expect in desc
         assert expect+f'/{n}/*' in desc
 
-        if n == 0:
-            assert here['label'] == 'Coldcard ' + xfp
+        assert 'label' not in d
 
         # test against bitcoind -- needs a "descriptor native" wallet
-        bitcoind_d_wallet.importdescriptors(obj)
+        res = bitcoind_d_wallet.importdescriptors(obj)
+        assert res[0]["success"]
+        assert res[1]["success"]
+        core_gen = []
+        for i in range(3):
+            core_gen.append(bitcoind_d_wallet.getnewaddress())
 
+        assert core_gen == addrs
         x = bitcoind_d_wallet.getaddressinfo(addrs[-1])
         pprint(x)
         assert x['address'] == addrs[-1]


### PR DESCRIPTION
* in `24.1` label is no longer supported with ranged descriptors
