### PR TITLE
NUM_SLOTS in PSRAM increased from 64 to 100

### DIFF
--- a/releases/ChangeLog.md
+++ b/releases/ChangeLog.md
@@ -15,6 +15,7 @@
   was removed as a consequence of this change.
 - Enhancement: Showing secrets now also display extended private key for BIP-39
   passphrase wallets.
+- Enhancement: Increase number of slots in PSRAM memory from 64 to 100
 - Bugfix: Fixed off by one bug in `Trick Pins -> Login Countdown` chooser
 
 ## 5.1.4 - 2023-09-08

--- a/shared/nvstore.py
+++ b/shared/nvstore.py
@@ -78,7 +78,7 @@ KEEP_IF_BLANK_SETTINGS = ["bkpw", "wa", "sighshchk", "emu", "rz",
                           "axskip", "del", "pms", "idle_to", "b39skip"]
 
 
-NUM_SLOTS = const(64)
+NUM_SLOTS = const(100)
 SLOTS = range(NUM_SLOTS)
 MK4_WORKDIR = '/flash/settings/'
 


### PR DESCRIPTION
based on `docs/memory-map.md` we have 512K for LFS filesystem - which in theory means that we can double the number of slots to 128 to still have 4k blocks (512/4=128), accounting for overhead --> incresed just to 100 (4k) slots