### PR TITLE
postpone `Restore Saved` MicroSD card reading

### DIFF
--- a/releases/ChangeLog.md
+++ b/releases/ChangeLog.md
@@ -4,6 +4,9 @@
 - Enhancement: Add current temporary seed to Seed Vault from within Seed Vault menu.
   If current active temporary seed is not saved yet, `Add current tmp` menu item is 
   present in Seed Vault menu.
+- Enhancement: `Restore Saved` passphrases: MicroSD card data reading postponed after 
+  user chooses the menu option, not on access to `Passphrase` menu as before.
+  This speeds up opening `Passphrase` menu when MicroSD card is available.
 - Reorg: `12 Words` menu option preferred on the top of the menu in all the seed menus
 
 ## 5.2.0 - 2023-10-10


### PR DESCRIPTION
* before: produced big lag (3-5sec) on access to `Passphrase` menu if SD card inserted --> as it also decrypts and read `.tmp.tmp`
*  now: menu item `Restore Saved` is only available if `.tmp.tmp` on SD card - but decrypting and reading is postponed to the access of the `Restore Saved`
