### PR TITLE
bugfix: prevent yikes in clone coldcard

### DIFF
--- a/releases/ChangeLog.md
+++ b/releases/ChangeLog.md
@@ -22,6 +22,7 @@
 - Bugfix: Hide `Upgrade Firmware` menu item if temporary seed is active
 - Bugfix: Disallow using master seed as temporary seed
 - Bugfix: Do not allow to `APPLY` empty BIP-39 passphrase
+- Bugfix: Fix yikes in `Clone Coldcard` (thanks to AnchorWatch)
 
 ## 5.2.0 - 2023-10-10
 

--- a/shared/backups.py
+++ b/shared/backups.py
@@ -74,7 +74,7 @@ def render_backup_contents(bypass_tmp=False):
             for k,v in pairs:
                 ADD(k, v)
 
-        if bypass_tmp:
+        if bypass_tmp and pa.tmp_value:
             current_tmp = pa.tmp_value[:]
             pa.tmp_value = None
             # we also need correct settings from main seed
@@ -110,7 +110,7 @@ def render_backup_contents(bypass_tmp=False):
 
     rv.write('\n# EOF\n')
 
-    if bypass_tmp:
+    if bypass_tmp and current_tmp:
         # go back to tmp secret and its settings
         stash.SensitiveValues.clear_cache()
         pa.tmp_value = current_tmp
@@ -281,7 +281,7 @@ async def make_complete_backup(fname_pattern='backup.7z', write_sflash=False):
             bypass_tmp = True
 
     elif pa.tmp_value:
-        if not await ux_confirm("An temporary seed is in effect, "
+        if not await ux_confirm("A temporary seed is in effect, "
                                 "so backup will be of that seed."):
             return
 
@@ -593,7 +593,6 @@ file with an ephemeral public key will be written.''')
     try:
         with CardSlot() as card:
             fname, nice = card.pick_filename('ccbk-start.json', overwrite=True)
-
             with card.open(fname, 'wb') as fd:
                 fd.write(ujson.dumps(dict(pubkey=b2a_hex(my_pubkey))))
             

--- a/testing/data/ccbk-start.json
+++ b/testing/data/ccbk-start.json
@@ -1,0 +1,1 @@
+{"pubkey": "038e96756bb520bc3fece6c663c61db10cd8c971dfdbf757f1602fa7eed3f83689"}

--- a/testing/test_backup.py
+++ b/testing/test_backup.py
@@ -1,4 +1,4 @@
-import pytest, time, json
+import pytest, time, json, os, shutil
 from constants import simulator_fixed_words, simulator_fixed_tprv
 from pycoin.key.BIP32Node import BIP32Node
 from mnemonic import Mnemonic
@@ -533,3 +533,21 @@ def test_seed_vault_backup_frozen(reset_seed_words, settings_set, repl):
     assert 'Coldcard backup file' in bk
     target = json.dumps(sv)
     assert target in bk
+
+
+def test_clone_start(reset_seed_words, pick_menu_item, cap_story, goto_home):
+    sd_dir = "../unix/work/MicroSD"
+    num_7z = len([i for i in os.listdir(sd_dir) if i.endswith(".7z")])
+    fname = "ccbk-start.json"
+    reset_seed_words()
+    shutil.copy(f"data/{fname}", sd_dir)
+    pick_menu_item("Advanced/Tools")
+    pick_menu_item("Backup")
+    pick_menu_item("Clone Coldcard")
+    time.sleep(1)
+    title, story = cap_story()
+    assert "Done" in story
+    assert "Take this MicroSD card back to other Coldcard" in story
+    goto_home()
+    assert len([i for i in os.listdir(sd_dir) if i.endswith(".7z")]) > num_7z
+    os.remove(f"{sd_dir}/{fname}")


### PR DESCRIPTION
* creating backup with `bypass_tmp=True` on master secret raises exception
