### PR TITLE
tests: Pillow `textsize` removed in 10.0.0

### DIFF
--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -448,7 +448,9 @@ def qr_quality_check():
             fnt = ImageFont.load_default()
 
     dr = ImageDraw.Draw(rv)
-    mw = int((w*scale) / dr.textsize('M', fnt)[0])
+    left, top, right, bottom = dr.textbbox((0, 0), text='M', font=fnt)
+    size = (right - left, bottom - top)
+    mw = int((w*scale) / size[0])
 
     for test_name, img in QR_HISTORY:
         if '[' in test_name:


### PR DESCRIPTION
`AttributeError: 'ImageDraw' object has no attribute 'textsize'`

`ImageDraw.Draw.textsize` was deprecated in Pillow==9.2.0 and removed in latest version 10.0.0

