### PR TITLE
NFC Push Tx feature

### DIFF
--- a/docs/nfc-pushtx.md
+++ b/docs/nfc-pushtx.md
@@ -1,0 +1,76 @@
+# NFC Push Tx
+
+This feature allows single-tap broadcast of the freshly-signed transaction.
+
+Once enabled with a URL, the COLDCARD will show the NFC animation
+after signing the transaction. When the user taps their phone, the
+phone will see an NFC tag with URL inside. That URL contains the
+signed transaction ready to go, and once opening in the mobile
+browser, that URL will load. The landing page will connect to a
+Bitcoin node (or similar) and send the transaction on the public
+Bitcoin network.
+
+This feature is available on Q and Mk4 and requires NFC to be enabled.
+See `Advanced/Tools > NFC Push Tx`
+
+## Protocol Spec
+
+The COLDCARD needs a URL prefix. To that it appends some values:
+
+- `t=...` 
+  - this is the transaction, in binary encoded with
+    [base64url](https://datatracker.ietf.org/doc/html/rfc4648#section-5)
+
+- `&c=...`
+    - the rightmost 8 bytes of SHA256 over the transaction. Also `base64url` encoded.
+
+- `&n=XTN`
+    - if, and only if, the COLDCARD is set for Testnet, this value is appended to
+      indicate that the transaction is for Testnet3 and not MainNet.
+    - when RegTest is enabled, the value will be `XRT`
+
+We provide a few default URL values to our customers, including one backend we
+will operate. The URL can also be directly entered by the customer. On the Q, 
+it can be scanned from a QR code.
+
+For COLDCARD backend, the url used is:
+
+    https://coldcard.com/pushtx#
+
+The complete URL with a typical transaction might look like this (but longer):
+
+    https://coldcard.com/pushtx#t=AgAAAAMNCxXtp2GVYVhkRXHLMmdZFs4p3kbFK ⋯ ABf&c=uiSVRda-1tw
+
+We are using hash symbol here so that our server logs do not get
+contaminated with the arguments. The landing page uses javascript
+to read the hash part of the URL and decodes from there. If you
+prefer, your URL can end with `?` and then the arguments will be
+sent by the phone's browser to your server. Your processing can be
+entirely done in the backend in this case.
+
+## Expectations for the Backend
+
+Your code should decode the transaction and check the SHA-256 hash
+matches. If it does not match, or if `c` value is missing, assume
+the URL has been truncated and report that to the user.
+
+Once decoded, your code should immediately broadcast the transaction.
+A confirmation step is not required in our opinion. Once it is
+submitted to Bitcoin Core (or other API), any status response should
+be decoded and shown to the user so they know it is on it's way.
+If it was not accepted, please report the error to the user as
+clearly as possible.
+
+Next, it would make sense to either link to the TXID on a block
+explorer to provide further proof that it has been sent and that
+it is now waiting in the mempool.
+
+### Notes
+
+- Complete URL might be as large as 8,000 bytes. Some web servers will not support beyond
+  4k bytes and the NFC implementation of the phone may also have limits.
+- The service URL provided must end in `?` or `#` or `&`.
+- `base64url` values from COLDCARD will not have padding (`=` bytes) at end.
+- Honest backends will not log the IP address of incoming transactions, but there is
+  no way to enforce that, and CloudFlare sees all.
+

--- a/docs/nfc-pushtx.md
+++ b/docs/nfc-pushtx.md
@@ -67,7 +67,7 @@ it is now waiting in the mempool.
 
 ## Backend Implementations
 
-- Mempool.space's [implementation of this feature](https://github.com/mempool/mempool/pull/5132)
+- Mempool.space's [implementation of this feature](https://github.com/mempool/mempool/pull/5132).
 
 - A single-file (html and javascript) file is available
   at [coldcard.com/static/coldcard-pushtx.html](https://coldcard.com/static/coldcard-pushtx.html).

--- a/docs/nfc-pushtx.md
+++ b/docs/nfc-pushtx.md
@@ -65,6 +65,17 @@ Next, it would make sense to either link to the TXID on a block
 explorer to provide further proof that it has been sent and that
 it is now waiting in the mempool.
 
+## Backend Implementations
+
+- Mempool.space's [implementation of this feature](https://github.com/mempool/mempool/pull/5132)
+
+- A single-file (html and javascript) file is available
+  at [coldcard.com/static/coldcard-pushtx.html](https://coldcard.com/static/coldcard-pushtx.html).
+  You can host this file anywhere your phone can reach, and then use that URL in your
+  COLDCARD settings. It uses your phone's browser to submit directly
+  to `mempool.space` and `blockstream.info` sites (both at same time). It is equivalent
+  to the page hosted at `https://coldcard.com/pushtx#`
+
 ### Notes
 
 - Complete URL might be as large as 8,000 bytes. Some web servers will not support beyond
@@ -72,7 +83,6 @@ it is now waiting in the mempool.
 - The service URL provided must end in `?` or `#` or `&`.
 - `base64url` values from COLDCARD will not have padding (`=` bytes) at end.
 - POST cannot be used directly because the expect the phone to do a GET on the URL provided.
-- Mempool.space's [implementation of this feature](https://github.com/mempool/mempool/pull/5132)
 - Honest backends will not log the IP address of incoming transactions, but there is
   no way to enforce that, and CloudFlare sees all.
 

--- a/docs/nfc-pushtx.md
+++ b/docs/nfc-pushtx.md
@@ -30,8 +30,8 @@ The COLDCARD needs a URL prefix. To that it appends some values:
     - when RegTest is enabled, the value will be `XRT`
 
 We provide a few default URL values to our customers, including one backend we
-will operate. The URL can also be directly entered by the customer. On the Q, 
-it can be scanned from a QR code.
+will operate on `colcard.com`. The URL can also be directly entered by the
+customer. On the Q, it can be scanned from a QR code.
 
 For COLDCARD backend, the url used is:
 
@@ -71,6 +71,18 @@ it is now waiting in the mempool.
   4k bytes and the NFC implementation of the phone may also have limits.
 - The service URL provided must end in `?` or `#` or `&`.
 - `base64url` values from COLDCARD will not have padding (`=` bytes) at end.
+- POST cannot be used directly because the expect the phone to do a GET on the URL provided.
+- Mempool.space's [implementation of this feature](https://github.com/mempool/mempool/pull/5132)
 - Honest backends will not log the IP address of incoming transactions, but there is
   no way to enforce that, and CloudFlare sees all.
+
+## Example URL
+
+```
+https://mempool.space/pushtx#t=AgAAAAOHqK3w3hC6PSC0buthnJA5R9Y88WAlEvm9cifNVUPhIwAAAABqRzBEAiB-M9YprNYoohqHdQHg4wY_qcEMwDmyIQH8prykk8-0KwIgARxcojKrtixicouiUxhk4jQq_MAl11ptIgHDlRjgk5ABIQM4bgMAVDbDSr_9CvLjbg5nxrWnDGI-kVmkfL81GXZtCf____8OaH0RxW7DjZKdIF6rvbHvvyFGCBQ0PTgpx20nA_wbLgAAAABqRzBEAiBwUFigORJDPK8ptnYPAntjV-RUn1jAuzphicQstwVv-QIgEbMC8FWXQ5Jve5DaAqKJsqoj3peK83iub_oOkmbiYg4BIQO5Ehn2t0oUG3hnK4cBnwCwMc33DcdJ8aSMWzRQ_wjZL_____-UG6M-eBeAun-EZp6EbVypvVJ3mXCQrN_fUDn-kwoEnQAAAABqRzBEAiAgFAtVTpQYTKplc9NuV7Ws7ZFYeNO8BCS4ozgWrgd2ogIgGTTcw98xQdcGWeWQhVfVm_vZorBIOYovQPQeK0Lg9t8BIQLPWPioVWvj1z4NMHBCkeirYOUalCa83wbSH0CREnGZvv____8CjM_wCAAAAAAZdqkUIJA8_yqzaj0NzhvYVEIBno5gETGIrIzP8AgAAAAAGXapFEaV7xTyleuEX9OejdlUlsz7RTr0iKwAAAAA&c=hre47vyMC78&n=XTN
+```
+
+- this transaction doesn't have valid inputs, and will cause an error
+- mempool.space will redirect this to a testnet endpoint (because ends with `n=XTN`)
+
 

--- a/docs/nfc-pushtx.md
+++ b/docs/nfc-pushtx.md
@@ -2,6 +2,8 @@
 
 This feature allows single-tap broadcast of the freshly-signed transaction.
 
+`PSBT ==[SD|QR|NFC]==> COLDCARD signed TXN ==[NFC tap]==> Phone Browser ==> Server TXN Broadcast`
+
 Once enabled with a URL, the COLDCARD will show the NFC animation
 after signing the transaction. When the user taps their phone, the
 phone will see an NFC tag with URL inside. That URL contains the

--- a/releases/Next-ChangeLog.md
+++ b/releases/Next-ChangeLog.md
@@ -4,6 +4,8 @@ This lists the new changes that have not yet been published in a normal release.
 
 # Shared Improvements - Both Mk4 and Q
 
+- New Feature: PushTX: when enabled with a service provider's URL, you can tap the COLDCARD
+  after signing with your phone and the transaction will be broadcast directly.
 - Enhancement: Stricter p2sh-p2wpkh validation 
 - Enhancement: mention the need to remove old duress wallets before locking down temporary seed
 - Bugfix: Fix PSBTv2 `PSBT_GLOBAL_TX_MODIFIABLE` parsing

--- a/shared/actions.py
+++ b/shared/actions.py
@@ -1412,10 +1412,19 @@ Erases and reformats MicroSD card. This is not a secure erase but more of a quic
 
 
 async def nfc_share_file(*A):
-    # Mk4: Share txt, txn and PSBT files over NFC.
+    # Share txt, txn and PSBT files over NFC.
     from glob import NFC
     try:
         await NFC.share_file()
+    except Exception as e:
+        await ux_show_story(title="ERROR", msg="Failed to share file. %s" % str(e))
+
+async def nfc_pushtx_file(*A):
+    # Share a signed txn over NFC using PushTx technology
+    # - requires a signed txn, perhaps from another system on SD card
+    from glob import NFC
+    try:
+        await NFC.push_tx_from_file()
     except Exception as e:
         await ux_show_story(title="ERROR", msg="Failed to share file. %s" % str(e))
 

--- a/shared/actions.py
+++ b/shared/actions.py
@@ -2156,7 +2156,8 @@ async def _scan_any_qr(expect_secret=False, tmp=False):
 PUSHTX_SUPPLIERS = [
     # (label, URL)
     ('coldcard.com', 'https://coldcard.com/pushtx#' ),
-    ('mempool.space', 'https://mempool.space/tx/push?' ),
+    # from https://github.com/mempool/mempool/pull/5132
+    ('mempool.space', 'https://mempool.space/pushtx#' ),
 ]
 
 async def pushtx_setup_menu(*a):

--- a/shared/actions.py
+++ b/shared/actions.py
@@ -2155,8 +2155,8 @@ async def _scan_any_qr(expect_secret=False, tmp=False):
 
 PUSHTX_SUPPLIERS = [
     # (label, URL)
-    ('coldcard.com', 'https://coldcard.com/pushtx?' ),
-    ('mempool.space', 'https://mempool.space/tx/push?tx=' ),
+    ('coldcard.com', 'https://coldcard.com/pushtx#' ),
+    ('mempool.space', 'https://mempool.space/tx/push?' ),
 ]
 
 async def pushtx_setup_menu(*a):
@@ -2203,8 +2203,14 @@ async def pushtx_setup_menu(*a):
         while 1:
             nv = await ux_input_text(val, confirm_exit=True, scan_ok=True, prompt="Enter URL")
             # cleanup? URL validation? 
-            if nv and ('http://' not in nv and 'https://' not in nv) or len(nv) < 12:
-                await ux_show_story("Must start with http:// or https://. Try again")
+            if nv:
+                if ('http://' not in nv and 'https://' not in nv):
+                    prob = "Must start with http:// or https://."
+                elif len(nv) < 12:
+                    prob = "Too short."
+                if nv[-1] not in '#?&':
+                    prob = "Final char must be # or ? or &."
+                await ux_show_story(prob + " Try again.")
                 val = nv
                 continue
             break

--- a/shared/auth.py
+++ b/shared/auth.py
@@ -806,7 +806,7 @@ class ApproveTransaction(UserAuthorizedAction):
         except BaseException as exc:
             return await self.failure("PSBT output failed", exc)
 
-        from glob import NFC, settings
+        from glob import NFC, settings, PSRAM
 
         if self.do_finalize and txid and not hsm_active:
 
@@ -814,7 +814,8 @@ class ApproveTransaction(UserAuthorizedAction):
             url = settings.get('ptxurl', False)
             if NFC and url:
                 try:
-                    await NFC.share_push_tx(url, txid, TXN_OUTPUT_OFFSET, self.result[0], self.result[1])
+                    data = PSRAM.read_at(TXN_OUTPUT_OFFSET, self.result[0])
+                    await NFC.share_push_tx(url, txid, data, self.result[1])
                     return
                 except:
                     # continue normally if it fails, perhaps too big?

--- a/shared/auth.py
+++ b/shared/auth.py
@@ -779,7 +779,7 @@ class ApproveTransaction(UserAuthorizedAction):
             return await self.failure("Signing failed late", exc)
 
         if self.approved_cb:
-            # for micro sd case
+            # for NFC, micro SD cases
             kws = dict(psbt=self.psbt)
             if self.is_sd and (ch == "b"):
                 kws["slot_b"] = True

--- a/shared/flow.py
+++ b/shared/flow.py
@@ -343,6 +343,7 @@ AdvancedNormalMenu = [
                             f=drv_entro_start),
     MenuItem("View Identity", f=view_ident),
     MenuItem("Temporary Seed", menu=make_ephemeral_seed_menu),
+    NonDefaultMenuItem('NFC PushTx', 'ptxurl', menu=pushtx_setup_menu),
     MenuItem('Paper Wallets', f=make_paper_wallet),
     ToggleMenuItem('Enable HSM', 'hsmcmd', ['Default Off', 'Enable'],
                    story=("Enable HSM? Enables all user management commands, and other HSM-only USB commands. "

--- a/shared/flow.py
+++ b/shared/flow.py
@@ -329,6 +329,7 @@ NFCToolsMenu = [
     MenuItem('Verify Address', f=nfc_address_verify),
     MenuItem('File Share', f=nfc_share_file),
     MenuItem('Import Multisig', f=import_multisig_nfc),
+    MenuItem('NFC Push Tx', f=nfc_pushtx_file, predicate=lambda: settings.get("ptxurl", False)),
 ]
 
 AdvancedNormalMenu = [

--- a/shared/flow.py
+++ b/shared/flow.py
@@ -329,7 +329,7 @@ NFCToolsMenu = [
     MenuItem('Verify Address', f=nfc_address_verify),
     MenuItem('File Share', f=nfc_share_file),
     MenuItem('Import Multisig', f=import_multisig_nfc),
-    MenuItem('NFC Push Tx', f=nfc_pushtx_file, predicate=lambda: settings.get("ptxurl", False)),
+    MenuItem('Push Transaction', f=nfc_pushtx_file, predicate=lambda: settings.get("ptxurl", False)),
 ]
 
 AdvancedNormalMenu = [
@@ -344,7 +344,7 @@ AdvancedNormalMenu = [
                             f=drv_entro_start),
     MenuItem("View Identity", f=view_ident),
     MenuItem("Temporary Seed", menu=make_ephemeral_seed_menu),
-    NonDefaultMenuItem('NFC PushTx', 'ptxurl', menu=pushtx_setup_menu),
+    NonDefaultMenuItem('NFC Push Tx', 'ptxurl', menu=pushtx_setup_menu),
     MenuItem('Paper Wallets', f=make_paper_wallet),
     ToggleMenuItem('Enable HSM', 'hsmcmd', ['Default Off', 'Enable'],
                    story=("Enable HSM? Enables all user management commands, and other HSM-only USB commands. "

--- a/shared/lcd_display.py
+++ b/shared/lcd_display.py
@@ -235,7 +235,7 @@ class Display:
         ch = (h+CELL_H) // CELL_H
         #print('pixel %dx%d @ (%d,%d) => %dx%d @ (%d,%d)' % (w, h, px,py,  cw, ch, cx,cy))
 
-        for y in range(cy, cy+ch+1):
+        for y in range(cy, cy+ch):
             for x in range(cx, cx+cw+1):
                 try:
                     self.last_buf[y][x] = self.next_buf[y][x] = 0xfffe

--- a/shared/nfc.py
+++ b/shared/nfc.py
@@ -259,6 +259,10 @@ class NFCHandler:
         if ch.ctype != 'BTC':
             url += '&n=' + ch.ctype         # XTN or XRT
 
+        if len(url) >= MAX_NFC_SIZE:
+            # ignoring overhead, this will not fit: so fail
+            raise ValueError("too big")
+
         n = ndef.ndefMaker()
         n.add_url(url, https=is_https)
 

--- a/shared/nvstore.py
+++ b/shared/nvstore.py
@@ -60,6 +60,7 @@ from utils import call_later_ms
 #   accts = (list of tuples: (addr_fmt, account#)) Single-sig wallets we've seen them use
 #   aei   = (bool) allow changing start index in Address Explorer
 #   b85max = (bool) allow max BIP-32 int value in BIP-85 derivations
+#   ptxurl = (str) URL for PushTx feature, clear to disable feature
 
 # Stored w/ key=00 for access before login
 #   _skip_pin = hard code a PIN value (dangerous, only for debug)

--- a/shared/utils.py
+++ b/shared/utils.py
@@ -180,7 +180,7 @@ class Base64Writer:
 
 def b2a_base64url(s):
     # see <https://datatracker.ietf.org/doc/html/rfc4648#section-5>
-    return b2a_base64(s).rstrip(b'=\n').replace(b'+', b'-').replace(b'/', b'_')
+    return b2a_base64(s).rstrip(b'=\n').replace(b'+', b'-').replace(b'/', b'_').decode()
 
 def swab32(n):
     # endian swap: 32 bits

--- a/shared/utils.py
+++ b/shared/utils.py
@@ -178,6 +178,10 @@ class Base64Writer:
             assert tmp[-2:-1] != b'=', tmp
             self.fd.write(tmp[:-1])
 
+def b2a_base64url(s):
+    # see <https://datatracker.ietf.org/doc/html/rfc4648#section-5>
+    return b2a_base64(s).rstrip(b'=\n').replace(b'+', b'-').replace(b'/', b'_')
+
 def swab32(n):
     # endian swap: 32 bits
     return ustruct.unpack('>I', ustruct.pack('<I', n))[0]

--- a/stm32/COLDCARD_Q1/file_time.c
+++ b/stm32/COLDCARD_Q1/file_time.c
@@ -2,12 +2,12 @@
 //
 // AUTO-generated.
 //
-//   built: 2024-05-08
-// version: 1.2.1Q
+//   built: 2024-06-03
+// version: 1.2.2Q
 //
 #include <stdint.h>
 
 // this overrides ports/stm32/fatfs_port.c
 uint32_t get_fattime(void) {
-    return 0x58a80840UL;
+    return 0x58c30840UL;
 }

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -1575,6 +1575,13 @@ def nfc_write(request, needs_nfc, is_q1):
         return doit_usb
 
 @pytest.fixture()
+def enable_nfc(needs_nfc, sim_exec, settings_set):
+    def doit():
+        settings_set('nfc', 1)
+        sim_exec('import nfc; nfc.NFCHandler.startup()')
+    return doit
+
+@pytest.fixture()
 def scan_a_qr(sim_exec, is_q1):
     # simulate a QR being scanned 
     # XXX limitation: our USB protocol can't send a v40 QR, limit is more like 30 or so

--- a/testing/test_nfc.py
+++ b/testing/test_nfc.py
@@ -419,7 +419,7 @@ def test_ndef_roundtrip(load_shared_mod):
 
 @pytest.mark.parametrize('num_outs', [2, 100, 250])
 @pytest.mark.parametrize('chain', ['BTC', 'XTN'])
-def test_nfc_pushtx(num_outs, chain, sim_exec, settings_set, settings_remove,
+def test_nfc_pushtx(num_outs, chain, enable_nfc, settings_set, settings_remove,
                     try_sign, fake_txn, nfc_block4rf, nfc_read, press_cancel,
                     cap_story, cap_screen, has_qwerty
 ):
@@ -433,7 +433,7 @@ def test_nfc_pushtx(num_outs, chain, sim_exec, settings_set, settings_remove,
 
     settings_set('chain', chain)
 
-    sim_exec('from pyb import SDCard; SDCard.ejected = True; import nfc; nfc.NFCHandler.startup()')
+    enable_nfc()
 
     prefix = 'http://10.0.0.10/pushtx#'
     settings_set('ptxurl', prefix)


### PR DESCRIPTION
This feature allows single-tap broadcast of the freshly-signed transaction.

Once enabled with a URL, the COLDCARD will show the NFC animation
after signing the transaction. When the user taps their phone, the
phone will see an NFC tag with URL inside. That URL contains the
signed transaction ready to go, and once opening in the mobile
browser, that URL will load. The landing page will connect to a
Bitcoin node (or similar) and send the transaction on the public
Bitcoin network.
