### PR TITLE
bugfix: PSBTv2 PSBT_GLOBAL_TX_MODIFIABLE parsing

### DIFF
--- a/releases/Next-ChangeLog.md
+++ b/releases/Next-ChangeLog.md
@@ -4,6 +4,7 @@ This lists the new changes that have not yet been published in a normal release.
 
 # Shared Improvements - Both Mk4 and Q
 
+- Bugfix: Fix PSBTv2 PSBT_GLOBAL_TX_MODIFIABLE parsing
 
 # Mk4 Specific Changes
 

--- a/shared/psbt.py
+++ b/shared/psbt.py
@@ -947,7 +947,7 @@ class psbtInputProxy(psbtProxy):
 
 class psbtObject(psbtProxy):
     "Just? parse and store"
-
+    short_values = { PSBT_GLOBAL_TX_MODIFIABLE }
     no_keys = { PSBT_GLOBAL_UNSIGNED_TX }
 
     def __init__(self):
@@ -1029,6 +1029,8 @@ class psbtObject(psbtProxy):
             self.num_outputs = deser_compact_size(BytesIO(self.get(val)))
             self.has_goc = True
         elif kt == PSBT_GLOBAL_TX_MODIFIABLE:
+            # bytes of length 1 (tx modifiable in short_values)
+            assert len(val) == 1
             self.txn_modifiable = val[0]
         else:
             self.unknown = self.unknown or {}


### PR DESCRIPTION
* bug that result in invalid PSBT after we serialize it back, or even with yikes (if position of `PSBT_GLOBAL_TX_MODIFIABLE` in PSBT is more than 255)
