### PR TITLE
bugfix: final flag was missing in framing error response

### DIFF
--- a/releases/ChangeLog.md
+++ b/releases/ChangeLog.md
@@ -1,6 +1,7 @@
 ## 5.2.3 - 2024-XX-XX
 
 - Bugfix: Saving passphrase on SD Card caused a freeze that required reboot
+- Bugfix: Properly handle and finalize framing error response
 
 ## 5.2.2 - 2023-12-21
 

--- a/shared/multisig.py
+++ b/shared/multisig.py
@@ -694,7 +694,7 @@ class MultisigWallet:
         #
         expect_chain = chains.current_chain().ctype
         if "sortedmulti(" in config or MultisigDescriptor.is_descriptor(config):
-            # assume descriptor, classic config should not contain sertedmulti( and check for checksum separator
+            # assume descriptor, classic config should not contain sortedmulti( and check for checksum separator
             # ignore name
             _, addr_fmt, xpubs, has_mine, M, N = cls.from_descriptor(config)
         else:


### PR DESCRIPTION
From Alfred Hodler:

> Firmware, usb.py: `def framing_error(self, why)` tries to construct the return packet manually and forgets to set the `0x80` bit to signal that it's the only (and last) packet in the response... cause the program on the other side of the wire to hang waiting for more packets...
