### PR TITLE
move 12 Words mnemonic options at the top of the menus

### DIFF
--- a/docs/menu-tree.txt
+++ b/docs/menu-tree.txt
@@ -4,14 +4,14 @@
     View Identity
     Temporary Seed
       Generate Words
-        24 Words
         12 Words
-        24 Word Dice Roll
+        24 Words
         12 Word Dice Roll
+        24 Word Dice Roll
       Import Words
-        24 Words
-        18 Words
         12 Words
+        18 Words
+        24 Words
         Import via NFC
       Import XPRV
       Tapsigner Backup
@@ -29,16 +29,16 @@
 
 [IF BLANK WALLET]
   New Seed Words
-    24 Word (default)
-    12 Word
-    24 Word Dice Roll
-    12 Word Dice Roll
-  Import Existing
+    12 Words
     24 Words
+    12 Word Dice Roll
+    24 Word Dice Roll
+  Import Existing
+    12 Words
       [SEED WORD MENUS]
     18 Words
       [SEED WORD MENUS]
-    12 Words
+    24 Words
       [SEED WORD MENUS]
     Restore Backup
     Clone Coldcard
@@ -50,14 +50,14 @@
     View Identity
     Temporary Seed
       Generate Words
-        24 Words
         12 Words
-        24 Word Dice Roll
+        24 Words
         12 Word Dice Roll
+        24 Word Dice Roll
       Import Words
-        24 Words
-        18 Words
         12 Words
+        18 Words
+        24 Words
         Import via NFC
       Import XPRV
       Tapsigner Backup
@@ -175,14 +175,14 @@
     (none saved yet)
     Temporary Seed
       Generate Words
-        24 Words
         12 Words
-        24 Word Dice Roll
+        24 Words
         12 Word Dice Roll
+        24 Word Dice Roll
       Import Words
-        24 Words
-        18 Words
         12 Words
+        18 Words
+        24 Words
         Import via NFC
       Import XPRV
       Tapsigner Backup
@@ -249,14 +249,14 @@
     View Identity
     Temporary Seed
       Generate Words
-        24 Words
         12 Words
-        24 Word Dice Roll
+        24 Words
         12 Word Dice Roll
+        24 Word Dice Roll
       Import Words
-        24 Words
-        18 Words
         12 Words
+        18 Words
+        24 Words
         Import via NFC
       Import XPRV
       Tapsigner Backup

--- a/releases/ChangeLog.md
+++ b/releases/ChangeLog.md
@@ -3,6 +3,7 @@
 - Enhancement: Add current temporary seed to Seed Vault from within Seed Vault menu.
   If current active temporary seed is not saved yet, `Add current tmp` menu item is 
   present in Seed Vault menu.
+- Reorg: `12 Words` menu option preferred on the top of the menu in all the seed menus
 
 ## 5.2.0 - 2023-10-10
 

--- a/shared/flow.py
+++ b/shared/flow.py
@@ -288,10 +288,9 @@ VirginSystem = [
 ]
 
 ImportWallet = [
-    #         xxxxxxxxxxxxxxxx
-    MenuItem("24 Words", menu=start_seed_import, arg=24),
-    MenuItem("18 Words", menu=start_seed_import, arg=18),
     MenuItem("12 Words", menu=start_seed_import, arg=12),
+    MenuItem("18 Words", menu=start_seed_import, arg=18),
+    MenuItem("24 Words", menu=start_seed_import, arg=24),
     MenuItem("Restore Backup", f=restore_everything),
     MenuItem("Clone Coldcard", menu=clone_start),
     MenuItem("Import XPRV", f=import_xprv, arg=False),  # ephemeral=False
@@ -300,11 +299,10 @@ ImportWallet = [
 ]
 
 NewSeedMenu = [
-    #         xxxxxxxxxxxxxxxx
-    MenuItem("24 Word (default)", f=pick_new_seed, arg=24),
-    MenuItem("12 Word", f=pick_new_seed, arg=12),
-    MenuItem("24 Word Dice Roll", f=new_from_dice, arg=24),
+    MenuItem("12 Words", f=pick_new_seed, arg=12),
+    MenuItem("24 Words", f=pick_new_seed, arg=24),
     MenuItem("12 Word Dice Roll", f=new_from_dice, arg=12),
+    MenuItem("24 Word Dice Roll", f=new_from_dice, arg=24),
 ]
 
 # has PIN, but no secret seed yet

--- a/shared/seed.py
+++ b/shared/seed.py
@@ -1018,16 +1018,16 @@ class EphemeralSeedMenu(MenuSystem):
         from actions import nfc_recv_ephemeral, import_tapsigner_backup_file, import_xprv
 
         import_ephemeral_menu = [
-            MenuItem("24 Words", f=cls.ephemeral_seed_import, arg=24),
-            MenuItem("18 Words", f=cls.ephemeral_seed_import, arg=18),
             MenuItem("12 Words", f=cls.ephemeral_seed_import, arg=12),
+            MenuItem("18 Words", f=cls.ephemeral_seed_import, arg=18),
+            MenuItem("24 Words", f=cls.ephemeral_seed_import, arg=24),
             MenuItem("Import via NFC", f=nfc_recv_ephemeral, predicate=lambda: NFC is not None),
         ]
         gen_ephemeral_menu = [
-            MenuItem("24 Words", f=cls.ephemeral_seed_generate, arg=24),
             MenuItem("12 Words", f=cls.ephemeral_seed_generate, arg=12),
-            MenuItem("24 Word Dice Roll", f=cls.ephemeral_seed_generate_from_dice, arg=24),
+            MenuItem("24 Words", f=cls.ephemeral_seed_generate, arg=24),
             MenuItem("12 Word Dice Roll", f=cls.ephemeral_seed_generate_from_dice, arg=12),
+            MenuItem("24 Word Dice Roll", f=cls.ephemeral_seed_generate_from_dice, arg=24),
         ]
 
         rv = [

--- a/testing/test_ux.py
+++ b/testing/test_ux.py
@@ -283,7 +283,7 @@ def test_new_wallet(nwords, goto_home, pick_menu_item, cap_story, need_keypress,
     unit_test('devtest/clear_seed.py')
     m = cap_menu()
     pick_menu_item('New Seed Words')
-    pick_menu_item('24 Word (default)' if nwords == 24 else f'{nwords} Word')
+    pick_menu_item(f'{nwords} Word')
 
     title, body = cap_story()
     assert title == 'NO-TITLE'


### PR DESCRIPTION
* `12 Words` on the top of the menu instead of `24 Words`
* removed `(default)` from label as user still has to choose - there is no default
* regenerate `doc/menu-tree.txt`