### PR TITLE
HSM: 'wallet' rule enabled for miniscript; allow miniscript address show

### DIFF
--- a/releases/EdgeChangeLog.md
+++ b/releases/EdgeChangeLog.md
@@ -9,12 +9,15 @@
 
 ## 6.2.2X - 2024-01-XX
 
-- New Feature: Miniscript USB interface
+- New Feature: Miniscript [USB interface](https://github.com/Coldcard/ckcc-protocol/blob/master/README.md#miniscript)
 - New Feature: Named miniscript imports. Wrap descriptor in json `{"name:"n0", "desc":"<descriptor>"}`
   with `name` key to use this name instead of the filename. Mostly usefull for USB and NFC
   imports that have no file, in which case name was created from descriptor checksum.
 - Enhancement: Allow keys with same origin, differentiated only by change index derivation
   in miniscript descriptor.
+- Enhancement: HSM `wallet` rule enabled for miniscript
+- Enhancement: Add `msas` in to the `share_addrs` HSM [rule](https://coldcard.com/docs/hsm/rules/)
+  to be able to check miniscript addresses in HSM mode.
 - Enhancement: HW Accelerated AES CTR for BSMS and passphrase saver
 - Bugfix: Do not allow to import duplicate miniscript wallets (thanks to [AnchorWatch](https://www.anchorwatch.com/))
 - Bugfix: Saving passphrase on SD Card caused a freeze that required reboot

--- a/shared/hsm.py
+++ b/shared/hsm.py
@@ -4,16 +4,15 @@
 #
 # Unattended signing of transactions and messages, subject to a set of rules.
 #
-import stash, ustruct, chains, sys, gc, uio, ujson, uos, utime, ckcc, ngu, version
-from sffile import SFFile
+import ustruct, chains, sys, gc, uio, ujson, uos, utime, ckcc, ngu
 from utils import problem_file_line, cleanup_deriv_path, match_deriv_path
 from pincodes import AE_LONG_SECRET_LEN
 from stash import blank_object
 from users import Users, MAX_NUMBER_USERS, calc_local_pincode
 from public_constants import MAX_USERNAME_LEN
 from multisig import MultisigWallet
+from miniscript import MiniScriptWallet
 from ubinascii import hexlify as b2a_hex
-from ubinascii import unhexlify as a2b_hex
 from uhashlib import sha256
 from ucollections import OrderedDict
 from files import CardSlot, CardMissingError
@@ -88,13 +87,13 @@ def pop_list(j, fld_name, cleanup_fcn=None):
     else:
         return []
 
-def pop_deriv_list(j, fld_name, extra_val=None):
+def pop_deriv_list(j, fld_name, extra_vals=None):
     # expect a list of derivation paths, but also 'any' meaning accept all
     # - maybe also 'p2sh' as special value
     # - also, path can have n
     def cu(s):
-        if s.lower() == 'any': return s.lower()
-        if extra_val and s.lower() == extra_val: return s.lower()
+        if extra_vals and s.lower() in extra_vals:
+            return s.lower()
         try:
             return cleanup_deriv_path(s, allow_star=True)
         except:
@@ -195,7 +194,7 @@ class ApprovalRule:
     # - users: list of authorized users
     # - min_users: how many of those are needed to approve
     # - local_conf: local user must also confirm w/ code
-    # - wallet: which multisig wallet to restrict to, or '1' for single signer only
+    # - wallet: which multisig/miniscript wallet to restrict to, or '1' for single signer only
     # - min_pct_self_transfer: minimum percentage of own input value that must go back to self
     # - patterns: list of transaction patterns to check for. Valid values:
     #       * EQ_NUM_INS_OUTS:      the number of inputs and outputs must be equal
@@ -212,6 +211,7 @@ class ApprovalRule:
             return u
 
         self.index = idx+1
+        self.ms_type = "multisig"
         self.per_period = pop_int(j, 'per_period', 0, MAX_SATS)
         self.max_amount = pop_int(j, 'max_amount', 0, MAX_SATS)
         self.users = pop_list(j, 'users', check_user)
@@ -238,8 +238,11 @@ class ApprovalRule:
 
         # if specified, 'wallet' must be an existing multisig wallet's name
         if self.wallet and self.wallet != '1':
-            names = [ms.name for ms in MultisigWallet.get_all()]
-            assert self.wallet in names, "unknown MS wallet: "+self.wallet
+            ms_names = [ms.name for ms in MultisigWallet.get_all()]
+            msc_names = [msc.name for msc in MiniScriptWallet.get_all()]
+            assert self.wallet in (ms_names+msc_names), "unknown wallet: "+self.wallet
+            if self.wallet in msc_names:
+                self.ms_type = "miniscript"
 
         # patterns must be valid
         for p in self.patterns:
@@ -283,9 +286,9 @@ class ApprovalRule:
             rv = 'Any amount'
 
         if self.wallet == '1':
-            rv += ' (non multisig)'
+            rv += ' (singlesig only)'
         elif self.wallet:
-            rv += ' from multisig wallet "%s"' % self.wallet
+            rv += ' from %s wallet "%s"' % (self.ms_type, self.wallet)
 
         if self.users:
             rv += ' may be authorized by '
@@ -328,7 +331,9 @@ class ApprovalRule:
             # rule limited to one wallet
             if psbt.active_multisig:
                 # if multisig signing, might need to match specific wallet name
-                assert self.wallet == psbt.active_multisig.name, 'wrong wallet'
+                assert self.wallet == psbt.active_multisig.name, 'wrong multisig wallet'
+            elif psbt.active_miniscript:
+                assert self.wallet == psbt.active_miniscript.name, 'wrong miniscript wallet'
             else:
                 # non multisig, but does this rule apply to all wallets or single-singers
                 assert self.wallet == '1', 'not multisig'
@@ -504,9 +509,9 @@ class HSMPolicy:
         self.warnings_ok = pop_bool(j, 'warnings_ok')
 
         # a list of paths we can accept for signing
-        self.msg_paths = pop_deriv_list(j, 'msg_paths')
-        self.share_xpubs = pop_deriv_list(j, 'share_xpubs')
-        self.share_addrs = pop_deriv_list(j, 'share_addrs', 'p2sh')
+        self.msg_paths = pop_deriv_list(j, 'msg_paths', ['any'])
+        self.share_xpubs = pop_deriv_list(j, 'share_xpubs', ['any'])
+        self.share_addrs = pop_deriv_list(j, 'share_addrs', ['p2sh', 'any', 'msas'])
 
         # free text shown at top
         self.notes = pop_string(j, 'notes', 1, 80)
@@ -814,11 +819,14 @@ class HSMPolicy:
 
         return match_deriv_path(self.share_xpubs, subpath)
 
-    def approve_address_share(self, subpath=None, is_p2sh=False):
+    def approve_address_share(self, subpath=None, is_p2sh=False, miniscript=False):
         # Are we allowing "show address" requests over USB?
 
         if not self.share_addrs:
             return False
+
+        if miniscript:
+            return ('msas' in self.share_addrs)
 
         if is_p2sh:
             return ('p2sh' in self.share_addrs)
@@ -994,7 +1002,8 @@ def hsm_status_report():
             rv['approval_wait'] = True
 
         rv['users'] = Users.list()
-        rv['wallets'] = [ms.name for ms in MultisigWallet.get_all()]
+        rv['wallets'] = [ms.name for ms in MultisigWallet.get_all()] \
+                        + [msc.name for msc in MiniScriptWallet.get_all()]
 
     rv['chain'] = settings.get('chain', 'BTC')
 

--- a/shared/usb.py
+++ b/shared/usb.py
@@ -53,7 +53,7 @@ HSM_WHITELIST = frozenset({
     'blkc', 'hsts',             # report status values
     'stok', 'smok',             # completion check: sign txn or msg
     'xpub', 'msck',             # quick status checks
-    'p2sh', 'show',             # limited by HSM policy
+    'p2sh', 'show', 'msas',     # limited by HSM policy
     'user',                     # auth HSM user, other user cmds not allowed
     'gslr',                     # read storage locker; hsm mode only, limited usage
 })
@@ -539,6 +539,9 @@ class USBHandler:
         if cmd == "msas":
             # get miniscript address based on int/ext index
             assert self.encrypted_req, 'must encrypt'
+            if hsm_active and not hsm_active.approve_address_share(miniscript=True):
+                raise HSMDenied
+
             from miniscript import MiniScriptWallet
 
             change, idx, = unpack_from('<II', args)

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -1839,6 +1839,7 @@ from test_ephemeral import ephemeral_seed_disabled_ui, restore_main_seed, confir
 from test_ephemeral import verify_ephemeral_secret_ui, get_identity_story, get_seed_value_ux, seed_vault_enable
 from test_multisig import import_ms_wallet, make_multisig, offer_ms_import, fake_ms_txn
 from test_multisig import make_ms_address, clear_ms, make_myself_wallet
+from test_miniscript import offer_minsc_import
 from test_se2 import goto_trick_menu, clear_all_tricks, new_trick_pin, se2_gate, new_pin_confirmed
 from test_seed_xor import restore_seed_xor
 from test_ux import enter_complex, pass_word_quiz, word_menu_entry

--- a/testing/test_hsm.py
+++ b/testing/test_hsm.py
@@ -206,7 +206,7 @@ def hsm_reset(dev, sim_exec):
 
     # wallets
     (DICT(rules=[dict(wallet='1')]),
-        '(non multisig)'),
+        '(singlesig only)'),
 
     # users
     (DICT(rules=[dict(users=USERS)]),
@@ -544,8 +544,8 @@ def test_simple_limit(dev, amount, over, start_hsm, fake_txn, attempt_psbt, twea
         tweak_rule(0, dict(max_amount=int(amount+over)))
         attempt_psbt(psbt)
 
-def test_named_wallets(dev, start_hsm, tweak_rule, make_myself_wallet, hsm_status,
-                       attempt_psbt, fake_txn, fake_ms_txn, amount=5E6, incl_xpubs=False):
+def test_named_wallets_multisig(dev, start_hsm, tweak_rule, make_myself_wallet, hsm_status,
+                                attempt_psbt, fake_txn, fake_ms_txn, amount=5E6, incl_xpubs=False):
     wname = 'Myself-4'
     M = 4
 
@@ -579,7 +579,119 @@ def test_named_wallets(dev, start_hsm, tweak_rule, make_myself_wallet, hsm_statu
 
     # check ms txn not accepted when rule spec's a single signer
     tweak_rule(0, dict(wallet='1'))
-    attempt_psbt(psbt, 'wrong wallet')
+    attempt_psbt(psbt, 'wrong multisig wallet')
+
+@pytest.mark.bitcoind
+def test_named_wallets_miniscript(dev, start_hsm, tweak_rule, make_myself_wallet,
+                                  hsm_status, attempt_psbt, fake_txn, bitcoind,
+                                  offer_minsc_import, need_keypress, pick_menu_item,
+                                  load_export, goto_home):
+    stat = hsm_status()
+    assert not stat.active
+
+    from test_miniscript import CHANGE_BASED_DESCS
+    for i, desc in enumerate(CHANGE_BASED_DESCS):
+        name = f"hsm_msc{i}"
+        xd = json.dumps({"name": name, "desc": desc})
+        title, story = offer_minsc_import(xd)
+        assert "Create new miniscript wallet?" in story
+        assert name in story
+        need_keypress("y")
+        time.sleep(.2)
+
+    core_wallets = []
+    for i in range(len(CHANGE_BASED_DESCS)):
+        name = f"hsm_msc{i}"
+        wo = bitcoind.create_wallet(wallet_name=name, disable_private_keys=True, blank=True,
+                                    passphrase=None, avoid_reuse=False, descriptors=True)
+        goto_home()
+        pick_menu_item("Settings")
+        pick_menu_item("Miniscript")
+        pick_menu_item(name)
+        pick_menu_item("Descriptors")
+        pick_menu_item("Bitcoin Core")
+        text = load_export("sd", label="Bitcoin Core miniscript", is_json=False, sig_check=False)
+        text = text.replace("importdescriptors ", "").strip()
+        # remove junk
+        r1 = text.find("[")
+        r2 = text.find("]", -1, 0)
+        text = text[r1: r2]
+        core_desc_object = json.loads(text)
+        res = wo.importdescriptors(core_desc_object)
+        for obj in res:
+            assert obj["success"]
+
+        af = "bech32"
+        if i > 1:
+            af = "bech32m"
+
+        addr = wo.getnewaddress("", af)
+        bitcoind.supply_wallet.sendtoaddress(addr, 1.0)
+        core_wallets.append(wo)
+
+    # mine above txns
+    bitcoind.supply_wallet.generatetoaddress(1, bitcoind.supply_wallet.getnewaddress())
+    for w in core_wallets:
+        assert len(w.listunspent()) > 0, "nu funds"
+
+    stat = hsm_status()
+    for i in range(len(CHANGE_BASED_DESCS)):
+        assert f"hsm_msc{i}" in stat.wallets
+
+    # policy: only allow miniscript 0
+    wname = "hsm_msc0"
+    policy = DICT(share_addrs=["any"], rules=[dict(wallet=wname)])
+
+    stat = start_hsm(policy)
+    assert 'Any amount from miniscript wallet' in stat.summary
+    assert wname in stat.summary
+    assert 'wallets' not in stat
+
+    # simple p2pkh should fail
+    psbt = fake_txn(1, 2, outvals=[5E6, 1E8-5E6], change_outputs=[1], fee=0)
+    attempt_psbt(psbt, "not multisig")
+
+    # but txn from target miniscript wallet 0 must work
+    wal0 = core_wallets[0]
+    psbt_res = wal0.walletcreatefundedpsbt([], [{bitcoind.supply_wallet.getnewaddress(): 0.2}], 0, {"fee_rate": 20})
+    attempt_psbt(base64.b64decode(psbt_res["psbt"]))
+
+    # WRONG
+    wal2 = core_wallets[2]
+    psbt_res = wal2.walletcreatefundedpsbt([], [{bitcoind.supply_wallet.getnewaddress(): 0.2}], 0, {"fee_rate": 18})
+    attempt_psbt(base64.b64decode(psbt_res["psbt"]), 'wrong miniscript wallet')
+
+    wal1 = core_wallets[1]
+    psbt_res = wal1.walletcreatefundedpsbt([], [{bitcoind.supply_wallet.getnewaddress(): 0.2}], 0, {"fee_rate": 12})
+    attempt_psbt(base64.b64decode(psbt_res["psbt"]), 'wrong miniscript wallet')
+
+    # works
+    psbt_res = wal0.walletcreatefundedpsbt([], [{bitcoind.supply_wallet.getnewaddress(): 0.3}], 0, {"fee_rate": 15})
+    attempt_psbt(base64.b64decode(psbt_res["psbt"]))
+
+    wname = "hsm_msc3"
+    tweak_rule(0, dict(wallet=wname))
+
+    # this worked before but now, after tweak, it does not
+    psbt_res = wal0.walletcreatefundedpsbt([], [{bitcoind.supply_wallet.getnewaddress(): 0.1}], 0, {"fee_rate": 13})
+    attempt_psbt(base64.b64decode(psbt_res["psbt"]), 'wrong miniscript wallet')
+
+    # correct wallet 3
+    wal3 = core_wallets[3]
+    psbt_res = wal3.walletcreatefundedpsbt([], [{bitcoind.supply_wallet.getnewaddress(): 0.6}], 0, {"fee_rate": 10})
+    attempt_psbt(base64.b64decode(psbt_res["psbt"]))
+
+    psbt_res = wal3.walletcreatefundedpsbt([], [{bitcoind.supply_wallet.getnewaddress(): 0.15}], 0, {"fee_rate": 15})
+    last_correct = base64.b64decode(psbt_res["psbt"])
+    attempt_psbt(last_correct)
+
+    # check ms txn not accepted when rule spec's a single signer
+    tweak_rule(0, dict(wallet='1'))
+    attempt_psbt(last_correct, 'wrong miniscript wallet')
+
+    stat = hsm_status()
+    assert stat.approvals == 4
+    assert stat.refusals == 5
 
 @pytest.mark.parametrize('with_whitelist_opts', [ False, True])
 def test_whitelist_single(dev, start_hsm, tweak_rule, attempt_psbt, fake_txn, with_whitelist_opts, amount=5E6):
@@ -589,12 +701,11 @@ def test_whitelist_single(dev, start_hsm, tweak_rule, attempt_psbt, fake_txn, wi
         policy = DICT(rules=[dict(whitelist=[junk], whitelist_opts=dict(mode="BASIC"))])
     else:
         policy = DICT(rules=[dict(whitelist=[junk])])
-    started = False
 
     start_hsm(policy)
 
     # try all addr types
-    for style in ['p2wpkh', 'p2wsh', 'p2sh', 'p2pkh', 'p2wsh-p2sh', 'p2wpkh-p2sh']:
+    for style in ['p2wpkh', 'p2wsh', 'p2sh', 'p2pkh', 'p2wsh-p2sh', 'p2wpkh-p2sh', 'p2tr']:
         dests = []
         psbt = fake_txn(1, 2, dev.master_xpub,
                             outstyles=[style, 'p2wpkh'],
@@ -887,7 +998,7 @@ def test_multiple_signings_multisig(cc_first, M_N, dev, quick_start_hsm,
                 psbt_str = resp.get("psbt")
                 signed +=1
                 # do not want to finalize this
-                if signed == M - 1:
+                if signed == (M - 1):
                     break
 
         psbt = base64.b64decode(psbt_str)
@@ -1156,6 +1267,30 @@ def test_show_p2sh_addr(dev, hsm_reset, start_hsm, change_hsm, make_myself_walle
             got_addr = dev.send_recv(CCProtocolPacker.show_p2sh_address(
                                     M, xfp_paths, scr, addr_fmt=AF_P2WSH))
         assert 'Not allowed in HSM mode' in str(ee)
+
+def test_show_miniscript_addr(dev, offer_minsc_import, start_hsm,
+                              change_hsm, need_keypress):
+    from test_miniscript import CHANGE_BASED_DESCS
+    name = "hsm_msc_msas"
+    xd = json.dumps({"name": name, "desc": CHANGE_BASED_DESCS[0]})
+    title, story = offer_minsc_import(xd)
+    assert "Create new miniscript wallet?" in story
+    assert name in story
+    need_keypress("y")
+    time.sleep(.2)
+
+    policy = DICT(share_addrs=["any", "p2sh"], rules=[dict(wallet=name)])
+    start_hsm(policy)
+
+    with pytest.raises(CCProtoError) as ee:
+        dev.send_recv(CCProtocolPacker.miniscript_address(name, False, 0))
+    assert "Not allowed in HSM mode" in ee.value.args[0]
+
+    # change policy to allow miniscript address show
+    policy = DICT(share_addrs=["any", "p2sh", "msas"], rules=[dict(wallet=name)])
+    change_hsm(policy)
+    addr = dev.send_recv(CCProtocolPacker.miniscript_address(name, False, 0))
+    assert addr[2:4] == "1q"
 
 def test_xpub_sharing(dev, start_hsm, change_hsm, addr_fmt=AF_CLASSIC):
     # xpub sharing, but only at certain derivations


### PR DESCRIPTION
* edge allow `wallet` rule for miniscript wallets
* `msas` in `share_addrs` for queying miniscript addresses in HSM mode