### PR TITLE
miniscript USB enroll

### DIFF
--- a/releases/EdgeChangeLog.md
+++ b/releases/EdgeChangeLog.md
@@ -7,6 +7,10 @@
 - for experimental use.  DO NOT use for large Bitcoin amounts.
 ```
 
+## 6.1.1X - 2023-08-XX
+
+- New Feature: Enroll Miniscript wallet via USB (requires ckcc `v1.4.0`)
+
 ## 6.1.0X - 2023-06-20
 
 - New Feature: Miniscript and MiniTapscript support (`docs/miniscript.md`)

--- a/shared/descriptor.py
+++ b/shared/descriptor.py
@@ -471,14 +471,18 @@ class Descriptor:
         return desc, checksum
 
     @classmethod
-    def from_string(cls, desc):
+    def from_string(cls, desc, checksum=False):
         desc = parse_desc_str(desc)
-        desc, checksum = cls.checksum_check(desc)
+        desc, cs = cls.checksum_check(desc)
         s = BytesIO(desc.encode())
         res = cls.read_from(s)
         left = s.read()
         if len(left) > 0:
             raise ValueError("Unexpected characters after descriptor: %r" % left)
+        if checksum:
+            if cs is None:
+                _, cs = res.to_string().split("#")
+            return res, cs
         return res
 
     @classmethod

--- a/shared/miniscript.py
+++ b/shared/miniscript.py
@@ -277,7 +277,11 @@ class MiniScriptWallet(BaseWallet):
     @classmethod
     def from_file(cls, config, name=None):
         from descriptor import Descriptor
-        desc_obj = Descriptor.from_string(config.strip())
+        if name is None:
+            desc_obj, cs = Descriptor.from_string(config.strip(), checksum=True)
+            name = cs
+        else:
+            desc_obj = Descriptor.from_string(config.strip())
         assert not desc_obj.is_basic_multisig, "Use Settings -> Multisig Wallets"
         wal = cls(desc_obj, name=name)
         return wal

--- a/shared/usb.py
+++ b/shared/usb.py
@@ -486,6 +486,21 @@ class USBHandler:
 
             return None
 
+        if cmd == 'mins':
+            # Enroll new xpubkey to be involved in miniscript.
+            # - descriptor text config file must already be uploaded
+
+            file_len, file_sha = unpack_from('<I32s', args)
+            if file_sha != self.file_checksum.digest():
+                return b'err_Checksum'
+            assert 100 < file_len <= (100*200), "badlen"
+
+            # Start an UX interaction, return immediately here
+            from auth import maybe_enroll_xpub
+            maybe_enroll_xpub(sf_len=file_len, ux_reset=True, miniscript=True)
+
+            return None
+
         if cmd == 'msck':
             # Quick check to test if we have a wallet already installed.
             from multisig import MultisigWallet


### PR DESCRIPTION
Add ability to enroll miniscript wallet via USB ckcc cmd `upload` with `--miniscript` flag.
