### PR TITLE
mainnet/testnet separation

### DIFF
--- a/releases/EdgeChangeLog.md
+++ b/releases/EdgeChangeLog.md
@@ -10,6 +10,8 @@
 ## 6.1.1X - 2023-08-XX
 
 - New Feature: Enroll Miniscript wallet via USB (requires ckcc `v1.4.0`)
+- Enhancement: mainnet/testnet separation. Only show wallets for current chain.
+- Bugfix: chain switching with miniscript wallet was not possible
 
 ## 6.1.0X - 2023-06-20
 

--- a/shared/auth.py
+++ b/shared/auth.py
@@ -1316,8 +1316,7 @@ class ShowP2SHAddress(ShowAddressBase):
 
         # calculate all the pubkeys involved.
         self.subpath_help = ms.validate_script(witdeem_script, xfp_paths=xfp_paths)
-
-        self.address = ms.chain.p2sh_address(addr_fmt, witdeem_script)
+        self.address = chains.current_chain().p2sh_address(addr_fmt, witdeem_script)
 
     def get_msg(self):
         return '''\

--- a/shared/chains.py
+++ b/shared/chains.py
@@ -356,7 +356,7 @@ class BitcoinRegtest(BitcoinMain):
 
 def get_chain(short_name):
     # lookup object from name: 'BTC' or 'XTN'
-    if short_name == 'BTC':
+    if short_name == 'BTC' or short_name is None:
         return BitcoinMain
     elif short_name == 'XTN':
         return BitcoinTestnet
@@ -374,6 +374,13 @@ def current_chain():
         return BitcoinMain
 
     return get_chain(chain)
+
+def current_key_chain():
+    c = current_chain()
+    if c == BitcoinRegtest:
+        # regtest has same extended keys as testnet
+        c = BitcoinTestnet
+    return c
 
 # Overbuilt: will only be testnet and mainchain.
 AllChains = [BitcoinMain, BitcoinTestnet, BitcoinRegtest]

--- a/shared/export.py
+++ b/shared/export.py
@@ -102,7 +102,8 @@ be needed for different systems.
             yield ('\n\n')
 
     from multisig import MultisigWallet
-    if MultisigWallet.exists():
+    exists, exists_other_chain = MultisigWallet.exists()
+    if exists:
         yield '\n# Your Multisig Wallets\n\n'
 
         for ms in MultisigWallet.get_all():

--- a/shared/utils.py
+++ b/shared/utils.py
@@ -573,7 +573,7 @@ def check_xpub(xfp, xpub, deriv, expect_chain, my_xfp, disable_checks=False):
         # HACK but there is no difference extended_keys - just bech32 hrp
         assert chain.ctype == "XTN"
     else:
-        assert chain.ctype == expect_chain      # 'wrong chain'
+        assert chain.ctype == expect_chain, 'wrong chain'
 
     depth = node.depth()
 

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -196,7 +196,7 @@ def enter_pin(enter_number, need_keypress, cap_screen):
 def master_xpub(dev):
     if hasattr(dev.dev, 'pipe'):
         # this works better against simulator in HSM mode, where the xpub cmd may be disabled
-        return simulator_fixed_xpub
+        return simulator_fixed_tpub
 
     r = dev.send_recv(CCProtocolPacker.get_xpub('m'), timeout=None, encrypt=1)
 
@@ -263,7 +263,7 @@ def addr_vs_path(master_xpub):
                     mk._netcode = "BTC"
                 sk = mk.subkey_for_path(path[2:])
             except PublicPrivateMismatchError:
-                mk = BIP32Node.from_wallet_key(simulator_fixed_xprv)
+                mk = BIP32Node.from_wallet_key(simulator_fixed_tprv)
                 if not testnet:
                     mk._netcode = "BTC"
                 sk = mk.subkey_for_path(path[2:])

--- a/testing/constants.py
+++ b/testing/constants.py
@@ -4,9 +4,12 @@
 SIM_PATH = '/tmp/ckcc-simulator.sock'
 
 # Simulator normally powers up with this 'wallet'
-simulator_fixed_xprv = "tprv8ZgxMBicQKsPeXJHL3vPPgTAEqQ5P2FD9qDeCQT4Cp1EMY5QkwMPWFxHdxHrxZhhcVRJ2m7BNWTz9Xre68y7mX5vCdMJ5qXMUfnrZ2si2X4"
+simulator_fixed_tprv = "tprv8ZgxMBicQKsPeXJHL3vPPgTAEqQ5P2FD9qDeCQT4Cp1EMY5QkwMPWFxHdxHrxZhhcVRJ2m7BNWTz9Xre68y7mX5vCdMJ5qXMUfnrZ2si2X4"
+simulator_fixed_tpub = "tpubD6NzVbkrYhZ4XzL5Dhayo67Gorv1YMS7j8pRUvVMd5odC2LBPLAygka9p7748JtSq82FNGPppFEz5xxZUdasBRCqJqXvUHq6xpnsMcYJzeh"
 
-simulator_fixed_xpub = "tpubD6NzVbkrYhZ4XzL5Dhayo67Gorv1YMS7j8pRUvVMd5odC2LBPLAygka9p7748JtSq82FNGPppFEz5xxZUdasBRCqJqXvUHq6xpnsMcYJzeh"
+# same wallet but mainnet BTC
+simulator_fixed_xprv = "xprv9s21ZrQH143K3i4kfV4tE2qAvhys9WDCpHJXKz2biqWkZwLKma1dzWaqin8CxCKPF3tX2fVRD9tBggJtxvdAxTpKfz8zRUoJZa3S7MtMgwy"
+simulator_fixed_xpub = "xpub661MyMwAqRbcGC9DmWbtbAmuUjpMYxw4BWE88NSDHB3jSjfUK7KtYJuKa52GbowD3DVLkgsxH9QwPnTx5mjdHykYFEncnmAsNsCTbWzBhA7"
 
 simulator_fixed_words = "wife shiver author away frog air rough vanish fantasy frozen noodle athlete pioneer citizen symptom firm much faith extend rare axis garment kiwi clarify"
 

--- a/testing/test_ephemeral.py
+++ b/testing/test_ephemeral.py
@@ -4,7 +4,7 @@
 #
 import pytest, time, re, os, shutil
 
-from constants import simulator_fixed_xpub
+from constants import simulator_fixed_tpub
 from ckcc.protocol import CCProtocolPacker
 from txn import fake_txn
 from test_ux import word_menu_entry
@@ -117,7 +117,7 @@ def verify_ephemeral_secret_ui(cap_story, need_keypress, cap_menu, dev, goto_hom
             assert mnemonic == seed_words
 
         e_master_xpub = dev.send_recv(CCProtocolPacker.get_xpub(), timeout=5000)
-        assert e_master_xpub != simulator_fixed_xpub
+        assert e_master_xpub != simulator_fixed_tpub
         if xpub:
             assert e_master_xpub == xpub
         psbt = fake_txn(2, 2, master_xpub=e_master_xpub, segwit_in=True)

--- a/testing/test_export.py
+++ b/testing/test_export.py
@@ -13,7 +13,7 @@ from pycoin.key.BIP32Node import BIP32Node
 from pycoin.contrib.segwit_addr import encode as sw_encode
 from ckcc_protocol.constants import *
 from helpers import xfp2str, slip132undo
-from conftest import simulator_fixed_xfp, simulator_fixed_xprv, simulator_fixed_words
+from conftest import simulator_fixed_xfp, simulator_fixed_tprv, simulator_fixed_words
 from ckcc_protocol.constants import AF_CLASSIC, AF_P2WPKH
 from pprint import pprint
 
@@ -75,7 +75,7 @@ def test_export_core(way, dev, use_regtest, acct_num, pick_menu_item, goto_home,
                 imd_js = ln[19:-2]
         elif '=>' in ln:
             path, addr = ln.strip().split(' => ', 1)
-            sk = BIP32Node.from_wallet_key(simulator_fixed_xprv).subkey_for_path(path[2:])
+            sk = BIP32Node.from_wallet_key(simulator_fixed_tprv).subkey_for_path(path[2:])
             if path.startswith(f"m/86'/1'/{acct_num}'/0"):
                 assert addr.startswith('bcrt1p')  # TODO here we should differentiate if testnet or smthg
                 sec = sk.sec()
@@ -109,7 +109,7 @@ def test_export_core(way, dev, use_regtest, acct_num, pick_menu_item, goto_home,
             assert len(chk) == 8
             assert desc.startswith(f'wpkh([{xfp}/84h/1h/{acct_num}h]')
 
-            expect = BIP32Node.from_wallet_key(simulator_fixed_xprv)\
+            expect = BIP32Node.from_wallet_key(simulator_fixed_tprv)\
                         .subkey_for_path(f"84'/1'/{acct_num}'.pub").hwif()
 
             assert expect in desc
@@ -135,7 +135,7 @@ def test_export_core(way, dev, use_regtest, acct_num, pick_menu_item, goto_home,
         assert len(chk) == 8
         assert desc.startswith(f'wpkh([{xfp}/84h/1h/{acct_num}h]')
 
-        expect = BIP32Node.from_wallet_key(simulator_fixed_xprv) \
+        expect = BIP32Node.from_wallet_key(simulator_fixed_tprv) \
             .subkey_for_path(f"84'/1'/{acct_num}'.pub").hwif()
 
         assert expect in desc
@@ -152,7 +152,7 @@ def test_export_core(way, dev, use_regtest, acct_num, pick_menu_item, goto_home,
         assert x['iswitness'] == True
         assert x['solvable'] == True
         assert x['hdmasterfingerprint'] == xfp2str(dev.master_fingerprint).lower()
-        assert x['hdkeypath'] == f"m/84'/1'/{acct_num}'/0/%d" % 2
+        assert x['hdkeypath'].replace("'", "h") == f"m/84h/1h/{acct_num}h/0/%d" % 2
 
     assert imd_js_tr
     obj = json.loads(imd_js_tr)
@@ -166,7 +166,7 @@ def test_export_core(way, dev, use_regtest, acct_num, pick_menu_item, goto_home,
 
         assert desc.startswith(f'tr([{xfp}/86h/1h/{acct_num}h]')
 
-        expect = BIP32Node.from_wallet_key(simulator_fixed_xprv) \
+        expect = BIP32Node.from_wallet_key(simulator_fixed_tprv) \
             .subkey_for_path(f"86'/1'/{acct_num}'.pub").hwif()
 
         assert expect in desc
@@ -184,7 +184,7 @@ def test_export_core(way, dev, use_regtest, acct_num, pick_menu_item, goto_home,
         assert x['iswitness'] == True
         assert x['solvable'] == True
         assert x['hdmasterfingerprint'] == xfp2str(dev.master_fingerprint).lower()
-        assert x['hdkeypath'] == f"m/86'/1'/{acct_num}'/0/%d" % 2
+        assert x['hdkeypath'].replace("'", "h") == f"m/86h/1h/{acct_num}h/0/%d" % 2
 
 
 @pytest.mark.parametrize('way', ["sd", "vdisk", "nfc"])
@@ -219,7 +219,7 @@ def test_export_wasabi(way, dev, pick_menu_item, goto_home, cap_story, need_keyp
     assert obj['MasterFingerprint'] == xfp2str(simulator_fixed_xfp)
 
     got = BIP32Node.from_wallet_key(xpub)
-    expect = BIP32Node.from_wallet_key(simulator_fixed_xprv).subkey_for_path(f"84'/{int(testnet)}'/0'.pub")
+    expect = BIP32Node.from_wallet_key(simulator_fixed_tprv).subkey_for_path(f"84'/{int(testnet)}'/0'.pub")
 
     assert got.sec() == expect.sec()
 
@@ -286,7 +286,7 @@ def test_export_electrum(way, dev, mode, acct_num, pick_menu_item, goto_home, ca
         # no slip132 here
 
         got = BIP32Node.from_wallet_key(xpub)
-        expect = BIP32Node.from_wallet_key(simulator_fixed_xprv).subkey_for_path(deriv[2:])
+        expect = BIP32Node.from_wallet_key(simulator_fixed_tprv).subkey_for_path(deriv[2:])
 
         assert got.sec() == expect.sec()
 
@@ -404,7 +404,7 @@ def test_export_unchained(way, dev, pick_menu_item, goto_home, cap_story, need_k
 
     obj = load_export(way, label="Unchained", is_json=True, sig_check=False)
 
-    root = BIP32Node.from_wallet_key(simulator_fixed_xprv)
+    root = BIP32Node.from_wallet_key(simulator_fixed_tprv)
     if not testnet:
         root._netcode = "BTC"
     assert obj['xfp'] == xfp2str(simulator_fixed_xfp)
@@ -450,7 +450,7 @@ def test_export_public_txt(way, dev, pick_menu_item, goto_home, need_keypress, m
 
     xfp = xfp2str(simulator_fixed_xfp).upper()
 
-    root = BIP32Node.from_wallet_key(simulator_fixed_xprv)
+    root = BIP32Node.from_wallet_key(simulator_fixed_tprv)
     if not testnet:
         root._netcode = "BTC"
     for ln in fp:
@@ -563,7 +563,7 @@ def test_export_xpub(use_nfc, acct_num, dev, cap_menu, pick_menu_item, goto_home
 
         got = BIP32Node.from_wallet_key(got_pub)
 
-        wallet = BIP32Node.from_wallet_key(simulator_fixed_xprv)
+        wallet = BIP32Node.from_wallet_key(simulator_fixed_tprv)
         if expect != 'm':
             wallet = wallet.subkey_for_path(expect[2:])
         assert got.sec() == wallet.sec()

--- a/testing/test_pwsave.py
+++ b/testing/test_pwsave.py
@@ -5,7 +5,7 @@
 import pytest, time, os
 from test_ux import word_menu_entry, enter_complex
 from binascii import b2a_hex, a2b_hex
-from constants import simulator_fixed_xprv
+from constants import simulator_fixed_tprv
 
 SIM_FNAME = '../unix/work/MicroSD/.tmp.tmp'
 
@@ -128,7 +128,7 @@ p=PassphraseSaver(); p._calc_key(cs); RV.write(b2a_hex(p.key)); cs.__exit__()'''
     from pycoin.encoding import from_bytes_32, to_bytes_32
     from hashlib import sha256
 
-    mk = BIP32Node.from_wallet_key(simulator_fixed_xprv)
+    mk = BIP32Node.from_wallet_key(simulator_fixed_tprv)
 
     sk = mk.subkey_for_path('2147431408p/0p')
 

--- a/testing/test_ux.py
+++ b/testing/test_ux.py
@@ -758,7 +758,6 @@ def test_bip39_complex(target, goto_home, pick_menu_item, cap_story,
 @pytest.mark.parametrize('b39_word', ['', 'AbcZz1203'])
 def test_show_seed(mode, b39_word, goto_home, pick_menu_item, cap_story, need_keypress, sim_exec,
                 cap_menu, get_pp_sofar, get_secrets, cap_screen_qr, set_encoded_secret, qr_quality_check):
-    from constants import simulator_fixed_xprv
 
     if mode == 'words':
         # Check the seed words are displayed correctly: the new "View Seed Words" feature

--- a/testing/txn.py
+++ b/testing/txn.py
@@ -8,7 +8,7 @@ from psbt import BasicPSBT, BasicPSBTInput, BasicPSBTOutput
 from io import BytesIO
 from helpers import fake_dest_addr, make_change_addr, taptweak
 from pycoin.key.BIP32Node import BIP32Node
-from constants import ADDR_STYLES, simulator_fixed_xprv
+from constants import ADDR_STYLES, simulator_fixed_tprv
 
 @pytest.fixture()
 def simple_fake_txn():
@@ -66,7 +66,7 @@ def fake_txn(dev):
                 change_outputs=[], capture_scripts=None, add_xpub=None, op_return=None, taproot_in=False):
         psbt = BasicPSBT()
         txn = Tx(2,[],[])
-        master_xpub = master_xpub or dev.master_xpub or simulator_fixed_xprv
+        master_xpub = master_xpub or dev.master_xpub or simulator_fixed_tprv
         
         # we have a key; use it to provide "plausible" value inputs
         mk = BIP32Node.from_wallet_key(master_xpub)


### PR DESCRIPTION
BUGFIX:
* checking chain in `parse_key` cause inability to use Minscript wallets after chain is switched
* moving chain validation from `parse_key` to `Descriptor.validate` resolves the issue

ENHANCEMENT:
* only show imported complex scripts (multisig, miniscript) on matching chain
* non-matching chain wallets are not shown
* switching XRT <-> XTN is allowed
