### PR TITLE
bug: fix paper wallet error when no secrets

### DIFF
--- a/releases/ChangeLog.md
+++ b/releases/ChangeLog.md
@@ -11,7 +11,8 @@
 - Bugfix: remove label from Bitcoin Core `importdescriptors` export as it is no longer supported
   with ranged descriptors in version `24.1` of Core.
 - Bugfix: empty number during BIP-39 passphrase entry could cause crash.
-- Bugfix: UX: Signing with BIP39 Passphrase showed master fingerprint as integer. Fixed to show hex. 
+- Bugfix: UX: Signing with BIP39 Passphrase showed master fingerprint as integer. Fixed to show hex.
+- Bugfix: Fixed inability to generate paper wallet without secrets
 
 ## 5.1.2 - 2023-04-07
 


### PR DESCRIPTION
* bug: failure to generate backup without secrets. Would fail on signature file generation. Do NOT use `SensitiveValues` with no secrets - instead just use private key generated
