### PR TITLE
bugfix: multisig ascii input validation

### DIFF
--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -71,6 +71,7 @@
   the active multisig wallet, and cannot be used to describe an unrelated (multisig) wallet.
 - derivation path for each cosigner must be known and consistent with PSBT
 - XFP values (fingerprints) MUST be unique for each of the co-signers
+- multisig wallet `name` can only contain printable ASCII characters `range(32, 127)`
 
 
 # SIGHASH types

--- a/releases/ChangeLog.md
+++ b/releases/ChangeLog.md
@@ -3,6 +3,8 @@
 - Bugfix: Saving passphrase on SD Card caused a freeze that required reboot
 - Bugfix: Properly handle and finalize framing error response
 - Bugfix: `Brick Me` option for `If Wrong` PIN caused yikes
+- Bugfix: Do not allow non-ascii or ascii non-printable characters in multisig
+  wallet name
 
 ## 5.2.2 - 2023-12-21
 

--- a/shared/auth.py
+++ b/shared/auth.py
@@ -15,7 +15,7 @@ from ux import ux_aborted, ux_show_story, abort_and_goto, ux_dramatic_pause, ux_
 from ux import show_qr_code
 from usb import CCBusyError
 from utils import HexWriter, xfp2str, problem_file_line, cleanup_deriv_path
-from utils import B2A, parse_addr_fmt_str
+from utils import B2A, parse_addr_fmt_str, to_ascii_printable
 from psbt import psbtObject, FatalPSBTIssue, FraudulentChangeOutput
 from exceptions import HSMDenied
 from version import MAX_TXN_LEN
@@ -278,27 +278,14 @@ def validate_text_for_signing(text):
     # - messages must be short and ascii only. Our charset is limited
     # - too many spaces, leading/trailing can be an issue
 
-    MSG_CHARSET = range(32, 127)
     MSG_MAX_SPACES = 4      # impt. compared to -=- positioning
 
-    try:
-        result = str(text, 'ascii')
-    except UnicodeError:
-        raise AssertionError('must be ascii')
+    result = to_ascii_printable(text)
 
     length = len(result)
     assert length >= 2, "msg too short (min. 2)"
     assert length <= MSG_SIGNING_MAX_LENGTH, "msg too long (max. %d)" % MSG_SIGNING_MAX_LENGTH
-    run = 0
-    for ch in result:
-        assert ord(ch) in MSG_CHARSET, "bad char: 0x%02x in msg" % ord(ch)
-
-        if ch == ' ':
-            run += 1
-            assert run < MSG_MAX_SPACES, 'too many spaces together in msg(max. 4)'
-        else:
-            run = 0
-
+    assert "   " not in result, 'too many spaces together in msg(max. 3)'
     # other confusion w/ whitepace
     assert result[0] != ' ', 'leading space(s) in msg'
     assert result[-1] != ' ', 'trailing space(s) in msg'

--- a/shared/multisig.py
+++ b/shared/multisig.py
@@ -3,7 +3,7 @@
 # multisig.py - support code for multisig signing and p2sh in general.
 #
 import stash, chains, ustruct, ure, uio, sys, ngu, uos, ujson
-from utils import xfp2str, str2xfp, swab32, cleanup_deriv_path, keypath_to_str
+from utils import xfp2str, str2xfp, swab32, cleanup_deriv_path, keypath_to_str, to_ascii_printable
 from utils import str_to_keypath, problem_file_line, export_prompt_builder, parse_extended_key
 from ux import ux_show_story, ux_confirm, ux_dramatic_pause, ux_clear_keys, ux_enter_bip32_index
 from files import CardSlot, CardMissingError, needs_microsd
@@ -716,7 +716,7 @@ class MultisigWallet:
             name = '%d-of-%d' % (M, N)
 
         try:
-            name = str(name, 'ascii')
+            name = to_ascii_printable(name)
             assert 1 <= len(name) <= 20
         except:
             raise AssertionError('name must be ascii, 1..20 long')

--- a/shared/utils.py
+++ b/shared/utils.py
@@ -175,6 +175,30 @@ def str2xfp(txt):
     # Inverse of xfp2str
     return ustruct.unpack('<I', a2b_hex(txt))[0]
 
+def is_ascii(s):
+    if len(s) == len(s.encode()):
+        return True
+    return False
+
+def is_printable(s):
+    PRINTABLE = range(32, 127)
+    for ch in s:
+        if ord(ch) not in PRINTABLE:
+            return False
+    return True
+
+def to_ascii_printable(s, strip=False):
+    try:
+        s = str(s, 'ascii')
+        if strip:
+            s = s.strip()
+        assert is_ascii(s)
+        assert is_printable(s)
+        return s
+    except:
+        raise AssertionError('must be ascii printable')
+
+
 def problem_file_line(exc):
     # return a string of just the filename.py and line number where
     # an exception occured. Best used on AssertionError.
@@ -211,10 +235,8 @@ def cleanup_deriv_path(bin_path, allow_star=False):
     # - if allow_star, then final position can be * or *' (wildcard)
     import ure
     from public_constants import MAX_PATH_DEPTH
-    try:
-        s = str(bin_path, 'ascii').lower()
-    except UnicodeError:
-        raise AssertionError('must be ascii')
+
+    s = to_ascii_printable(bin_path, strip=True).lower()
 
     # empty string is valid
     if s == '': return 'm'

--- a/testing/test_msg.py
+++ b/testing/test_msg.py
@@ -63,7 +63,7 @@ def test_sign_msg_refused(dev, need_keypress, msg=b'testing 123', path='m'):
     ('23234pp', 'bad component'),
     ("23234p'", 'bad component'),
     ("m/1p/3455343434443534543345p", 'bad component'),
-    ("m/\n34p", 'invalid characters'),
+    ("m/\n34p", 'must be ascii printable'),
     ("2147483648/1/2/3", 'bad component'),    # 2**31 = 0x80000000 not allowed (because that's 0')
     ("214748364800/1/2/3", 'bad component'),
     ('/'.join('0' for i in range(13)), 'too deep'),
@@ -209,14 +209,19 @@ def sign_using_nfc(goto_home, pick_menu_item, nfc_write_text, cap_story):
     ('hello%20sworld'%'', 'many spaces', 0),        # spaces
     ('hello%10sworld'%'', 'many spaces', 0),        # spaces
     ('hello%5sworld'%'', 'many spaces', 0),        # spaces
-    ('test\ttest', "bad char: 0x09", 0),
-    ])
+    ('test\ttest', "must be ascii printable", 0),
+    ('testêtest', "must be ascii printable", 0),
+])
 @pytest.mark.parametrize('transport', ['sd', 'usb', 'nfc'])
 def test_sign_msg_fails(dev, sign_on_microsd, msg, concern, no_file, transport, sign_using_nfc, path='m/12/34'):
 
     if transport == 'usb':
         with pytest.raises(CCProtoError) as ee:
-            dev.send_recv(CCProtocolPacker.sign_message(msg.encode('ascii'), path), timeout=None)
+            try:
+                encoded_msg = msg.encode('ascii')
+            except UnicodeEncodeError:
+                encoded_msg = msg.encode()
+            dev.send_recv(CCProtocolPacker.sign_message(encoded_msg, path), timeout=None)
         story = ee.value.args[0]
     elif transport == 'sd':
         try:

--- a/testing/test_multisig.py
+++ b/testing/test_multisig.py
@@ -144,9 +144,9 @@ def make_multisig(dev, sim_execfile):
 
 @pytest.fixture
 def offer_ms_import(cap_story, dev, need_keypress):
-    def doit(config):
+    def doit(config, allow_non_ascii=False):
         # upload the file, trigger import
-        file_len, sha = dev.upload_file(config.encode('ascii'))
+        file_len, sha = dev.upload_file(config.encode('utf-8' if allow_non_ascii else 'ascii'))
 
         open('debug/last-config.txt', 'wt').write(config)
 
@@ -2646,5 +2646,22 @@ def test_multisig_descriptor_export(M_N, way, addr_fmt, cmn_pth_from_root, clear
         else:
             assert obj["desc"] == bare_desc
     clear_ms()
+
+
+def test_multisig_name_validation(microsd_path, offer_ms_import):
+    with open("data/multisig/export-p2wsh-myself.txt", "r") as f:
+        config = f.read()
+
+    c0 = config.replace("Name: CC-2-of-4", "Name: eê")
+
+    with pytest.raises(Exception) as e:
+        offer_ms_import(c0, allow_non_ascii=True)
+    assert "must be ascii" in e.value.args[0]
+
+    c0 = config.replace("Name: CC-2-of-4", "Name: eee\teee")
+
+    with pytest.raises(Exception) as e:
+        offer_ms_import(c0, allow_non_ascii=True)
+    assert "must be ascii" in e.value.args[0]
 
 # EOF


### PR DESCRIPTION
* only allow printable ascii characters `range(32, 127)` as multisig wallet name
* push `ckcc-protocol` to current master HEAD
