### PR TITLE
tx output explorer

### DIFF
--- a/releases/Next-ChangeLog.md
+++ b/releases/Next-ChangeLog.md
@@ -4,6 +4,7 @@ This lists the new changes that have not yet been published in a normal release.
 
 # Shared Improvements - Both Mk4 and Q
 
+- New Feature: Transaction output explorer
 - Enhancement: Stricter p2sh-p2wpkh validation 
 - Enhancement: mention the need to remove old duress wallets before locking down temporary seed
 - Bugfix: Fix PSBTv2 `PSBT_GLOBAL_TX_MODIFIABLE` parsing

--- a/shared/auth.py
+++ b/shared/auth.py
@@ -21,7 +21,7 @@ from psbt import psbtObject, FatalPSBTIssue, FraudulentChangeOutput
 from files import CardSlot
 from exceptions import HSMDenied
 from version import MAX_TXN_LEN
-from charcodes import KEY_QR, KEY_NFC, KEY_ENTER, KEY_CANCEL
+from charcodes import KEY_QR, KEY_NFC, KEY_ENTER, KEY_CANCEL, KEY_LEFT, KEY_RIGHT
 
 # Where in SPI flash/PSRAM the two PSBT files are (in and out)
 TXN_INPUT_OFFSET = 0
@@ -728,17 +728,27 @@ class ApproveTransaction(UserAuthorizedAction):
                 self.result = await self.save_visualization(msg, (self.stxn_flags & STXN_SIGNED))
                 del self.psbt
                 self.done()
-
                 return
 
             ux_clear_keys(True)
             dis.progress_bar_show(1)  # finish the Validating...
             if not hsm_active:
-                msg.write("Press OK to approve and sign transaction.")
+                explore = self.psbt.num_outputs > 10
+                msg.write("\nPress OK to approve and sign transaction.")
+                if explore:
+                    msg.write(" Press (2) to explore txn.")
                 if self.is_sd and CardSlot.both_inserted():
                     msg.write(" (B) to write to lower SD slot.")
                 msg.write(" X to abort.")
-                ch = await ux_show_story(msg, title="OK TO SEND?", escape="b")
+                while True:
+                    ch = await ux_show_story(msg, title="OK TO SEND?", escape="2b")
+                    if ch == "2" and explore:
+                        await self.txn_explorer()
+                        continue
+                    else:
+                        msg.close()
+                        del msg
+                        break
             else:
                 ch = await hsm_active.approve_transaction(self.psbt, self.psbt_sha, msg.getvalue())
                 dis.progress_bar_show(1)     # finish the Validating...
@@ -831,6 +841,51 @@ class ApproveTransaction(UserAuthorizedAction):
                                                self.result[0], self.result[1])
                     continue
                 break
+
+    async def txn_explorer(self):
+        from glob import dis
+        start = 0
+        n = 10
+
+        def make_msg(start, n):
+            dis.fullscreen('Wait...')
+            rv = ""
+            end = min(start + n, self.psbt.num_outputs)
+
+            for idx, out in self.psbt.output_iter(start, end):
+                outp = self.psbt.outputs[idx]
+                item = "Output %d%s:\n\n" % (idx, " (change)" if outp.is_change else "")
+                item += self.render_output(out)
+                item += "\n"
+                rv += item
+
+            if self.psbt.num_outputs > n:
+                rv += "Press RIGHT to see next group, LEFT to go back. X to quit."
+            return rv
+
+        msg = make_msg(start, n)
+        while True:
+            ch = await ux_show_story(msg, escape='79'+KEY_RIGHT+KEY_LEFT)
+            if ch == 'x':
+                del msg
+                return
+            elif (ch in KEY_LEFT+"7"):
+                # go backwards in explorer
+                if (start - n) < 0:
+                    continue
+                else:
+                    start -= n
+            elif (ch in KEY_RIGHT+"9"):
+                # go forwards
+                if (start + n) >= self.psbt.num_outputs:
+                    continue
+                else:
+                    start += n
+            else:
+                # nothing changed - do not recalc msg
+                continue
+
+            msg = make_msg(start, n)
 
     async def save_visualization(self, msg, sign_text=False):
         # write text into spi flash, maybe signing it as we go

--- a/shared/ux.py
+++ b/shared/ux.py
@@ -196,11 +196,6 @@ async def ux_show_story(msg, title=None, escape=None, sensitive=False,
             ln = q1_reword(ln)
 
             lines.extend(word_wrap(ln, CH_PER_W))
-
-        # no longer needed & rude to our caller, but let's save the memory
-        msg.close()
-        del msg
-        gc.collect()
     else:
         # simple string being shown
         msg = q1_reword(msg)

--- a/testing/test_bbqr.py
+++ b/testing/test_bbqr.py
@@ -253,16 +253,25 @@ def test_bbqr_psbt(size, encoding, max_ver, partial, segwit, scan_a_qr, readback
     if file_type == 'T':
         assert not partial
         decoded = decode_with_bitcoind(rb)
-    elif file_type == 'P':
+        ic, oc = len(decoded['vin']), len(decoded['vout'])
+    else:
+        assert file_type == 'P'
         assert partial
         assert rb[0:4] == b'psbt'
         decoded = decode_psbt_with_bitcoind(rb)
         assert not decoded['unknown']
-        decoded = decoded['tx']
+        if 'tx' in decoded:
+            # psbt v0
+            decoded = decoded['tx']
+            ic, oc = len(decoded['vin']), len(decoded['vout'])
+        else:
+            # expect psbt v2
+            ic = decoded["input_count"]
+            oc = decoded["output_count"]
 
     # just smoke test; syntax not content
-    assert len(decoded['vin']) == num_in
-    assert len(decoded['vout']) == num_out
+    assert ic == num_in
+    assert oc == num_out
 
     press_cancel()      # back to menu
 

--- a/testing/test_hsm.py
+++ b/testing/test_hsm.py
@@ -1518,7 +1518,7 @@ def test_priv_over_ux(quick_start_hsm, hsm_status, load_hsm_users):
 @pytest.mark.parametrize("allow_op_return", [False, True])
 def test_op_return_output_local(op_return_data, start_hsm, attempt_psbt, fake_txn, allow_op_return):
     dests = []
-    psbt = fake_txn(2, 2, op_return=(0, op_return_data), capture_scripts=dests)
+    psbt = fake_txn(2, 2, op_return=[(0, op_return_data)], capture_scripts=dests)
     if allow_op_return:
         policy = DICT(rules=[dict(whitelist=[render_address(d) for d in dests[0:2]],
             whitelist_opts=dict(allow_zeroval_outs=True))])


### PR DESCRIPTION
* add ability to "explore" all tx outputs (useful txs with out > 10)
*  fix `fake_ms_txn` and add psbtV2 to fixture
* add ability to add multiple `op_return`s to `fake_txn` fixture