### PR TITLE
always use SettingsObject class for master data

### DIFF
--- a/shared/pincodes.py
+++ b/shared/pincodes.py
@@ -479,6 +479,7 @@ class PinAttempt:
     def tmp_secret(self, encoded, chain=None, bip39pw=''):
         # Use indicated secret and stop using the SE; operate like this until reboot
         from glob import settings
+        from nvstore import SettingsObject
 
         val = bytes(encoded + bytes(AE_SECRET_LEN - len(encoded)))
         if self.tmp_value == val:
@@ -490,9 +491,9 @@ class PinAttempt:
             # disallow using master seed as temporary
             master_err = "Cannot use master seed as temporary."
             target_nvram_key = settings.hash_key(encoded)
-            if settings.master_nvram_key:
+            if SettingsObject.master_nvram_key:
                 assert self.tmp_value
-                if target_nvram_key == settings.master_nvram_key:
+                if target_nvram_key == SettingsObject.master_nvram_key:
                     return False, master_err
             else:
                 if target_nvram_key == settings.nvram_key:

--- a/shared/seed.py
+++ b/shared/seed.py
@@ -693,8 +693,8 @@ async def remember_ephemeral_seed():
     # old master settings are destroyed
     dis.fullscreen("Cleanup...")
     assert pa.tmp_value, "no tmp"
-    assert settings.master_nvram_key, "master nvram k"
-    old_master = SettingsObject(settings.master_nvram_key)
+    assert SettingsObject.master_nvram_key, "master nvram k"
+    old_master = SettingsObject(SettingsObject.master_nvram_key)
     old_master.load()
     old_master.blank()
     del old_master
@@ -703,8 +703,8 @@ async def remember_ephemeral_seed():
     pa.change(new_secret=pa.tmp_value, tmp_lockdown=True)
 
     # not needed - will be handled by reboot
-    settings.master_nvram_key = None
-    settings.master_sv_data = {}
+    SettingsObject.master_nvram_key = None
+    SettingsObject.master_sv_data = {}
 
     # check and reload secret
     pa.reset()

--- a/testing/devtest/clear_seed.py
+++ b/testing/devtest/clear_seed.py
@@ -6,6 +6,7 @@ from pincodes import pa
 from glob import settings
 from pincodes import AE_SECRET_LEN, PA_IS_BLANK
 from sim_settings import sim_defaults
+from nvstore import SettingsObject
 
 if not pa.is_secret_blank():
     # clear settings associated with this key, since it will be no more
@@ -24,8 +25,8 @@ if not pa.is_secret_blank():
     assert pa.is_secret_blank()
     settings.blank()
 
-settings.master_sv_data = {}
-settings.master_nvram_key = None
+SettingsObject.master_sv_data = {}
+SettingsObject.master_nvram_key = None
 # reset top menu and go there
 from actions import goto_top_menu
 goto_top_menu()


### PR DESCRIPTION
* this is NOT a bug fix as using instance `settings` work properly on real HW which requires a reboot
* unification of access via class instance
* fixes `test_bip39pw.py` on simulator
