### PR TITLE
bug: xfp shown as integer in signing UI when bip39 passphrase in effect

### DIFF
--- a/releases/ChangeLog.md
+++ b/releases/ChangeLog.md
@@ -11,6 +11,7 @@
 - Bugfix: remove label from Bitcoin Core `importdescriptors` export as it is no longer supported
   with ranged descriptors in version `24.1` of Core.
 - Bugfix: empty number during BIP-39 passphrase entry could cause crash.
+- Bugfix: UX: Signing with BIP39 Passphrase showed master fingerprint as integer. Fixed to show hex. 
 
 ## 5.1.2 - 2023-04-07
 

--- a/shared/actions.py
+++ b/shared/actions.py
@@ -1750,7 +1750,7 @@ async def ready2sign(*a):
                                 max_size=MAX_TXN_LEN, taster=is_psbt)
 
     if stash.bip39_passphrase:
-        title = '[%s]' % settings.get('xfp')
+        title = '[%s]' % xfp2str(settings.get('xfp'))
     else:
         title = None
 

--- a/testing/test_ux.py
+++ b/testing/test_ux.py
@@ -964,6 +964,24 @@ def test_sign_file_from_list_files(f_len, goto_home, cap_story, pick_menu_item, 
     assert "List Files" in menu
 
 
+def test_bip39_pw_signing_xfp_ux(goto_home, pick_menu_item, need_keypress, cap_story,
+                                 enter_complex, reset_seed_words):
+    goto_home()
+    pick_menu_item("Passphrase")
+    need_keypress("y")
+    enter_complex("21coinkite21")
+    pick_menu_item("APPLY")
+    time.sleep(0.3)
+    title, _ = cap_story()
+    assert title == "[0C9DC99D]"
+    need_keypress("y")  # confirm new wallet
+    pick_menu_item("Ready To Sign")
+    time.sleep(0.1)
+    title_sign, _ = cap_story()
+    assert title == title_sign
+    reset_seed_words()  # for subsequent tests
+
+
 @pytest.mark.onetime
 def test_dump_menutree(sim_execfile):
     # saves to ../unix/work/menudump.txt


### PR DESCRIPTION
* MUST be hex (not int)
