### PR TITLE
accept TOS only presented if `pa.is_blank=True` and `settings.terms_ok=False`

### DIFF
--- a/releases/ChangeLog.md
+++ b/releases/ChangeLog.md
@@ -17,6 +17,7 @@
   Prevents infinite seed wipe loop when restoring backup after 2FA MicroSD lost or damaged.
   SD2FA is not backed up and also not restored from older backups. If SD2FA is set up,
   it will not survive restore of backup.
+- Bugfix: TOS only presented if main PIN was not chosen already.
 
 
 ## 5.1.2 - 2023-04-07

--- a/shared/auth.py
+++ b/shared/auth.py
@@ -362,7 +362,7 @@ def sign_msg(text, subpath, addr_fmt):
     abort_and_goto(UserAuthorizedAction.active_request)
 
 
-def sign_txt_file(filename):
+async def sign_txt_file(filename):
     # sign a one-line text file found on a MicroSD card
     # - not yet clear how to do address types other than 'classic'
     from files import CardSlot, CardMissingError
@@ -385,7 +385,7 @@ def sign_txt_file(filename):
     if not addr_fmt:
         addr_fmt = AF_CLASSIC
 
-    def done(signature, address, text):
+    async def done(signature, address, text):
         # complete. write out result
         from glob import dis
 
@@ -821,7 +821,7 @@ class ApproveTransaction(UserAuthorizedAction):
         #if NFC:
             #NFC.share_signed_psbt(TXN_OUTPUT_OFFSET, self.result[0], self.result[1])
 
-    def save_visualization(self, msg, sign_text=False):
+    async def save_visualization(self, msg, sign_text=False):
         # write text into spi flash, maybe signing it as we go
         # - return length and checksum
         txt_len = msg.seek(0, 2)
@@ -840,7 +840,6 @@ class ApproveTransaction(UserAuthorizedAction):
                 fd.write(blk)
 
             if chk:
-                from ubinascii import b2a_base64
                 # append the signature
                 digest = ngu.hash.sha256s(chk.digest())
                 sig = sign_message_digest(digest, 'm', None, AF_CLASSIC)[0]

--- a/shared/drv_entro.py
+++ b/shared/drv_entro.py
@@ -17,7 +17,7 @@ from utils import chunk_writer
 
 BIP85_PWD_LEN = 21
 
-def drv_entro_start(*a):
+async def drv_entro_start(*a):
 
     # UX entry
     ch = await ux_show_story('''\

--- a/shared/main.py
+++ b/shared/main.py
@@ -69,7 +69,7 @@ async def more_setup():
     # Boot up code; splash screen is being shown
                 
     # MAYBE: check if we're a brick and die again? Or show msg?
-    
+
     try:
         from files import CardSlot
         CardSlot.setup()
@@ -78,7 +78,9 @@ async def more_setup():
         try:
             from pincodes import pa
             pa.setup(b'')       # just to see where we stand.
+            is_blank = pa.is_blank()
         except RuntimeError as e:
+            is_blank = True
             print("Problem: %r" % e)
 
         if version.is_factory_mode:
@@ -92,8 +94,9 @@ async def more_setup():
                 from actions import start_selftest
                 await start_selftest()
 
-        else:
-            # force them to accept terms (unless marked as already done)
+        elif is_blank:
+            # force them to accept terms (unless marked as already done in settings)
+            # only if no main PIN chosen
             from actions import accept_terms
             await accept_terms()
 


### PR DESCRIPTION
* currently "accept TOS" is presented even if CC has main PIN already set and somehow settings are corrupted or wiped with `Wipe LFS` (because `settings.terms_ok=False`)
* unrelated: added some missing `async` keywords for functions that use `await`. Works even without it as mpy treats any function with `await` statement in it as coroutine
