### PR TITLE
Improve BIP39 Passphrase UX if temporary seed active and passphrase applicable

### DIFF
--- a/releases/ChangeLog.md
+++ b/releases/ChangeLog.md
@@ -17,6 +17,7 @@
 - Enhancement: One instant retry on SE1 comm failures
 - Enhancement: Allow passphrase via USB if passphrase already set - operates on master seed.
 - Enhancement: Continuation of removal of obsolete Mk2/Mk3 code-paths from master branch.
+- Enhancement: Improve BIP39 Passphrase UX when temporary seed is active and applicable.
 - Bugfix: Handle any failures in slot reading when loading settings
 - Bugfix: Add missing First Time UX for extended key import as master seed
 - Bugfix: Hide `Upgrade Firmware` menu item if temporary seed is active

--- a/shared/seed.py
+++ b/shared/seed.py
@@ -1194,30 +1194,41 @@ class PassphraseMenu(MenuSystem):
             # empty string here - noop
             return
 
-        nv, xfp, parent_xfp = await calc_bip39_passphrase(pp_sofar, bypass_tmp=True)
-
-        msg = ('Above is the master key fingerprint of the new wallet. '
-               'Press X to abort and keep editing passphrase, '
-               'OK to use the new wallet, (1) to use and save to MicroSD')
-
-        msg1 = ""
+        nv, xfp, parent_xfp = await calc_bip39_passphrase(pp_sofar,
+                                                          bypass_tmp=True)
+        parent_xfp_str = xfp2str(parent_xfp)
+        xfp_str = xfp2str(xfp)
+        msg0 = "master seed [%s]" % parent_xfp_str
         if pa.tmp_value and settings.get("words", True):
-            # we have ephemeral seed but can add passphrase to it as it is word based
-            msg1 = (", or press (2) to add passphrase to the current "
-                    "active temporary seed instead of the main seed.")
+            # we have ephemeral seed - can add passphrase to it as it is word based
+            t_nv, t_xfp, t_parent_xfp = await calc_bip39_passphrase(pp_sofar,
+                                                                    bypass_tmp=False)
+            t_parent_xfp_str = xfp2str(t_parent_xfp)
+            t_xfp_str = xfp2str(t_xfp)
+            choice_msg = "(1) master+pass:\n%s→%s\n\n" % (parent_xfp_str, xfp_str)
+            choice_msg += "(2) tmp+pass:\n%s→%s\n\n" % (t_parent_xfp_str, t_xfp_str)
+            ch = await ux_show_story(choice_msg, escape='12x', strict_escape=True,
+                                     scrollbar=False)
+            if ch == "x": return  # exit
+            if ch == "2":
+                parent_xfp_str = t_parent_xfp_str
+                xfp = t_xfp
+                xfp_str = t_xfp_str
+                msg0 = "current active temporary seed [%s]" % t_parent_xfp_str
+                nv = t_nv
 
-        ch = await ux_show_story(msg + msg1, title="[%s]" % xfp2str(xfp), escape='12')
+        msg = ('Above is the master key fingerprint of the new wallet'
+               ' created by adding passphrase to %s.'
+               ' Press X to abort and keep editing passphrase,'
+               ' OK to use the new wallet, (1) to use'
+               ' and save to MicroSD') % msg0
+
+        ch = await ux_show_story(msg, title="[%s]" % xfp_str, escape='1')
         if ch == 'x':
             return
 
-        if ch == "2":
-            stash.SensitiveValues.clear_cache()
-            nv, xfp, parent_xfp = await calc_bip39_passphrase(pp_sofar, bypass_tmp=False)
-            ch = await ux_show_story(msg, title="[%s]" % xfp2str(xfp), escape='1')
-            if ch == "x": return
-
         await set_ephemeral_seed(nv, summarize_ux=False, bip39pw=pp_sofar,
-                                 meta="BIP-39 Passphrase on [%s]" % xfp2str(parent_xfp))
+                                 meta="BIP-39 Passphrase on [%s]" % parent_xfp_str)
         if ch == '1':
             await PassphraseSaver().append(xfp, pp_sofar)
 

--- a/shared/ux.py
+++ b/shared/ux.py
@@ -173,7 +173,8 @@ class PressRelease:
 # (using FontSmall)
 CH_PER_W = const(17)
 
-async def ux_show_story(msg, title=None, escape=None, sensitive=False, strict_escape=False):
+async def ux_show_story(msg, title=None, escape=None, sensitive=False,
+                        strict_escape=False, scrollbar=True):
     # show a big long string, and wait for XY to continue
     # - returns character used to get out (X or Y)
     # - can accept other chars to 'escape' as well.
@@ -239,7 +240,10 @@ async def ux_show_story(msg, title=None, escape=None, sensitive=False, strict_es
 
                 y += 13
 
-        dis.scroll_bar(top / len(lines))
+        if scrollbar:
+            # help in cases when last char in a row hidden by scroll bar
+            dis.scroll_bar(top / len(lines))
+
         dis.show()
 
         # wait to do something


### PR DESCRIPTION
## NEW UX

**New choice UX** - Only visible if temporary seed is active and is word based. Otherwise this UX is skipped. Press (1) or press (2) without explanation. Arrows!
![snapshot-349-122538](https://github.com/coinkite/afirmware/assets/25349625/6902e084-29cc-4871-af17-48e3d3be0367)
