### PR TITLE
duplicate XFP limitations.md

### DIFF
--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -70,7 +70,7 @@
 - change outputs (indicated with paths, scripts in output section) must correspond to
   the active multisig wallet, and cannot be used to describe an unrelated (multisig) wallet.
 - derivation path for each cosigner must be known and consistent with PSBT
-- fixed: XFP values (fingerprints) for each of the co-signers must be unique (limitation removed)
+- XFP values (fingerprints) MUST be unique for each of the co-signers
 
 
 # SIGHASH types


### PR DESCRIPTION
* duplicate XFPs in one multisig is not allowed. It does not matter whether it is my XFP or random multisig member.
* `limitations.md` seems to hint that we no longer have this requirement - but we have and this update should make it clearer