### PR TITLE
prevent yikes in `settings._read_slot` when loading settings

### DIFF
--- a/releases/ChangeLog.md
+++ b/releases/ChangeLog.md
@@ -8,6 +8,7 @@
   deferring card read (and decryption) until after `Restore Saved` menu item is selected.
 - Enhancement: `12 Words` menu option preferred on the top of the menu in all the seed menus
   (rather than 24 words).
+- Bugfix: Handle any failures in slot reading when loading settings
 
 ## 5.2.0 - 2023-10-10
 

--- a/shared/nvstore.py
+++ b/shared/nvstore.py
@@ -332,9 +332,8 @@ class SettingsObject:
                 continue
 
             # probably good, read it
-            aes = aes.cipher
-            json_data, expect, actual = self._read_slot(pos, aes)
             try:
+                json_data, expect, actual = self._read_slot(pos, aes.cipher)
                 # verify checksum in last 32 bytes
                 assert expect == actual
 


### PR DESCRIPTION
* `_read_slot` can produce multiple exception types - better to have it inside try/except and ignore any malformed data