### PR TITLE
preserve defined order of chooser in Login Countdown

### DIFF
--- a/releases/ChangeLog.md
+++ b/releases/ChangeLog.md
@@ -19,6 +19,7 @@
   SD2FA is not backed up and also not restored from older backups. If SD2FA is set up,
   it will not survive restore of backup.
 - Bugfix: TOS only presented if main PIN was not chosen already.
+- Bugfix: preserve defined order of Login Countdown chooser
 
 
 ## 5.1.2 - 2023-04-07

--- a/shared/countdowns.py
+++ b/shared/countdowns.py
@@ -2,28 +2,30 @@
 #
 # countdowns.py - various details and chooser menus for setting/showing countdown times
 #
-from glob import settings
+from ucollections import OrderedDict
 from nvstore import SettingsObject
 from menu import MenuItem
 from ux import ux_show_story, ux_dramatic_pause
 
 # Login countdown length, stored in minutes
 #
-lgto_map = {  
-         0: 'Disabled',
-         5: ' 5 minutes',
-        15: '15 minutes',
-        30: '30 minutes',
-        60: ' 1 hour',
-      2*60: ' 2 hours',
-      4*60: ' 4 hours',
-      8*60: ' 8 hours',
-     12*60: '12 hours',
-     24*60: '24 hours',
-     48*60: '48 hours',
-   3*24*60: ' 3 days',
-   7*24*60: ' 1 week',
-  28*24*60: '28 days later' }
+lgto_map = OrderedDict([
+    (0, 'Disabled'),
+    (5, ' 5 minutes'),
+    (15, '15 minutes'),
+    (30, '30 minutes'),
+    (60, ' 1 hour'),
+    (2*60, ' 2 hours'),
+    (4*60, ' 4 hours'),
+    (8*60, ' 8 hours'),
+    (12*60, '12 hours'),
+    (24*60, '24 hours'),
+    (48*60, '48 hours'),
+    (3*24*60, ' 3 days'),
+    (7*24*60, ' 1 week'),
+    (28*24*60, '28 days later'),
+])
+
 lgto_va = list(lgto_map.keys())
 lgto_ch = list(lgto_map.values())
 


### PR DESCRIPTION
* values in chooser were unordered

![259334805-f8ab4dfa-0b5b-41d8-abb6-c99c28466f4a](https://github.com/Coldcard/firmware/assets/25349625/c9e31d5c-d7b8-4b10-9b6d-16659c50a99d)


* used `OrderedDict` instead of `dict`
