### PR TITLE
Seed Vault

### DIFF
--- a/releases/ChangeLog.md
+++ b/releases/ChangeLog.md
@@ -1,6 +1,9 @@
 ## 5.1.3 - 2023-06-20
 
 - New Feature: Batch Sign PSBTs. `Advanced/Tools -> File Management -> Batch Sign PSBT`
+- New Feature: Seed Vault. Store ephemeral secrets in encrypted settings object for later use.
+  Enable Seed Vault functionality in `Advanced/Tools -> Danger Zone -> Seed Vault -> Enable`. 
+  Use stored seeds from Seed Vault with `Seed Vault` menu choice (shown once enabled).
 - Enhancement: change Key Origin Information export format in multisig `addresses.csv` to match
   [BIP-0380](https://github.com/bitcoin/bips/blob/master/bip-0380.mediawiki#key-expressions)
   was `(m=0F056943)/m/48'/1'/0'/2'/0/0` now `[0F056943/48'/1'/0'/2'/0/0]`

--- a/shared/actions.py
+++ b/shared/actions.py
@@ -579,6 +579,17 @@ def new_from_dice(menu, label, item):
     import seed
     return seed.new_from_dice(item.arg)
 
+async def save_bip39_to_vault(*a):
+    # save current seed+bip39 passphrase into the Seed Vault
+    # - only reachable if feature is enabled
+    import seed, stash
+    if not stash.bip39_passphrase:
+        await ux_show_story('''You do not have a BIP-39 passphrase set right now, \
+so this command is not useful.''')
+        return
+
+    await seed.remember_bip39_passphrase(True)
+
 async def convert_bip39_to_bip32(*a):
     import seed, stash
 

--- a/shared/actions.py
+++ b/shared/actions.py
@@ -1302,7 +1302,7 @@ async def import_extended_key_as_secret(extended_key, ephemeral):
     try:
         import seed
         if ephemeral:
-            await seed.set_ephemeral_seed_extended_key(extended_key)
+            await seed.set_ephemeral_seed_extended_key(extended_key, name='Imported')
         else:
             await seed.set_seed_extended_key(extended_key)
     except ValueError:
@@ -1369,7 +1369,6 @@ async def import_xprv(_1, _2, item):
                         break
 
     await import_extended_key_as_secret(extended_key, ephemeral)
-    # not reached; will do reset.
 
 EMPTY_RESTORE_MSG = '''\
 You must clear the wallet seed before restoring a backup because it replaces \

--- a/shared/actions.py
+++ b/shared/actions.py
@@ -2213,6 +2213,17 @@ async def change_virtdisk_enable(enable):
         glob.VD.shutdown()
         assert not glob.VD
 
+async def change_seed_vault(is_enabled):
+    # user has changed seed vault enable/disable flag
+    from glob import settings
+    if not is_enabled and settings.get('seeds'):
+        # restore it
+        settings.set('seedvault', True)
+        ch = await ux_show_story("Please remove all seeds from the vault before disabling")
+        return
+
+    goto_top_menu()
+
 async def change_which_chain(*a):
     # setting already changed, but reflect that value in other settings
     try:

--- a/shared/auth.py
+++ b/shared/auth.py
@@ -1219,7 +1219,7 @@ Press (2) to view the provided passphrase.\n\nOK to continue, X to cancel.''' % 
                 from seed import set_bip39_passphrase
 
                 # full screen message shown: "Working..."
-                set_bip39_passphrase(self._pw)
+                await set_bip39_passphrase(self._pw)
 
                 self.result = settings.get('xpub')
 

--- a/shared/backups.py
+++ b/shared/backups.py
@@ -5,13 +5,13 @@
 import compat7z, stash, ckcc, chains, gc, sys, bip39, uos, ngu
 from ubinascii import hexlify as b2a_hex
 from ubinascii import unhexlify as a2b_hex
-from utils import imported, xfp2str
+from utils import pad_raw_secret
 from ux import ux_show_story, ux_confirm, ux_dramatic_pause
 import version, ujson
 from uio import StringIO
 import seed
 from glob import settings
-from pincodes import pa, AE_SECRET_LEN
+from pincodes import pa
 
 # we make passwords with this number of words
 num_pw_words = const(12)
@@ -124,12 +124,9 @@ def restore_from_dict_ll(vals):
         chain = chains.get_chain(vals.get('chain', 'BTC'))
 
         assert 'raw_secret' in vals
-        raw = bytearray(AE_SECRET_LEN)
         rs = vals.pop('raw_secret')
-        if len(rs) % 2:
-            rs += '0'
-        x = a2b_hex(rs)
-        raw[0:len(x)] = x
+
+        raw = pad_raw_secret(rs)
 
         # check we can decode this right (might be different firmare)
         opmode, bits, node = stash.SecretStash.decode(raw)

--- a/shared/drv_entro.py
+++ b/shared/drv_entro.py
@@ -246,12 +246,8 @@ async def drv_entro_step2(_1, picked, _2):
     stash.blank_object(msg)
 
     if ch == '2' and (encoded is not None):
-        from glob import dis
-        from pincodes import pa
-
         # switch over to new secret!
-        dis.fullscreen("Applying...")
-        await seed.set_ephemeral_seed(encoded)
+        await seed.set_ephemeral_seed(encoded, name='Derived #%d' % index)
         from actions import goto_top_menu
         goto_top_menu()
 

--- a/shared/drv_entro.py
+++ b/shared/drv_entro.py
@@ -252,6 +252,8 @@ async def drv_entro_step2(_1, picked, _2):
         # switch over to new secret!
         dis.fullscreen("Applying...")
         await seed.set_ephemeral_seed(encoded)
+        from actions import goto_top_menu
+        goto_top_menu()
 
     if encoded is not None:
         stash.blank_object(encoded)

--- a/shared/flow.py
+++ b/shared/flow.py
@@ -9,7 +9,7 @@ from glob import settings
 from actions import *
 from choosers import *
 from multisig import make_multisig_menu, import_multisig_nfc
-from seed import make_ephemeral_seed_menu
+from seed import make_ephemeral_seed_menu, make_seed_vault_menu
 from address_explorer import address_explore
 from users import make_users_menu
 from drv_entro import drv_entro_start, password_entry
@@ -283,6 +283,9 @@ Keep blocked unless you intend to sign special transactions.'''),
         on_change=change_which_chain,
         story="Testnet must only be used by developers because \
 correctly- crafted transactions signed on Testnet could be broadcast on Mainnet."),
+    ToggleMenuItem('Seed Vault', 'seedvault', ['Default Off', 'Enable'],
+                   on_change=change_seed_vault,
+                   story="Enable Seed Vault? Adds prompt to store ephemeral secrets into Seed Vault, where they can easily to reused later."),
     MenuItem('Settings Space', f=show_settings_space),
     MenuItem('MCU Key Slots', predicate=lambda: version.has_se2, f=show_mcu_keys_left),
 ]
@@ -371,6 +374,7 @@ NormalSystem = [
     MenuItem('Start HSM Mode', f=start_hsm_menu_item, predicate=hsm_policy_available),
     MenuItem("Address Explorer", f=address_explore),
     MenuItem('Type Passwords', f=password_entry, predicate=lambda: settings.get("emu", False) and has_secrets()),
+    MenuItem('Seed Vault', menu=make_seed_vault_menu, predicate=lambda: settings.get('seedvault')),
     MenuItem('Secure Logout', f=logout_now),
     MenuItem('Advanced/Tools', menu=AdvancedNormalMenu),
     MenuItem('Settings', menu=SettingsMenu),

--- a/shared/flow.py
+++ b/shared/flow.py
@@ -257,9 +257,11 @@ SeedXORMenu = [
 ]
 
 SeedFunctionsMenu = [
+    #         xxxxxxxxxxxxxxxx
     MenuItem('View Seed Words', f=view_seed_words),     # text is a little wrong sometimes, rare
     MenuItem('Seed XOR', menu=SeedXORMenu),
     MenuItem("Destroy Seed", f=clear_seed),
+    MenuItem('Capture to Vault', f=save_bip39_to_vault, predicate=lambda: settings.get('seedvault')),
     MenuItem('Lock Down Seed', f=convert_bip39_to_bip32),
 ]
 

--- a/shared/nfc.py
+++ b/shared/nfc.py
@@ -579,7 +579,7 @@ class NFCHandler:
 
         try:
             from seed import set_ephemeral_seed_words
-            await set_ephemeral_seed_words(winner)
+            await set_ephemeral_seed_words(winner, name='NFC Import')
         except Exception as e:
             #import sys; sys.print_exception(e)
             await ux_show_story('Failed to import.\n\n%s\n%s' % (e, problem_file_line(e)))

--- a/shared/nvstore.py
+++ b/shared/nvstore.py
@@ -68,6 +68,8 @@ from glob import PSRAM
 #   cd_mode = [<=mk3] set to enable some less-destructive modes
 #   cd_pin = [<=mk3] pin code which enables "countdown to brick" mode
 #   kbtn =  (1 char) '1'-'9' that will wipe seed during login process (mk4+)
+#   seedvault = (bool) opt-in enable seed vault feature
+#   seeds = list of stored secrets for seedvault feature
 
 
 if mk_num <= 3:

--- a/shared/pincodes.py
+++ b/shared/pincodes.py
@@ -446,6 +446,7 @@ class PinAttempt:
 
     def tmp_secret(self, encoded, chain=None):
         # Use indicated secret and stop using the SE; operate like this until reboot
+        # - use None to clear and reset to normal
         self.tmp_value = bytes(encoded + bytes(AE_SECRET_LEN - len(encoded)))
 
         # We're no longer blank. hard to say about duress secret and stuff tho

--- a/shared/pwsave.py
+++ b/shared/pwsave.py
@@ -132,7 +132,7 @@ class PassphraseSaver:
         async def doit(menu, idx, item):
             # apply the password immediately and drop them at top menu
             pw, expect_xfp = item.arg
-            set_bip39_passphrase(pw)
+            await set_bip39_passphrase(pw)
 
             from glob import settings
             from utils import xfp2str

--- a/shared/seed.py
+++ b/shared/seed.py
@@ -444,7 +444,7 @@ async def set_ephemeral_seed(encoded, chain=None, is_restore=False):
         xfp = "[" + xfp2str(xfp) + "]\n"
 
     msg = xfp + "New ephemeral master key in effect until next power down."
-    if not saved or is_restore:
+    if not saved and not is_restore:
         msg += "\nIt is NOT stored anywhere."
     msg += "\n\nAll settings data stored in this mode will be lost on next power down."
 

--- a/shared/seed.py
+++ b/shared/seed.py
@@ -436,9 +436,11 @@ async def add_seed_to_vault(encoded):
         return True
 
 async def set_ephemeral_seed(encoded, chain=None, is_restore=False):
+    # Take encoded master secret and put it into effect as an ephemeral seed
     saved = is_restore or (await add_seed_to_vault(encoded))
     pa.tmp_secret(encoded, chain=chain)
     dis.progress_bar_show(1)
+
     xfp = settings.get("xfp", "")
     if xfp:
         xfp = "[" + xfp2str(xfp) + "]\n"

--- a/shared/stash.py
+++ b/shared/stash.py
@@ -127,6 +127,26 @@ class SecretStash:
 
             return 'master', ms, hd
 
+    @staticmethod
+    def summary(marker):
+        # decode enough to explain what we have in a text form
+        # - give us the first byte of the stored, encoded secret
+        if marker == 0x01:
+            # xprv => BIP-32 private key values
+            return 'xprv'
+
+        if marker & 0x80:
+            # seed phrase
+            ll = ((marker & 0x3) + 2) * 8
+            return '%d words' % len_to_numwords(ll)
+
+        if marker == 0x00:
+            # probably all zeros, which we don't normally store, and represents "no secret"
+            return 'zeros'
+
+        # variable-length master secret for BIP-32
+        return '%d bytes' % marker
+
 # optional global value: user-supplied passphrase to salt BIP-39 seed process
 bip39_passphrase = ''
 

--- a/shared/trick_pins.py
+++ b/shared/trick_pins.py
@@ -750,25 +750,23 @@ normal operation.''')
         # TC_BLANK_WALLET here would be nice, but no support working w/ fake empty secret
 
         # emulate stash.py encoding
+        name = 'Duress #%d' % (arg % 10)+1
         if flags & TC_XPRV_WALLET:
             encoded = b'\x01' + slot.xdata[0:64]
+            name = 'Mk3 Duress'
         elif flags & TC_WORD_WALLET and (arg // 1000 == 1):
             encoded = b'\x82' + slot.xdata[0:32]
         elif flags & TC_WORD_WALLET and (arg // 1000 == 2):
             encoded = b'\x80' + slot.xdata[0:16]
         else:
-            raise ValueError('f=0x%x a=%d' % (flags, arg))
+            raise ValueError            #('f=0x%x a=%d' % (flags, arg))
 
-        from glob import dis
+        from seed import set_ephemeral_seed
+        from actions import goto_top_menu
 
         # switch over to new secret!
-        dis.fullscreen("Applying...")
-        pa.tmp_secret(encoded)
+        await set_ephemeral_seed(encoded, name=name)
         tp.reload()
-
-        await ux_show_story("New master key in effect until next power down.")
-
-        from actions import goto_top_menu
         goto_top_menu()
 
     async def countdown_details(self, m, l, item):

--- a/shared/trick_pins.py
+++ b/shared/trick_pins.py
@@ -750,7 +750,7 @@ normal operation.''')
         # TC_BLANK_WALLET here would be nice, but no support working w/ fake empty secret
 
         # emulate stash.py encoding
-        name = 'Duress #%d' % (arg % 10)+1
+        name = 'Duress #%d' % (arg % 10)
         if flags & TC_XPRV_WALLET:
             encoded = b'\x01' + slot.xdata[0:64]
             name = 'Mk3 Duress'

--- a/shared/utils.py
+++ b/shared/utils.py
@@ -544,4 +544,15 @@ def addr_fmt_label(addr_fmt):
         AF_P2WPKH: "Segwit P2WPKH"
     }[addr_fmt]
 
+
+def pad_raw_secret(raw_sec_str):
+    from pincodes import AE_SECRET_LEN
+
+    raw = bytearray(AE_SECRET_LEN)
+    if len(raw_sec_str) % 2:
+        raw_sec_str += '0'
+    x = a2b_hex(raw_sec_str)
+    raw[0:len(x)] = x
+    return raw
+
 # EOF

--- a/shared/ux.py
+++ b/shared/ux.py
@@ -53,6 +53,12 @@ class UserInteraction:
         old = self.stack.pop()
         del old
 
+    def parent_of(self, child_ux):
+        for n, x in enumerate(self.stack):
+            if x == child_ux and n:
+                return self.stack[n-1]
+        return None
+
 # Singleton. User interacts with this "menu" stack.
 the_ux = UserInteraction()
 

--- a/shared/xor_seed.py
+++ b/shared/xor_seed.py
@@ -170,7 +170,8 @@ class XORWordNestMenu(WordNestMenu):
                 goto_top_menu(first_time=True)
             else:
                 # set as ephemeral seed, maybe save it too
-                await set_ephemeral_seed(enc)
+                await set_ephemeral_seed(enc, name='SeedXOR')
+                goto_top_menu()
 
         return None
 

--- a/shared/xor_seed.py
+++ b/shared/xor_seed.py
@@ -7,7 +7,7 @@
 #
 import stash, ngu, bip39, random
 from ux import ux_show_story, the_ux, ux_confirm, ux_dramatic_pause
-from seed import word_quiz, WordNestMenu, set_seed_value
+from seed import word_quiz, WordNestMenu, set_seed_value, set_ephemeral_seed
 from glob import settings
 from actions import goto_top_menu
 
@@ -169,8 +169,8 @@ class XORWordNestMenu(WordNestMenu):
                 # update menu contents now that wallet defined
                 goto_top_menu(first_time=True)
             else:
-                pa.tmp_secret(enc)
-                await ux_show_story("New master key in effect until next power down.")
+                # set as ephemeral seed, maybe save it too
+                await set_ephemeral_seed(enc)
 
         return None
 

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -1650,6 +1650,18 @@ def tapsigner_encrypted_backup(microsd_path, virtdisk_path):
         return fname, backup_key_hex, node
     return doit
 
+@pytest.fixture
+def choose_by_word_length(need_keypress):
+    # for use in seed XOR menu system
+    def doit(num_words):
+        if num_words == 12:
+            need_keypress('1')
+        elif num_words == 18:
+            need_keypress("2")
+        else:
+            need_keypress("y")
+    return doit
+
 
 # useful fixtures related to multisig
 from test_multisig import (import_ms_wallet, make_multisig, offer_ms_import, fake_ms_txn,

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -533,9 +533,8 @@ def get_secrets(sim_execfile):
         assert 'Error' not in resp
         for ln in resp.split('\n'):
             ln = ln.strip()
-            if '#' in ln:
-                ln = ln[0:ln.index('#')]
             if not ln: continue
+            if ln[0] == '#': continue
 
             assert ' = ' in ln
             n, v = ln.split(' = ', 1)

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -1661,6 +1661,9 @@ def choose_by_word_length(need_keypress):
             need_keypress("y")
     return doit
 
+# workaround: need these fixtures to be global so I can call test from a test
+from test_se2 import clear_all_tricks, new_trick_pin, new_pin_confirmed, goto_trick_menu, se2_gate
+
 
 # useful fixtures related to multisig
 from test_multisig import (import_ms_wallet, make_multisig, offer_ms_import, fake_ms_txn,

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -575,7 +575,7 @@ def pick_menu_item(cap_menu, need_keypress):
     WRAP_IF_OVER = 16       # see ../shared/menu.py
 
     def doit(text):
-        print(f"PICK menu item: {text}")
+        #print(f"PICK menu item: {text}")
         need_keypress('0')
         m = cap_menu()
         if text not in m:

--- a/testing/test_drv_entro.py
+++ b/testing/test_drv_entro.py
@@ -142,15 +142,13 @@ def test_bip_vectors(mode, index, entropy, expect,
             time.sleep(0.1)
             need_keypress('2')
 
-            if 0:   # screen was removed
-                time.sleep(0.1)
-                title, story = cap_story()
-                assert title == "WARNING"
-                assert 'Press (4) to prove you read to the end of this message and accept all consequences.' in story
-                need_keypress("4")
-
             time.sleep(0.1)
             title, story = cap_story()
+            if "Press (1) to store ephemeral secret into Seed Vault" in story:
+                need_keypress("y")  # do not store
+                time.sleep(0.1)
+                title, story = cap_story()
+
             assert 'master key in effect' in story
 
             encoded = sim_exec('from pincodes import pa; RV.write(repr(pa.fetch()))')

--- a/testing/test_ephemeral.py
+++ b/testing/test_ephemeral.py
@@ -683,7 +683,7 @@ def test_seed_vault_captures(request, dev, settings_set, settings_get,
     # - XOR seed restore
     # - Ephemeral keys menu: random and import
     # - Capture a BIP-39 passphrase into words
-    # - NOT YET: Trick pin -> duress wallet * 4 options
+    # - Trick pin -> duress wallet * 4 options
     # Then, verify those can all co-exist and be recalled correctly.
 
     reset_seed_words()
@@ -710,6 +710,11 @@ def test_seed_vault_captures(request, dev, settings_set, settings_get,
         assert 'Saved to Seed Vault' in story
         
         expect_count += 1
+
+    if 1:
+        # Trick Pin -> duress wallet
+        from test_se2 import build_duress_wallets
+        expect_count += build_duress_wallets(request)
 
     if 1:
         # Seed XOR of 12words into 3 parts... not simple, kinda slow

--- a/testing/test_ephemeral.py
+++ b/testing/test_ephemeral.py
@@ -556,7 +556,7 @@ def test_ephemeral_seed_import_xprv(way, retry, testnet, cap_menu, pick_menu_ite
     ("47649253", "344f9dc08e88b8a46d4b8f46c4e6bb6c", "crowd language ice brown merit fall release impose egg cheese put suit"),
     ("CC7BB706", "88f53ed897cc371ffe4b715c267206f3286ed2f655ba9d68", "material prepare renew convince sell morning weird hotel found crime like town manage harvest sun resemble output dolphin"),
     ("AC39935C", "956f484cc2136178fd1ad45faeb54972c829f65aad0d74eb2541b11984655893", "nice kid basket loud current round virtual fold garden interest false tortoise little will height payment insane float expire giraffe obscure crawl girl glare"),
-    ('939B32C4', '017caa3142d48791f837b42fcd7a98662f9fb4101a15ae87cdbc1fecc96f33c11ffcefd8121daaba0625c918a335a0712b8c35c2da60e6fc6eef78b7028f4be02a', None),      # BIP-85 -> bip-32 -> #23
+    ('939B32C4', '017caa3142d48791f837b42fcd7a98662f9fb4101a15ae87cdbc1fecc96f33c11ffcefd8121daaba0625c918a335a0712b8c35c2da60e6fc6eef78b7028f4be02a', None),      # BIP-85 -> BIP-32 -> #23
 ])
 def test_seed_vault_menus(dev, data, settings_set, settings_get, pick_menu_item, need_keypress, cap_story,
                     cap_menu, reset_seed_words, get_identity_story, get_seed_value_ux, fake_txn,
@@ -675,5 +675,20 @@ def test_seed_vault_menus(dev, data, settings_set, settings_get, pick_menu_item,
     reset_seed_words()
     time.sleep(.2)
     need_keypress("x")
+
+def test_seed_vault_captures(dev, data, settings_set, settings_get,
+                    pick_menu_item, need_keypress, cap_story,
+                    cap_menu, reset_seed_words, get_identity_story, get_seed_value_ux, fake_txn,
+                    try_sign, sim_exec, goto_home, goto_eph_seed_menu
+):
+    # Capture seeds by all the different paths and verify correct values are captured.
+    # - BIP-85 -> 12, 24 words
+    # - BIP-85 -> xprv (BIP-32)
+    # - Capture a BIP-39 passphrase into words
+    # - XOR seed restore
+    # Then, verify those can all co-exist and be recalled correctly.
+
+
+    pass
 
 # EOF

--- a/testing/test_ephemeral.py
+++ b/testing/test_ephemeral.py
@@ -115,50 +115,44 @@ def verify_ephemeral_secret_ui(cap_story, need_keypress, cap_menu, dev, goto_hom
         assert menu[0] == "Ready To Sign"  # returned to main menu
 
         if seed_vault:
-            # check seed is saved
+            # check exactly one seed is saved, then delete it
             pick_menu_item("Seed Vault")
             time.sleep(.1)
             sc_menu = cap_menu()
             assert len(sc_menu) == 1  # stored seed
-            for i in sc_menu:
-                if in_effect_xfp in i.split()[-1]:
-                    pick_menu_item(i)
-                    time.sleep(.1)
-                    m = cap_menu()
-                    assert "Use This Seed" in m
-                    assert "Delete" in m
-                    assert "Rename" in m
-                    assert len(m) == 4  # xfp is top item (works same as "Use this seed")
-                    # apply it - even if it is applied already
-                    pick_menu_item("Use This Seed")
-                    time.sleep(.1)
-                    _, story = cap_story()
-                    assert "Press (1)" not in story
-                    assert "key in effect until next power down." in story
-                    assert in_effect_xfp in story
-                    need_keypress("y")
-                    pick_menu_item("Seed Vault")
-                    pick_menu_item(i)
-                    time.sleep(.1)
-                    # delete it from records
-                    pick_menu_item("Delete")
-                    time.sleep(.1)
-                    _, story = cap_story()
-                    assert "Delete" in story
-                    assert in_effect_xfp in story
-                    need_keypress("y")
-                    time.sleep(.1)
-                    m = cap_menu()
-                    assert "(none saved yet)" in m
-                    assert len(m) == 1
-                    break
-            else:
-                raise pytest.fail("Failed to save seed?")
+            pick_menu_item(sc_menu[0])
+            time.sleep(.1)
+            m = cap_menu()
+            assert "Use This Seed" in m
+            assert "Delete" in m
+            assert "Rename" in m
+            assert len(m) == 4  # xfp is top item (works same as "Use this seed")
+            # apply it - even if it is applied already
+            pick_menu_item("Use This Seed")
+            time.sleep(.1)
+            _, story = cap_story()
+            assert "Press (1)" not in story
+            assert "key in effect until next power down." in story
+            assert in_effect_xfp in story
+            need_keypress("y")
+            pick_menu_item("Seed Vault")
+            pick_menu_item(sc_menu[0])
+            time.sleep(.1)
+            # delete it from records
+            pick_menu_item("Delete")
+            time.sleep(.1)
+            _, story = cap_story()
+            assert "Delete" in story
+            assert in_effect_xfp in story
+            need_keypress("y")
+            time.sleep(.1)
+            m = cap_menu()
+            assert "(none saved yet)" in m
+            assert len(m) == 1
         else:
             # Seed Vault disabled
             m = cap_menu()
             assert "Seed Vault" not in m
-
 
         ident_story = get_identity_story()
         assert "Ephemeral seed is in effect" in ident_story

--- a/testing/test_ephemeral.py
+++ b/testing/test_ephemeral.py
@@ -683,6 +683,7 @@ def test_seed_vault_captures(request, dev, settings_set, settings_get,
     # - XOR seed restore
     # - Ephemeral keys menu: random and import
     # - Capture a BIP-39 passphrase into words
+    # - NOT YET: Trick pin -> duress wallet * 4 options
     # Then, verify those can all co-exist and be recalled correctly.
 
     reset_seed_words()

--- a/testing/test_ephemeral.py
+++ b/testing/test_ephemeral.py
@@ -802,4 +802,9 @@ def test_seed_vault_captures(request, dev, settings_set, settings_get,
 
         assert raw == encoded_sec
 
+    # cleanup
+    reset_seed_words()
+    settings_set("seedvault", None)
+    settings_set("seeds", [])
+
 # EOF

--- a/testing/test_ephemeral.py
+++ b/testing/test_ephemeral.py
@@ -107,7 +107,7 @@ def verify_ephemeral_secret_ui(cap_story, need_keypress, cap_menu, dev, goto_hom
         assert menu[0] == "Ready To Sign"  # returned to main menu
 
         if seed_vault:
-            # check seed is saved in cache
+            # check seed is saved
             pick_menu_item("Seed Vault")
             time.sleep(.1)
             sc_menu = cap_menu()
@@ -132,7 +132,7 @@ def verify_ephemeral_secret_ui(cap_story, need_keypress, cap_menu, dev, goto_hom
                     pick_menu_item("Seed Vault")
                     pick_menu_item(i)
                     time.sleep(.1)
-                    # delete it from cache
+                    # delete it from records
                     pick_menu_item("Delete")
                     time.sleep(.1)
                     _, story = cap_story()
@@ -145,7 +145,7 @@ def verify_ephemeral_secret_ui(cap_story, need_keypress, cap_menu, dev, goto_hom
                     assert len(m) == 1
                     break
             else:
-                raise pytest.fail("Failed to cache seed?")
+                raise pytest.fail("Failed to save seed?")
         else:
             # Seed Vault disabled
             m = cap_menu()
@@ -553,8 +553,10 @@ def test_ephemeral_seed_import_xprv(way, retry, testnet, cap_menu, pick_menu_ite
 def test_seed_vault(dev, data, settings_set, settings_get, pick_menu_item, need_keypress, cap_story,
                     cap_menu, reset_seed_words, get_identity_story, get_seed_value_ux, fake_txn,
                     try_sign, sim_exec, goto_home, goto_eph_seed_menu):
-    cache_data, mnemonic = data
-    xfp, entropy = cache_data
+
+    # Verify "seed vault" feature works as intended
+
+    (xfp, entropy), mnemonic = data
     entropy_bytes = bytes.fromhex(entropy)
     vlen = len(entropy_bytes)
     assert vlen in [16, 24, 32]

--- a/testing/test_multisig.py
+++ b/testing/test_multisig.py
@@ -1925,7 +1925,7 @@ def test_ms_addr_explorer(descriptor, change, M, N, addr_fmt, make_multisig, cle
         path_mapper = lambda co_idx: str_to_path(derivs[co_idx]) + [chng_idx, idx]
         
         expect, pubkey, script, _ = make_ms_address(M, keys, idx=idx, addr_fmt=addr_fmt,
-                                                        path_mapper=path_mapper)
+                                                    path_mapper=path_mapper)
 
         assert int(subpath.split('/')[-1]) == idx
         #print('../0/%s => \n %s' % (idx, B2A(script)))

--- a/testing/test_seed_xor.py
+++ b/testing/test_seed_xor.py
@@ -149,7 +149,19 @@ def test_import_xor(incl_self, parts, expect, goto_home, pick_menu_item, cap_sto
 
     time.sleep(0.01)
     title, body = cap_story()
-    assert 'New master key in effect' in body
+
+    if 'into Seed Vault' in body:
+        # seed vault saving is enabled, use it
+        need_keypress('1')
+        time.sleep(0.01)
+        title, body = cap_story()
+        assert 'Saved to Seed Vault' in body
+
+        need_keypress('y')
+        time.sleep(0.01)
+        title, body = cap_story()
+
+    assert 'master key in effect until next power down' in body
 
     assert get_secrets()['mnemonic'] == expect
     reset_seed_words()

--- a/testing/test_seed_xor.py
+++ b/testing/test_seed_xor.py
@@ -47,17 +47,6 @@ def random_test_cases():
                                     [12, 18, 24]))  # mnemonic length
     return [(c, None) for c in comb]
 
-@pytest.fixture
-def choose_by_word_length(need_keypress):
-    def doit(num_words):
-        if num_words == 12:
-            need_keypress('1')
-        elif num_words == 18:
-            need_keypress("2")
-        else:
-            need_keypress("y")
-    return doit
-
 @pytest.mark.parametrize('incl_self', [False, True])
 @pytest.mark.parametrize('parts, expect', [
     # 24words - 3 parts
@@ -89,7 +78,7 @@ def choose_by_word_length(need_keypress):
 ])
 def test_import_xor(incl_self, parts, expect, goto_home, pick_menu_item, cap_story, need_keypress,
                     cap_menu, word_menu_entry, get_secrets, reset_seed_words, set_seed_words,
-                    choose_by_word_length):
+                    choose_by_word_length, save_to_vault=False):
 
     if expect is None:
         parts, expect = prepare_test_pairs(*parts)
@@ -119,8 +108,8 @@ def test_import_xor(incl_self, parts, expect, goto_home, pick_menu_item, cap_sto
 
     title, body = cap_story()
     assert 'you have a seed already' in body
-    assert '(1) to include this Coldcard' in body
     if incl_self:
+        assert '(1) to include this Coldcard' in body
         need_keypress('1')
     else:
         need_keypress('y')
@@ -151,13 +140,17 @@ def test_import_xor(incl_self, parts, expect, goto_home, pick_menu_item, cap_sto
     title, body = cap_story()
 
     if 'into Seed Vault' in body:
-        # seed vault saving is enabled, use it
-        need_keypress('1')
-        time.sleep(0.01)
-        title, body = cap_story()
-        assert 'Saved to Seed Vault' in body
+        # seed vault saving is enabled, use it, maybe
+        if save_to_vault:
+            need_keypress('1')
+            time.sleep(0.01)
+            title, body = cap_story()
+            assert 'Saved to Seed Vault' in body
 
-        need_keypress('y')
+            need_keypress('y')
+        else:
+            need_keypress('x')
+
         time.sleep(0.01)
         title, body = cap_story()
 


### PR DESCRIPTION
* offer to store/vault ephemeral secrets if opt-in enabled by user
* vault is in settings object (encrypted)
* user can easily switch to ephemeral seeds stored in Seed Vault

Seed Vault (if enabled) is inside `Advanced/Tools` -> `Seed Vault`: 

![snapshot-174-194946](https://github.com/Coldcard/firmware/assets/25349625/51ce3542-0477-4aad-898f-991315df1ada)

![snapshot-174-195002](https://github.com/Coldcard/firmware/assets/25349625/54f2f770-ed0d-456c-a79e-eb295a1d2c48)

![snapshot-174-195104](https://github.com/Coldcard/firmware/assets/25349625/7f84c585-6539-4878-b7aa-e5e01ea3ab44)


Stored seeds can be chosen based on secret XFP:

![snapshot-174-195154](https://github.com/Coldcard/firmware/assets/25349625/5bf5fd92-d6b3-4dfc-ac1a-bca6f9217502)

![snapshot-174-195158](https://github.com/Coldcard/firmware/assets/25349625/b831ed38-59f4-41fd-bfbe-0fef338e4a34)
