### PR TITLE
bugfix: off by one bug in trick pin - login countdown

### DIFF
--- a/releases/ChangeLog.md
+++ b/releases/ChangeLog.md
@@ -15,6 +15,7 @@
   was removed as a consequence of this change.
 - Enhancement: Showing secrets now also display extended private key for BIP-39
   passphrase wallets.
+- Bugfix: Fixed off by one bug in `Trick Pins -> Login Countdown` chooser
 
 ## 5.1.4 - 2023-09-08
 

--- a/shared/trick_pins.py
+++ b/shared/trick_pins.py
@@ -799,7 +799,7 @@ normal operation.''')
             va = lgto_va[1:]
 
             def set_it(idx, text):
-                new_val = va[idx+1]
+                new_val = va[idx]
                 # save it
                 try:
                     b, slot = tp.update_slot(pin.encode(), tc_flags=flags, tc_arg=new_val)


### PR DESCRIPTION
* bug only in trick pin login countdown chooser - NOT in normal login countdown chooser (`lgto`)
* if user chooses `5 minutes` in chooser, `15 minutes` is saved instead (off by one)

