### PR TITLE
BIP39 passphrase as ephemeral seed; Lock Down Seed for all ephemeral;BIP-39 wallet backup

### DIFF
--- a/docs/backup-files.md
+++ b/docs/backup-files.md
@@ -38,6 +38,17 @@ a single file, which is a simple text file and
 easy to read. Before version 4.0.0, this text file was always
 called `ckcc-backup.txt`, but the filename is now picked randomly.
 
+## BIP39 Passphrase
+
+If BIP39 passphrase is active the default behavior is to back-up
+main wallet - not BIP39 passphrase wallet. From version `5.2.0`
+users can choose to back-up also BIP39 passphrase wallet.
+
+## Ephemeral Seeds
+
+If ephemeral seed is active the default behavior is to always 
+back-up ephemeral wallet instead of the main wallet.
+
 ## Limitations
 
 - The archive file names are not encrypted. You can see there is a single

--- a/releases/ChangeLog.md
+++ b/releases/ChangeLog.md
@@ -1,11 +1,19 @@
 ## 5.2.0 - 2023-09-21
 
+- New Feature: `Lock Down Seed` now works with every ephemeral secret (not just BIP39 passphrase)
+- New Feature: BIP-39 Passphrase can now be added to word based Ephemeral Seeds
+- New Feature: Add ability to back-up BIP39 Passphrase wallet
 - Enhancement: Shortcut to `Batch Sign PSBT` via `Ready To Sign` -> `Press (9)`
 - Enhancement: Old plausible deniability feature on fresh COLDCARD removed.
   Only needed for Mk 2-3 where SPI flash was external chip, 
   easily observed, but now that's different. New simpler and less storage
   wasteful plausible deniability.
 - Enhancement: Remove obsolete Mk2/Mk3 code-paths from master branch
+- Enhancement: BIP39 Passphrase is now internally handled as an ephemeral secret.
+  Ability to see BIP-39 Passphrase after wallet is active via `View Seed Words`
+  was removed as a consequence of this change.
+- Enhancement: Showing secrets now also display extended private key for BIP-39
+  passphrase wallets.
 
 ## 5.1.4 - 2023-09-08
 

--- a/shared/actions.py
+++ b/shared/actions.py
@@ -108,8 +108,7 @@ Extended Master Key:
 
     if stash.bip39_passphrase:
         msg += '\nBIP-39 passphrase is in effect.\n'
-
-    if pa.tmp_value:
+    elif pa.tmp_value:
         msg += '\nEphemeral seed is in effect.\n'
 
     bn = callgate.get_bag_number()
@@ -555,22 +554,42 @@ def new_from_dice(menu, label, item):
     import seed
     return seed.new_from_dice(item.arg)
 
-async def convert_bip39_to_bip32(*a):
-    import seed, stash
+async def convert_ephemeral_to_master(*a):
+    import seed
+    from pincodes import pa
+    from stash import bip39_passphrase
 
-    if not await ux_confirm('''This operation computes the extended master private key using your BIP-39 seed words and passphrase, and then saves the resulting value (xprv) as the wallet secret.
+    if not pa.tmp_value:
+        await ux_show_story('You do not have an active ephemeral seed (including BIP-39 passphrase)'
+                            ' right now, so this command does little except forget the seed words.'
+                            ' It does not enhance security in any way.')
+        return
 
-The seed words themselves are erased forever, but effectively there is no other change. If a BIP-39 passphrase is currently in effect, its value is captured during this process and will be 'in effect' going forward, but the passphrase itself is erased and unrecoverable. The resulting wallet cannot be used with any other passphrase.
+    words = settings.get("words", True)
+    msg = 'Convert currently used '
+    msg += 'BIP-39 passphrase ' if bip39_passphrase else 'ephemeral seed '
+    msg += 'to main seed. '
+    if words or bip39_passphrase:
+        msg += 'Main seed words themselves are erased forever, '
+    else:
+        msg += 'Main seed is erased forever, '
 
-A reboot is part of this process. PIN code, and funds are not affected.
-'''):
+    msg += 'but effectively there is no other change. '
+
+    if bip39_passphrase:
+        msg += ('BIP-39 passphrase is currently in effect, its value '
+                'is captured during this process and will be in effect '
+                'going forward, but the passphrase itself is erased '
+                'and unrecoverable. ')
+    if not words:
+        msg += 'The resulting wallet cannot be used with any other passphrase. '
+
+    msg += 'A reboot is part of this process. PIN code, and funds are not affected.'
+    if not await ux_confirm(msg):
+
         return await ux_aborted()
 
-    if not stash.bip39_passphrase:
-        if not await ux_confirm('''You do not have a BIP-39 passphrase set right now, so this command does little except forget the seed words. It does not enhance security.'''):
-            return
-
-    await seed.remember_bip39_passphrase()
+    await seed.remember_ephemeral_seed()
 
     settings.save()
 
@@ -612,8 +631,9 @@ consequences.''', escape='4')
 
 def render_master_secrets(mode, raw, node):
     # Render list of words, or XPRV / master secret to text.
-    import stash
+    import stash, chains
 
+    c = chains.current_chain()
     qr_alnum = False
 
     if mode == 'words':
@@ -628,12 +648,14 @@ def render_master_secrets(mode, raw, node):
         msg = 'Seed words (%d):\n' % len(words)
         msg += '\n'.join('%2d: %s' % (i+1, w) for i,w in enumerate(words))
 
-        pw = stash.bip39_passphrase
-        if pw:
-            msg += '\n\nBIP-39 Passphrase:\n%s' % pw
+        if stash.bip39_passphrase:
+            msg += '\n\nBIP-39 Passphrase:\n    *****'
+            if node:
+                msg += '\n\nSeed+Passphrase:\n%s' % c.serialize_private(node)
+
+
     elif mode == 'xprv':
-        import chains
-        msg = chains.current_chain().serialize_private(node)
+        msg = c.serialize_private(node)
         qr = msg
 
     elif mode == 'master':
@@ -648,21 +670,40 @@ def render_master_secrets(mode, raw, node):
 async def view_seed_words(*a):
     import stash
 
-    if not await ux_confirm('''The next screen will show the seed words (and if defined, your BIP-39 passphrase).\n\nAnyone with knowledge of those words can control all funds in this wallet.''' ):
+    if not await ux_confirm('The next screen will show the seed words'
+                            ' (and if defined, your BIP-39 passphrase).'
+                            '\n\nAnyone with knowledge of those words '
+                            'can control all funds in this wallet.'):
         return
 
     from glob import dis
     dis.fullscreen("Wait...")
     dis.busy_bar(True)
 
-    with stash.SensitiveValues() as sv:
+    # preserve old UI where we show words + passphrase
+    # instead of just calculated seed + passphrase = extended privkey
+    # new: calculated xprv is now also shown for BIP39 passphrase wallet
+    raw = mode = None
+    if stash.bip39_passphrase:
+        # get main secret - bypass tmp
+        with stash.SensitiveValues(bypass_tmp=True) as sv:
+            if not sv.deltamode:
+                assert sv.mode == "words"
+                raw = sv.raw[:]
+                mode = sv.mode
+
+        stash.SensitiveValues.clear_cache()
+
+    with stash.SensitiveValues(bypass_tmp=False) as sv:
         if sv.deltamode:
             # give up and wipe self rather than show true seed values.
             import callgate
             callgate.fast_wipe()
 
         dis.busy_bar(False)
-        msg, qr, qr_alnum = render_master_secrets(sv.mode, sv.raw, sv.node)
+        msg, qr, qr_alnum = render_master_secrets(mode or sv.mode,
+                                                  raw or sv.raw,
+                                                  sv.node)
 
         msg += '\n\nPress (1) to view as QR Code.'
 
@@ -674,8 +715,9 @@ async def view_seed_words(*a):
                 continue
             break
 
-        stash.blank_object(qr)
-        stash.blank_object(msg)
+    stash.blank_object(qr)
+    stash.blank_object(msg)
+    stash.blank_object(raw)
 
 async def damage_myself():
     # called when it's time to disable ourselves due to various
@@ -1702,13 +1744,14 @@ async def ready2sign(*a):
     # - if no card, check virtual disk for PSBT
     # - if still nothing, then talk about USB connection
     import stash
+    from pincodes import pa
     from glob import NFC
 
     # just check if we have candidates, no UI
     choices = await file_picker(None, suffix='psbt', min_size=50,
                                 max_size=MAX_TXN_LEN, taster=is_psbt)
 
-    if stash.bip39_passphrase:
+    if pa.tmp_value:
         title = '[%s]' % xfp2str(settings.get('xfp'))
     else:
         title = None

--- a/shared/auth.py
+++ b/shared/auth.py
@@ -1217,7 +1217,7 @@ Press (2) to view the provided passphrase.\n\nOK to continue, X to cancel.''' % 
                 from seed import set_bip39_passphrase
 
                 # full screen message shown: "Working..."
-                set_bip39_passphrase(self._pw)
+                await set_bip39_passphrase(self._pw, summarize_ux=False)
 
                 self.result = settings.get('xpub')
 
@@ -1230,8 +1230,9 @@ Press (2) to view the provided passphrase.\n\nOK to continue, X to cancel.''' % 
 
         if self.result:
             new_xfp = settings.get('xfp')
-            await ux_show_story('''Above is the master key fingerprint of the current wallet.''',
-                            title="[%s]" % xfp2str(new_xfp))
+            await ux_show_story('Above is the master key fingerprint '
+                                'of the current wallet.',
+                                title="[%s]" % xfp2str(new_xfp))
 
 
 def start_bip39_passphrase(pw):

--- a/shared/drv_entro.py
+++ b/shared/drv_entro.py
@@ -18,6 +18,7 @@ from utils import chunk_writer
 BIP85_PWD_LEN = 21
 
 async def drv_entro_start(*a):
+    from pincodes import pa
 
     # UX entry
     ch = await ux_show_story('''\
@@ -36,8 +37,14 @@ so the other wallet is effectively segregated from the Coldcard and yet \
 still backed-up.''')
     if ch != 'y': return
 
-    if stash.bip39_passphrase:
-        if not await ux_confirm('''You have a BIP-39 passphrase set right now and so that will become wrapped into the new secret.'''):
+    if pa.tmp_value:
+        if stash.bip39_passphrase:
+            msg = ('You have a BIP-39 passphrase set right now '
+                   'and so it will be wrapped into the new secret.')
+        else:
+            msg = 'You have an ephemeral seed - deriving from ephemeral.'
+
+        if not await ux_confirm(msg):
             return
 
     choices = [ '12 words', '18 words', '24 words', 'WIF (privkey)',

--- a/shared/flow.py
+++ b/shared/flow.py
@@ -47,6 +47,11 @@ def se2_and_real_secret():
     from pincodes import pa
     return (not pa.is_secret_blank()) and (not pa.tmp_value)
 
+def bip39_passphrase_active():
+    from stash import bip39_passphrase
+    from pincodes import pa
+    return settings.get('words', True) or (bip39_passphrase and pa.tmp_value)
+
 
 HWTogglesMenu = [
     ToggleMenuItem('USB Port', 'du', ['Default On', 'Disable USB'], invert=True,
@@ -203,7 +208,7 @@ SeedFunctionsMenu = [
     MenuItem('View Seed Words', f=view_seed_words),     # text is a little wrong sometimes, rare
     MenuItem('Seed XOR', menu=SeedXORMenu),
     MenuItem("Destroy Seed", f=clear_seed),
-    MenuItem('Lock Down Seed', f=convert_bip39_to_bip32),
+    MenuItem('Lock Down Seed', f=convert_ephemeral_to_master),
 ]
 
 DangerZoneMenu = [
@@ -307,7 +312,7 @@ EmptyWallet = [
 NormalSystem = [
     #         xxxxxxxxxxxxxxxx
     MenuItem('Ready To Sign', f=ready2sign),
-    MenuItem('Passphrase', f=start_b39_pw, predicate=lambda: settings.get('words', True)),
+    MenuItem('Passphrase', f=start_b39_pw, predicate=bip39_passphrase_active),
     MenuItem('Start HSM Mode', f=start_hsm_menu_item, predicate=hsm_policy_available),
     MenuItem("Address Explorer", f=address_explore),
     MenuItem('Type Passwords', f=password_entry, predicate=lambda: settings.get("emu", False) and has_secrets()),

--- a/shared/nvstore.py
+++ b/shared/nvstore.py
@@ -97,7 +97,6 @@ class SettingsObject:
         self.nvram_key = b'\0'*32
         self.capacity = 0
         self.current = self.default_values()
-        self.overrides = {}         # volatile overide values
 
         self.load(dis)
 
@@ -255,7 +254,6 @@ class SettingsObject:
         # and pick the newest one (in unlikely case of dups)
         # reset
         self.current.clear()
-        self.overrides.clear()
         self.my_pos = None
         self.is_dirty = 0
         self.capacity = 0
@@ -310,10 +308,7 @@ class SettingsObject:
             self.current['chain'] = 'XTN'
 
     def get(self, kn, default=None):
-        if kn in self.overrides:
-            return self.overrides.get(kn)
-        else:
-            return self.current.get(kn, default)
+        return self.current.get(kn, default)
 
     def changed(self):
         self.is_dirty += 1
@@ -328,9 +323,6 @@ class SettingsObject:
     def put(self, kn, v):
         self.current[kn] = v
         self.changed()
-
-    def put_volatile(self, kn, v):
-        self.overrides[kn] = v
 
     set = put
 
@@ -358,8 +350,7 @@ class SettingsObject:
         rk = [k for k in self.current if k[0] != '_']
         for k in rk:
             del self.current[k]
-            
-        self.overrides.clear()
+
         self.changed()
         
     async def write_out(self):
@@ -418,7 +409,6 @@ class SettingsObject:
 
         # act blank too, just in case.
         self.current.clear()
-        self.overrides.clear()
         self.is_dirty = 0
         self.capacity = 0
 

--- a/shared/pwsave.py
+++ b/shared/pwsave.py
@@ -25,7 +25,7 @@ class PassphraseSaver:
         try:
             salt = card.get_id_hash()
 
-            with stash.SensitiveValues(bypass_pw=True) as sv:
+            with stash.SensitiveValues(bypass_tmp=True) as sv:
                 self.key = bytearray(sv.encryption_key(salt))
 
         except:
@@ -132,7 +132,7 @@ class PassphraseSaver:
         async def doit(menu, idx, item):
             # apply the password immediately and drop them at top menu
             pw, expect_xfp = item.arg
-            set_bip39_passphrase(pw)
+            await set_bip39_passphrase(pw)
 
             from glob import settings
             from utils import xfp2str

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -1,6 +1,7 @@
 # (c) Copyright 2020 by Coinkite Inc. This file is covered by license found in COPYING-CC.
 #
 import pytest, time, sys, random, re, ndef, os, glob, hashlib, json
+from subprocess import check_output
 from ckcc.protocol import CCProtocolPacker
 from helpers import B2A, U2SAT
 from msg import verify_message
@@ -693,7 +694,7 @@ def set_master_key(sim_exec, sim_execfile, simulator, reset_seed_words):
     reset_seed_words()
 
 @pytest.fixture(scope="function")
-def set_xfp(sim_exec, sim_execfile, simulator, reset_seed_words):
+def set_xfp(sim_exec):
     # set the XFP, without really knowing the private keys
     # - won't be able to sign, but should accept PSBT for signing
 
@@ -703,11 +704,12 @@ def set_xfp(sim_exec, sim_execfile, simulator, reset_seed_words):
         import struct
         need_xfp, = struct.unpack("<I", a2b_hex(xfp))
 
-        sim_exec('from main import settings; settings.put_volatile("xfp", 0x%x);' % need_xfp)
+        sim_exec('from main import settings; settings.set("xfp", 0x%x);' % need_xfp)
 
     yield doit
 
-    sim_exec('from main import settings; settings.overrides.clear();')
+    sim_exec('from main import settings; settings.set("xfp", 0x%x);' % simulator_fixed_xfp)
+
 
 @pytest.fixture(scope="function")
 def set_encoded_secret(sim_exec, sim_execfile, simulator, reset_seed_words):
@@ -1653,10 +1655,97 @@ def tapsigner_encrypted_backup(microsd_path, virtdisk_path):
     return doit
 
 
+@pytest.fixture
+def verify_backup_file(goto_home, pick_menu_item, cap_story, need_keypress):
+    def doit(fn):
+        # Check on-device verify UX works.
+        goto_home()
+        pick_menu_item('Advanced/Tools')
+        pick_menu_item('Backup')
+        pick_menu_item('Verify Backup')
+        time.sleep(0.1)
+        title, body = cap_story()
+        assert "Select file" in body
+        need_keypress('y')
+        time.sleep(0.1)
+        pick_menu_item(os.path.basename(fn))
+
+        time.sleep(0.1)
+        title, body = cap_story()
+        assert "Backup file CRC checks out okay" in body
+    return doit
+
+
+@pytest.fixture
+def check_and_decrypt_backup(microsd_path):
+    def doit(fn, passphrase):
+        # List contents using unix tools
+        pn = microsd_path(fn)
+        out = check_output(['7z', 'l', pn], encoding='utf8')
+        xfname, = re.findall('[a-z0-9]{4,30}.txt', out)
+        print(f"Filename inside 7z: {xfname}")
+        assert xfname in out
+        assert 'Method = 7zAES' in out
+
+        xfn_path = microsd_path(xfname)
+        if os.path.exists(xfn_path):
+            os.remove(xfn_path)
+
+        # does decryption; at least for CRC purposes
+        args = ['7z', 'e', '-p' + ' '.join(passphrase), pn, xfname, '-o' + '../unix/work/MicroSD',]
+        out = check_output(args, encoding='utf8')
+        assert "Extracting archive" in out, out
+        assert "Everything is Ok" in out, out
+
+        with open(xfn_path, "r") as f:
+            res = f.read()
+        return res
+
+    return doit
+
+
+@pytest.fixture
+def restore_backup_cs(unit_test, pick_menu_item, cap_story, cap_menu,
+                      need_keypress, word_menu_entry, get_setting):
+    # restore backup with clear seed as first step
+    def doit(fn, passphrase, avail_settings=None):
+        unit_test('devtest/clear_seed.py')
+
+        m = cap_menu()
+        assert m[0] == 'New Seed Words'
+        pick_menu_item('Import Existing')
+        pick_menu_item('Restore Backup')
+
+        # skip
+        title, body = cap_story()
+        if ('files to pick from' in body) or ("only one file to pick from" in body):
+            need_keypress('y')
+            time.sleep(.01)
+
+            pick_menu_item(fn)
+
+        time.sleep(.1)
+        word_menu_entry(passphrase)
+        title, body = cap_story()
+        assert title == 'Success!'
+        assert 'has been successfully restored' in body
+
+        if avail_settings:
+            for key in avail_settings:
+                assert get_setting(key)
+
+        # avoid simulator reboot; restore normal state
+        unit_test('devtest/abort_ux.py')
+
+    return doit
+
+
 # useful fixtures related to multisig
 from test_multisig import (import_ms_wallet, make_multisig, offer_ms_import, fake_ms_txn,
                                 make_ms_address, clear_ms, make_myself_wallet)
-from test_bip39pw import set_bip39_pw, clear_bip39_pw
-
+from test_bip39pw import set_bip39_pw
+from test_ephemeral import generate_ephemeral_words, import_ephemeral_xprv, goto_eph_seed_menu
+from test_ephemeral import ephemeral_seed_disabled_ui
+from test_ux import enter_complex, pass_word_quiz, word_menu_entry
 
 # EOF

--- a/testing/devtest/clear_seed.py
+++ b/testing/devtest/clear_seed.py
@@ -10,7 +10,7 @@ from sim_settings import sim_defaults
 if not pa.is_secret_blank():
     # clear settings associated with this key, since it will be no more
     settings.current = dict(sim_defaults)
-    settings.overrides.clear()
+    pa.tmp_value = None
 
     # save a blank secret (all zeros is a special case, detected by bootloader)
     dis.fullscreen('Wipe Seed!')

--- a/testing/devtest/set_encoded_secret.py
+++ b/testing/devtest/set_encoded_secret.py
@@ -10,7 +10,6 @@ from stash import SecretStash, SensitiveValues
 from utils import xfp2str
 
 settings.current = dict(sim_defaults)
-settings.overrides.clear()
 
 import main
 raw = main.ENCODED_SECRET

--- a/testing/devtest/set_raw_secret.py
+++ b/testing/devtest/set_raw_secret.py
@@ -15,7 +15,6 @@ print("New raw secret: %s" % b2a_hex(rs))
 
 if 1:
     settings.current = dict(sim_defaults)
-    settings.overrides.clear()
     settings.set('chain', 'XTN')
 
     pa.change(new_secret=rs)

--- a/testing/devtest/set_seed.py
+++ b/testing/devtest/set_seed.py
@@ -14,7 +14,6 @@ tn = chains.BitcoinTestnet
 
 stash.bip39_passphrase = ''
 settings.current = sim_defaults
-settings.overrides.clear()
 settings.set('chain', 'XTN')
 settings.set('words', True)
 settings.set('terms_ok', True)

--- a/testing/devtest/set_tprv.py
+++ b/testing/devtest/set_tprv.py
@@ -25,7 +25,6 @@ if settings.get('xfp') == swab32(node.my_fp()):
 
 else:
     settings.current = sim_defaults
-    settings.overrides.clear()
     settings.set('chain', 'XTN')
 
     raw = SecretStash.encode(xprv=node)

--- a/testing/test_ephemeral.py
+++ b/testing/test_ephemeral.py
@@ -7,6 +7,9 @@ from constants import simulator_fixed_xpub
 from ckcc.protocol import CCProtocolPacker
 from txn import fake_txn
 from test_ux import word_menu_entry
+from constants import simulator_fixed_words, simulator_fixed_xprv
+from pycoin.key.BIP32Node import BIP32Node
+from mnemonic import Mnemonic
 
 
 WORDLISTS = {
@@ -33,8 +36,17 @@ def seed_story_to_words(story: str):
 
 
 @pytest.fixture
-def ephemeral_seed_disabled(cap_menu):
+def ephemeral_seed_disabled(sim_exec):
     def doit():
+        rv = sim_exec('from pincodes import pa; RV.write(repr(pa.tmp_value))')
+        assert not eval(rv)
+    return doit
+
+
+@pytest.fixture
+def ephemeral_seed_disabled_ui(cap_menu):
+    def doit():
+        # MUST be in ephemeral seed menu already
         time.sleep(0.1)
         menu = cap_menu()
         # no ephemeral seed chosen (yet)
@@ -85,7 +97,7 @@ def get_identity_story(goto_home, pick_menu_item, cap_story):
 
 @pytest.fixture
 def goto_eph_seed_menu(goto_home, pick_menu_item, cap_story, need_keypress):
-    def doit():
+    def _doit():
         goto_home()
         pick_menu_item("Advanced/Tools")
         pick_menu_item("Ephemeral Seed")
@@ -95,6 +107,14 @@ def goto_eph_seed_menu(goto_home, pick_menu_item, cap_story, need_keypress):
             assert "temporary secret stored solely in device RAM" in story
             assert "Press (4) to prove you read to the end of this message and accept all consequences." in story
             need_keypress("4")  # understand consequences
+
+    def doit():
+        try:
+            _doit()
+        except:
+            time.sleep(.1)
+            _doit()
+
     return doit
 
 
@@ -104,8 +124,8 @@ def verify_ephemeral_secret_ui(cap_story, need_keypress, cap_menu, dev, fake_txn
                                get_seed_value_ux):
     def doit(mnemonic=None, xpub=None, expected_xfp=None):
         time.sleep(0.3)
-        _, story = cap_story()
-        in_effect_xfp = story[1:9]
+        title, story = cap_story()
+        in_effect_xfp = title[1:-1]
         if expected_xfp is not None:
             assert in_effect_xfp == expected_xfp
         assert "key in effect until next power down." in story
@@ -146,42 +166,115 @@ def verify_ephemeral_secret_ui(cap_story, need_keypress, cap_menu, dev, fake_txn
     return doit
 
 
+@pytest.fixture
+def generate_ephemeral_words(goto_eph_seed_menu, pick_menu_item,
+                             need_keypress, cap_story,
+                             ephemeral_seed_disabled_ui):
+    def doit(num_words, dice=False, from_main=False):
+        goto_eph_seed_menu()
+        if from_main:
+            ephemeral_seed_disabled_ui()
+
+        pick_menu_item("Generate Words")
+        if not dice:
+            pick_menu_item(f"{num_words} Words")
+            time.sleep(0.1)
+        else:
+            pick_menu_item(f"{num_words} Word Dice Roll")
+            for ch in '123456yy':
+                need_keypress(ch)
+
+        time.sleep(0.2)
+        title, story = cap_story()
+        assert f"Record these {num_words} secret words!" in story
+        assert "Press (6) to skip word quiz" in story
+
+        # filter those that starts with space, number and colon --> actual words
+        e_seed_words = seed_story_to_words(story)
+        assert len(e_seed_words) == num_words
+
+        need_keypress("6")  # skip quiz
+        need_keypress("y")  # yes - I'm sure
+        time.sleep(0.1)
+        need_keypress("4")  # understand consequences
+        return e_seed_words
+
+    return doit
+
+
+@pytest.fixture
+def import_ephemeral_xprv(microsd_path, virtdisk_path, goto_eph_seed_menu,
+                          pick_menu_item, need_keypress, cap_story,
+                          nfc_write_text, ephemeral_seed_disabled_ui):
+    def doit(way, extended_key=None, testnet=True, from_main=False):
+        from pycoin.key.BIP32Node import BIP32Node
+        fname = "ek.txt"
+        if extended_key is None:
+            node = BIP32Node.from_master_secret(os.urandom(32), netcode="XTN" if testnet else "BTC")
+            ek = node.hwif(as_private=True) + '\n'
+            if way == "sd":
+                fpath = microsd_path(fname)
+            elif way == "vdisk":
+                fpath = virtdisk_path(fname)
+            if way != "nfc":
+                with open(fpath, "w") as f:
+                    f.write(ek)
+        else:
+            node = BIP32Node.from_wallet_key(extended_key)
+            assert extended_key == node.hwif(as_private=True)
+            ek = extended_key
+
+        if testnet:
+            assert "tprv" in ek
+        else:
+            assert "xprv" in ek
+
+        goto_eph_seed_menu()
+        if from_main:
+            ephemeral_seed_disabled_ui()
+
+        pick_menu_item("Import XPRV")
+        time.sleep(0.1)
+        _, story = cap_story()
+        if way == "sd":
+            if "Press (1) to import extended private key file from SD Card" in story:
+                need_keypress("1")
+        elif way == "nfc":
+            if "press (3) to import via NFC" not in story:
+                pytest.xfail("NFC disabled")
+            else:
+                need_keypress("3")
+                time.sleep(0.2)
+                nfc_write_text(ek)
+                time.sleep(0.3)
+        else:
+            # virtual disk
+            if "press (2) to import from Virtual Disk" not in story:
+                pytest.xfail("Vdisk disabled")
+            else:
+                need_keypress("2")
+
+        if way != "nfc":
+            time.sleep(0.1)
+            _, story = cap_story()
+            assert "Select file containing the extended private key" in story
+            need_keypress("y")
+            pick_menu_item(fname)
+
+        return node
+
+    return doit
+
+
 @pytest.mark.parametrize("num_words", [12, 24])
 @pytest.mark.parametrize("dice", [False, True])
-def test_ephemeral_seed_generate(num_words, pick_menu_item, cap_story, need_keypress,
-                                 reset_seed_words, goto_eph_seed_menu, dice,
+def test_ephemeral_seed_generate(num_words, generate_ephemeral_words, dice,
+                                 reset_seed_words, goto_eph_seed_menu,
                                  ephemeral_seed_disabled, verify_ephemeral_secret_ui):
-
     reset_seed_words()
-    try:
-        goto_eph_seed_menu()
-    except:
-        time.sleep(.1)
-        goto_eph_seed_menu()
-
     ephemeral_seed_disabled()
-    pick_menu_item("Generate Words")
-    if not dice:
-        pick_menu_item(f"{num_words} Words")
-        time.sleep(0.1)
-    else:
-        pick_menu_item(f"{num_words} Word Dice Roll")
-        for ch in '123456yy':
-            need_keypress(ch)
-
-    time.sleep(0.2)
-    title, story = cap_story()
-    assert f"Record these {num_words} secret words!" in story
-    assert "Press (6) to skip word quiz" in story
-
-    # filter those that starts with space, number and colon --> actual words
-    e_seed_words = seed_story_to_words(story)
-    assert len(e_seed_words) == num_words
-
-    need_keypress("6")  # skip quiz
-    need_keypress("y")  # yes - I'm sure
-    time.sleep(0.1)
-    need_keypress("4")  # understand consequences
+    e_seed_words = generate_ephemeral_words(num_words=num_words, dice=dice,
+                                            from_main=True)
     verify_ephemeral_secret_ui(mnemonic=e_seed_words)
 
 
@@ -198,11 +291,7 @@ def test_ephemeral_seed_import_words(nfc, truncated, num_words, cap_menu, pick_m
     words, expect_xfp = WORDLISTS[num_words]
 
     reset_seed_words()
-    try:
-        goto_eph_seed_menu()
-    except:
-        time.sleep(.1)
-        goto_eph_seed_menu()
+    goto_eph_seed_menu()
 
     ephemeral_seed_disabled()
     pick_menu_item("Import Words")
@@ -244,11 +333,7 @@ def test_ephemeral_seed_import_tapsigner(way, retry, testnet, pick_menu_item, ca
 
     fname, backup_key_hex, node = tapsigner_encrypted_backup(way, testnet=testnet)
 
-    try:
-        goto_eph_seed_menu()
-    except:
-        time.sleep(.1)
-        goto_eph_seed_menu()
+    goto_eph_seed_menu()
 
     ephemeral_seed_disabled()
     pick_menu_item("Tapsigner Backup")
@@ -302,11 +387,8 @@ def test_ephemeral_seed_import_tapsigner_fail(pick_menu_item, cap_story, fail,
     if fail == "garbage":
         with open(microsd_path(fname), "wb") as f:
             f.write(os.urandom(152))
-    try:
-        goto_eph_seed_menu()
-    except:
-        time.sleep(.1)
-        goto_eph_seed_menu()
+
+    goto_eph_seed_menu()
 
     ephemeral_seed_disabled()
     pick_menu_item("Tapsigner Backup")
@@ -359,11 +441,7 @@ def test_ephemeral_seed_import_tapsigner_real(data, pick_menu_item, cap_story, m
     fpath = microsd_path(fname)
     shutil.copy(f"data/{fname}", fpath)
     reset_seed_words()
-    try:
-        goto_eph_seed_menu()
-    except:
-        time.sleep(.1)
-        goto_eph_seed_menu()
+    goto_eph_seed_menu()
 
     ephemeral_seed_disabled()
     pick_menu_item("Tapsigner Backup")
@@ -390,63 +468,12 @@ def test_ephemeral_seed_import_tapsigner_real(data, pick_menu_item, cap_story, m
 @pytest.mark.parametrize("way", ["sd", "vdisk", "nfc"])
 @pytest.mark.parametrize('retry', range(3))
 @pytest.mark.parametrize("testnet", [True, False])
-def test_ephemeral_seed_import_xprv(way, retry, testnet, pick_menu_item,
-                                    cap_story, need_keypress, reset_seed_words,
-                                    goto_eph_seed_menu, nfc_write_text, microsd_path,
-                                    virtdisk_path, verify_ephemeral_secret_ui,
-                                    ephemeral_seed_disabled):
+def test_ephemeral_seed_import_xprv(way, retry, testnet, reset_seed_words,
+                                    goto_eph_seed_menu, verify_ephemeral_secret_ui,
+                                    ephemeral_seed_disabled, import_ephemeral_xprv):
     reset_seed_words()
-    fname = "ek.txt"
-    from pycoin.key.BIP32Node import BIP32Node
-    node = BIP32Node.from_master_secret(os.urandom(32), netcode="XTN" if testnet else "BTC")
-    ek = node.hwif(as_private=True) + '\n'
-    if way =="sd":
-        fpath = microsd_path(fname)
-    elif way == "vdisk":
-        fpath = virtdisk_path(fname)
-    if way != "nfc":
-        with open(fpath, "w") as f:
-            f.write(ek)
-    if testnet:
-        assert "tprv" in ek
-    else:
-        assert "xprv" in ek
-
-    try:
-        goto_eph_seed_menu()
-    except:
-        time.sleep(.1)
-        goto_eph_seed_menu()
-
     ephemeral_seed_disabled()
-    pick_menu_item("Import XPRV")
-    time.sleep(0.1)
-    _, story = cap_story()
-    if way == "sd":
-        if "Press (1) to import extended private key file from SD Card" in story:
-            need_keypress("1")
-    elif way == "nfc":
-        if "press (3) to import via NFC" not in story:
-            pytest.xfail("NFC disabled")
-        else:
-            need_keypress("3")
-            time.sleep(0.2)
-            nfc_write_text(ek)
-            time.sleep(0.3)
-    else:
-        # virtual disk
-        if "press (2) to import from Virtual Disk" not in story:
-            pytest.xfail("Vdisk disabled")
-        else:
-            need_keypress("2")
-
-    if way != "nfc":
-        time.sleep(0.1)
-        _, story = cap_story()
-        assert "Select file containing the extended private key" in story
-        need_keypress("y")
-        pick_menu_item(fname)
-
+    node = import_ephemeral_xprv(way=way, testnet=testnet, from_main=True)
     verify_ephemeral_secret_ui(xpub=node.hwif())
 
 
@@ -455,11 +482,7 @@ def test_activate_current_tmp_secret(reset_seed_words, goto_eph_seed_menu,
                                      pick_menu_item, need_keypress,
                                      word_menu_entry):
     reset_seed_words()
-    try:
-        goto_eph_seed_menu()
-    except:
-        time.sleep(.1)
-        goto_eph_seed_menu()
+    goto_eph_seed_menu()
 
     ephemeral_seed_disabled()
     words, expected_xfp = WORDLISTS[12]
@@ -469,15 +492,11 @@ def test_activate_current_tmp_secret(reset_seed_words, goto_eph_seed_menu,
 
     word_menu_entry(words.split())
     time.sleep(0.3)
-    _, story = cap_story()
+    title, story = cap_story()
     assert "key in effect until next power down." in story
-    in_effect_xfp = story[1:9]
+    in_effect_xfp = title[1:-1]
     need_keypress("y")
-    try:
-        goto_eph_seed_menu()
-    except:
-        time.sleep(.1)
-        goto_eph_seed_menu()
+    goto_eph_seed_menu()
 
     pick_menu_item("Import Words")
     pick_menu_item(f"12 Words")
@@ -485,10 +504,92 @@ def test_activate_current_tmp_secret(reset_seed_words, goto_eph_seed_menu,
 
     word_menu_entry(words.split())
     time.sleep(0.3)
-    _, story = cap_story()
+    title, story = cap_story()
     assert "Ephemeral master key already in use" in story
-    already_used_xfp = story[1:9]
+    already_used_xfp = title[1:-1]
     assert already_used_xfp == in_effect_xfp == expected_xfp
     need_keypress("y")
+
+
+@pytest.mark.parametrize("stype", ["words12", "words24", "xprv"])
+def test_backup_ephemeral_wallet(stype, pick_menu_item, need_keypress, goto_home,
+                                 cap_story, pass_word_quiz, get_setting,
+                                 verify_backup_file, microsd_path, check_and_decrypt_backup,
+                                 sim_execfile, unit_test, word_menu_entry, cap_menu,
+                                 restore_backup_cs, generate_ephemeral_words,
+                                 import_ephemeral_xprv, reset_seed_words):
+    reset_seed_words()
+    goto_home()
+    if "words" in stype:
+        num_words = int(stype.replace("words", ""))
+        sec = generate_ephemeral_words(num_words, from_main=True)
+    else:
+        sec = import_ephemeral_xprv("sd", from_main=True)
+
+    target = sim_execfile('devtest/get-secrets.py')
+    assert 'Error' not in target
+    need_keypress("y")
+    pick_menu_item("Advanced/Tools")
+    pick_menu_item("Backup")
+    pick_menu_item("Backup System")
+    time.sleep(.1)
+    title, story = cap_story()
+    assert "An ephemeral seed is in effect" in story
+    assert "so backup will be of that seed" in story
+    need_keypress("y")
+    time.sleep(.1)
+    title, story = cap_story()
+    if "Use same backup file password as last time?" in story:
+        need_keypress("x")
+        time.sleep(.1)
+        title, story = cap_story()
+    assert title == 'NO-TITLE'
+    assert 'Record this' in story
+    assert 'password:' in story
+
+    words = [w[3:].strip() for w in story.split('\n') if w and w[2] == ':']
+    assert len(words) == 12
+    # pass the quiz!
+    count, title, body = pass_word_quiz(words)
+    assert count >= 4
+    assert "same words next time" in body
+    assert "Press (1) to save" in body
+    need_keypress('x')
+    time.sleep(.01)
+    assert get_setting('bkpw', 'xxx') == 'xxx'
+    title, story = cap_story()
+    assert "Backup file written:" in story
+    fn = story.split("\n\n")[1]
+    assert fn.endswith(".7z")
+    verify_backup_file(fn)
+    contents = check_and_decrypt_backup(fn, words)
+    if "words" in stype:
+        assert "mnemonic" in contents
+    else:
+        assert "mnemonic" not in contents
+    assert simulator_fixed_words not in contents
+    assert simulator_fixed_xprv not in contents
+    assert target == contents
+    if "words" in stype:
+        words_str = " ".join(sec)
+        assert words_str in contents
+        seed = Mnemonic.to_seed(words_str)
+        expect = BIP32Node.from_master_secret(seed, netcode="XTN")
+    else:
+        expect = sec
+
+    target_esk = None
+    target_epk = None
+    esk = expect.hwif(as_private=True)
+    epk = expect.hwif(as_private=False)
+    for line in contents.split("\n"):
+        if line.startswith("xprv ="):
+            target_esk = line.split("=")[-1].strip().replace('"', '')
+        if line.startswith("xpub ="):
+            target_epk = line.split("=")[-1].strip().replace('"', '')
+    assert target_epk == epk
+    assert target_esk == esk
+
+    restore_backup_cs(fn, words)
 
 # EOF

--- a/testing/test_pwsave.py
+++ b/testing/test_pwsave.py
@@ -46,8 +46,8 @@ def get_to_pwmenu(cap_story, need_keypress, goto_home, pick_menu_item):
         '1aaa2aaa',
         'ab'*25,
     ])
-def test_first_time(pws, need_keypress, cap_story, pick_menu_item, goto_home, enter_complex, cap_menu, get_to_pwmenu):
-
+def test_first_time(pws, need_keypress, cap_story, pick_menu_item, enter_complex,
+                    cap_menu, get_to_pwmenu, reset_seed_words):
     try:    os.unlink(SIM_FNAME)
     except: pass
 
@@ -75,11 +75,11 @@ def test_first_time(pws, need_keypress, cap_story, pick_menu_item, goto_home, en
         time.sleep(.01)
         title, story = cap_story()
         xfp = title[1:-1]
-        assert '1 to use and save to MicroSD' in story
+        assert '(1) to use and save to MicroSD' in story
 
         need_keypress('1')
         xfps[pw] = xfp
-
+        reset_seed_words()
 
     for n, pw in enumerate(uniq):
         get_to_pwmenu()
@@ -103,7 +103,8 @@ def test_first_time(pws, need_keypress, cap_story, pick_menu_item, goto_home, en
         xfp = title[1:-1]
 
         assert xfp == xfps[uniq[n]]
-        need_keypress('y'); 
+        need_keypress('y')
+        reset_seed_words()
 
 
 def test_crypto_unittest(sim_eval, sim_exec, simulator):

--- a/testing/test_se2.py
+++ b/testing/test_se2.py
@@ -2,7 +2,7 @@
 #
 # Mk4 SE2 (second secure element) test cases and fixtures.
 #
-# - use 'simulator.py --eff' for these
+# - use 'simulator.py' without '--eff' for these
 #
 import pytest, struct, time
 from collections import namedtuple
@@ -497,7 +497,6 @@ def test_ux_duress_choices(with_wipe, subchoice, expect, xflags, xargs,
 
     need_keypress('x')
     time.sleep(.1)
-
     pick_menu_item('Activate Wallet')
     time.sleep(.1)
     _, story = cap_story()
@@ -512,9 +511,7 @@ def test_ux_duress_choices(with_wipe, subchoice, expect, xflags, xargs,
     assert xp == wallet.hwif(as_private=False)
 
     assert not get_setting('multisig')  # multisig is not copied
-    assert not get_setting('tp')  # trick pins are not copied
-    assert not get_setting('bkpw')  # backup password is not copied
-    assert not get_setting('usr')  # hsm users are not copied
+
     # re-login to recover normal seed
     reset_seed_words()
     repl.exec('pa.tmp_value=False; pa.setup(pa.pin); pa.login()')

--- a/testing/test_sign.py
+++ b/testing/test_sign.py
@@ -2039,7 +2039,7 @@ def test_batch_sign(num_tx, ui_path, action, fake_txn, need_keypress,
             pytest.skip("classic sign")
 
         _, story = cap_story()
-        assert "Press (9) to use Batch Sign" in story
+        assert "Press (9) to select all files for potential signing" in story
         need_keypress("9")
 
     time.sleep(.1)


### PR DESCRIPTION
* bip39 passphrase is now internally handled as ephemeral secret
* bip39 passphrases now have its own encrypted settings
* add ability to backup bip39 passphrase wallet
* bip39 passphrases can now be added to ephemeral (word based) secrets
* new feature to make normal main seed(Lock Down Seed) from any currently loaded ephemeral (previously feature called bip39 to bip32 and only implemented for passphrases)
* removed ability to see BIP-39 Passphrase after wallet is active
* showing secrets now also display extended private key for BIP-39 passphrase wallets.

