### PR TITLE
allow passphrase via USB if passphrase already set (work on master seed)

### DIFF
--- a/releases/ChangeLog.md
+++ b/releases/ChangeLog.md
@@ -10,6 +10,7 @@
 - Enhancement: `12 Words` menu option preferred on the top of the menu in all the seed menus
   (rather than 24 words).
 - Enhancement: One instant retry on SE1 comm failures
+- Enhancement: Allow passphrase via USB if passphrase already set - operates on master seed.
 - Bugfix: Handle any failures in slot reading when loading settings
 - Bugfix: Add missing First Time UX for extended key import as master seed
 - Bugfix: Hide `Upgrade Firmware` menu item if temporary seed is active

--- a/shared/auth.py
+++ b/shared/auth.py
@@ -1196,29 +1196,24 @@ class NewPassphrase(UserAuthorizedAction):
         title = "Passphrase"
         bypass_tmp = True
         escape = "2"
-        showit = False
         while 1:
-            if showit:
-                ch = await ux_show_story('Given:\n\n%s\n\nShould we switch to that wallet now?'
-                                         '\n\nOK to continue, X to cancel.' % self._pw, title=title)
-            else:
-                msg = ('BIP-39 passphrase (%d chars long) has been provided over '
-                       'USB connection. Should we switch to that wallet now?\n\n')
-                if pa.tmp_value and settings.get("words", True):
-                    escape += "1"
-                    msg += "Press (1) to add passphrase to currently active temporary seed. "
+            msg = ('BIP-39 passphrase (%d chars long) has been provided over '
+                   'USB connection. Should we switch to that wallet now?\n\n')
+            if pa.tmp_value and settings.get("words", True):
+                escape += "1"
+                msg += "Press (1) to add passphrase to currently active temporary seed. "
 
-                msg += ('Press (2) to view the provided passphrase.\n\n'
-                        'OK to continue, X to cancel.')
-                ch = await ux_show_story(msg=msg % len(self._pw), title=title, escape=escape)
-
+            msg += ('Press (2) to view the provided passphrase.\n\n'
+                    'OK to continue, X to cancel.')
+            ch = await ux_show_story(msg=msg % len(self._pw), title=title, escape=escape)
             if ch == '2':
-                showit = True
+                await ux_show_story('Provided:\n\n%s\n\n' % self._pw, title=title)
                 continue
-            elif ch == '1':
-                bypass_tmp = False
+            else:
+                if ch == '1':
+                    bypass_tmp = False
 
-            break
+                break
 
         try:
             if ch not in 'y1':
@@ -1233,7 +1228,6 @@ class NewPassphrase(UserAuthorizedAction):
                                            summarize_ux=False)
 
                 self.result = settings.get('xpub')
-
 
         except BaseException as exc:
             self.failed = "Exception"

--- a/shared/drv_entro.py
+++ b/shared/drv_entro.py
@@ -257,7 +257,7 @@ async def drv_entro_step2(_1, picked, _2):
         dis.fullscreen("Applying...")
         from actions import goto_top_menu
         from glob import settings
-        xfp_str = xfp2str(settings.get("xfp"))
+        xfp_str = xfp2str(settings.get("xfp", 0))
         await seed.set_ephemeral_seed(
             encoded,
             meta='BIP85 Derived from [%s], index=%d' % (xfp_str, index)

--- a/shared/usb.py
+++ b/shared/usb.py
@@ -546,10 +546,11 @@ class USBHandler:
         if cmd == 'pass':
             # bip39 passphrase provided, maybe use it if authorized
             assert self.encrypted_req, 'must encrypt'
+            import stash
             from auth import start_bip39_passphrase
             from glob import settings
 
-            assert settings.get('words', True), 'no seed'
+            assert settings.get('words', True) or stash.bip39_passphrase, 'no seed'
             assert len(args) < 400, 'too long'
             pw = str(args, 'utf8')
             assert len(pw) < 100, 'too long'


### PR DESCRIPTION
* show password over USB UX change - showing passphrase is just a loop - getting back to main ux story
* allow to set passphrase via USB if other passphrase is active - will operate on master seed (copy manual passphrase entry behavior)
