### PR TITLE
Batch Sign

### DIFF
--- a/releases/ChangeLog.md
+++ b/releases/ChangeLog.md
@@ -1,5 +1,6 @@
 ## 5.1.3 - 2023-06-20
 
+- New Feature: Batch Sign PSBTs. `Advanced/Tools -> File Management -> Batch Sign`
 - Enhancement: change Key Origin Information export format in multisig `addresses.csv` to match
   [BIP-0380](https://github.com/bitcoin/bips/blob/master/bip-0380.mediawiki#key-expressions)
   was `(m=0F056943)/m/48'/1'/0'/2'/0/0` now `[0F056943/48'/1'/0'/2'/0/0]`

--- a/shared/flow.py
+++ b/shared/flow.py
@@ -180,6 +180,7 @@ FileMgmtMenu = [
     MenuItem("Verify Backup", f=verify_backup),
     MenuItem("Backup System", predicate=has_secrets, f=backup_everything),
     MenuItem('Export Wallet', predicate=has_secrets, menu=WalletExportMenu),        #dup elsewhere
+    MenuItem('Batch Sign', predicate=has_secrets, f=batch_sign),
     MenuItem('Sign Text File', predicate=has_secrets, f=sign_message_on_sd),
     #MenuItem('Upgrade Firmware', f=microsd_upgrade),
     MenuItem('Clone Coldcard', predicate=has_secrets, f=clone_write_data),

--- a/shared/utils.py
+++ b/shared/utils.py
@@ -480,7 +480,7 @@ def parse_extended_key(ln, private=False):
     return node, chain, addr_fmt
 
 
-def import_prompt_builder(title):
+def import_prompt_builder(title, no_nfc=False):
     from glob import NFC, VD
     prompt, escape = None, None
     if NFC or VD:
@@ -489,7 +489,7 @@ def import_prompt_builder(title):
         if VD is not None:
             prompt += ", press (2) to import from Virtual Disk"
             escape += "2"
-        if NFC is not None:
+        if NFC is not None and not no_nfc:
             prompt += ", press (3) to import via NFC"
             escape += "3"
         prompt += "."

--- a/testing/test_sign.py
+++ b/testing/test_sign.py
@@ -2010,4 +2010,56 @@ def test_send2taproot_addresss(fake_txn , start_sign, end_sign, cap_story):
     signed = end_sign(accept=True, finalize=False)
     assert signed
 
+
+@pytest.mark.parametrize("num_tx", [1, 2, 10])
+@pytest.mark.parametrize("action", ["sign", "skip", "refuse"])
+def test_batch_sign(num_tx, action, fake_txn, need_keypress, pick_menu_item,
+                    cap_story, microsd_path, microsd_wipe, goto_home):
+
+    goto_home()
+    microsd_wipe()
+
+    for i in range(num_tx):
+        psbt = fake_txn(2, 2, segwit_in=random.getrandbits(1))
+        with open(microsd_path(f"{i}.psbt"), "wb") as f:
+            f.write(psbt)
+
+    pick_menu_item("Advanced/Tools")
+    pick_menu_item("File Management")
+    pick_menu_item("Batch Sign")
+    time.sleep(.1)
+    title, story = cap_story()
+    if "Press (1)" in story:
+        need_keypress("1")
+        time.sleep(.1)
+        title, story = cap_story()
+
+    for i in range(num_tx):
+        assert "Sign" in story
+        assert "(1) to skip" in story
+        assert "X to quit and exit" in story
+        if action == "skip":
+            need_keypress("1")  # skip this PSBT
+            time.sleep(.5)
+            title, story = cap_story()
+            continue
+
+        need_keypress("y")  # sign this PSBT
+        time.sleep(.5)
+        title, story = cap_story()
+        assert title == "OK TO SEND?"
+        if action == "refuse":
+            need_keypress("x")  # refuse
+            time.sleep(.5)
+            title, story = cap_story()
+            continue
+
+        need_keypress("y")  # confirm send
+        time.sleep(.5)
+        title, story = cap_story()
+        assert "-signed.psbt" in story
+        need_keypress("y")
+        time.sleep(.5)
+        title, story = cap_story()
+
 # EOF


### PR DESCRIPTION
* basic batch sign for MicroSD and VDisk (gets all `.psbt` from target location)
* first story ask whether to sign this PSBT file (with filename in story). User can always confirm with OK to sign, press (1) to skip this specific PSBT, or X to abort batch sign completely
* if users chooses to sign - standard `ApproveTransaction` flow follows