### PR TITLE
remove ability to use `Passphrase` if already in use

### DIFF
--- a/releases/ChangeLog.md
+++ b/releases/ChangeLog.md
@@ -1,3 +1,9 @@
+## 5.2.3 - 2024-XX-XX
+
+- Change: `Passphrase` menu item is no longer offered if BIP39 passphrase
+  already in use. Use `Restore Master` with ability to keep or purge current
+  passphrase wallet settings.
+
 ## 5.2.2 - 2023-12-21
 
 - Bugfix: Re-enable `Lock Down Seed` feature which was disabled by accident

--- a/shared/flow.py
+++ b/shared/flow.py
@@ -51,10 +51,8 @@ def se2_and_real_secret():
     from pincodes import pa
     return (not pa.is_secret_blank()) and (not pa.tmp_value)
 
-def bip39_passphrase_active():
-    import stash
-    return settings.get('words', True) \
-        or (settings.master_get('words', True) and stash.bip39_passphrase)
+def word_based_seed():
+    return settings.get("words", True)
 
 
 HWTogglesMenu = [
@@ -204,7 +202,7 @@ DebugFunctionsMenu = [
 
 SeedXORMenu = [
     #         xxxxxxxxxxxxxxxx
-    MenuItem("Split Existing", f=xor_split_start, predicate=lambda: settings.get('words', True)),
+    MenuItem("Split Existing", f=xor_split_start, predicate=word_based_seed),
     MenuItem("Restore Seed XOR", f=xor_restore_start),
 ]
 
@@ -213,8 +211,7 @@ SeedFunctionsMenu = [
     MenuItem('Seed XOR', menu=SeedXORMenu),
     MenuItem("Destroy Seed", f=clear_seed),
     MenuItem('Lock Down Seed', f=convert_ephemeral_to_master),
-    MenuItem('Export SeedQR', f=export_seedqr,
-             predicate=lambda: settings.get('words', True)),
+    MenuItem('Export SeedQR', f=export_seedqr, predicate=word_based_seed),
 ]
 
 DangerZoneMenu = [
@@ -324,7 +321,7 @@ EmptyWallet = [
 NormalSystem = [
     #         xxxxxxxxxxxxxxxx
     MenuItem('Ready To Sign', f=ready2sign),
-    MenuItem('Passphrase', f=start_b39_pw, predicate=bip39_passphrase_active),
+    MenuItem('Passphrase', f=start_b39_pw, predicate=word_based_seed),
     MenuItem('Start HSM Mode', f=start_hsm_menu_item, predicate=hsm_policy_available),
     MenuItem("Address Explorer", f=address_explore),
     MenuItem('Type Passwords', f=password_entry,

--- a/shared/seed.py
+++ b/shared/seed.py
@@ -1235,7 +1235,7 @@ class PassphraseMenu(MenuSystem):
         if tdata is None and mdata is None:
             # if master is not word based, temporary has to be, otherwise "Passphrase"
             # not offered in menu
-            # should never be seen by user because flow.py::bip39_passphrase_active
+            # should never be seen by user because flow.py::word_based_seed
             await ux_show_story(title="FAILED", msg="Need word based secret")
             return
 

--- a/shared/usb.py
+++ b/shared/usb.py
@@ -546,11 +546,10 @@ class USBHandler:
         if cmd == 'pass':
             # bip39 passphrase provided, maybe use it if authorized
             assert self.encrypted_req, 'must encrypt'
-            from flow import bip39_passphrase_active
             from auth import start_bip39_passphrase
             from glob import settings
 
-            assert bip39_passphrase_active(), 'no seed'
+            assert settings.get("words", True), 'no seed'
             assert len(args) < 400, 'too long'
             pw = str(args, 'utf8')
             assert len(pw) < 100, 'too long'

--- a/testing/test_bip39pw.py
+++ b/testing/test_bip39pw.py
@@ -357,7 +357,7 @@ def test_bip39pass_on_ephemeral_seed_usb(generate_ephemeral_words, import_epheme
         import_ephemeral_xprv("sd", from_main=True, seed_vault=False)
 
     goto_home()
-    if stype == "xprv":
+    if stype in ("xprv", "b39pw"):
         with pytest.raises(Exception) as e:
             set_bip39_pw(passphrase, reset=False)
         assert "no seed" in e.value.args[0]
@@ -417,7 +417,6 @@ def test_tmp_on_xprv_master(generate_ephemeral_words, goto_home, cap_menu,
     pick_menu_item("APPLY")
     time.sleep(.1)
     title, story = cap_story()
-
 
     assert parent_fp in title  # no choice story
     assert "current active temporary seed" in story


### PR DESCRIPTION
* this was kept as legacy UI/UX compatibility when passphrase was migrated from global var tmp value to classic way of doing tmp seed.
* main reason for this feature to exist in a first place was inability to switch from tmp to master seed without reboot- now have `Restore Master`