### PR TITLE
add shortcut to PSBT signing in `NFC tools`

### DIFF
--- a/releases/Next-ChangeLog.md
+++ b/releases/Next-ChangeLog.md
@@ -11,6 +11,7 @@ This lists the new changes that have not yet been published in a normal release.
   transaction on the MicroSD card (See `Tools > NFC Tools > Push Transaction`)
 - New Feature: Transaction output explorer: allows view output details of larger (10+ output)
   transactions before signing.
+- Enhancement: Add `Sign PSBT` shortcut to `NFC Tools` menu
 - Enhancement: Stricter p2sh-p2wpkh validation checks.
 - Enhancement: mention the need to remove old duress wallets before locking down temporary seed.
 - Bugfix: Fix PSBTv2 `PSBT_GLOBAL_TX_MODIFIABLE` parsing.

--- a/shared/actions.py
+++ b/shared/actions.py
@@ -1417,7 +1417,10 @@ async def nfc_share_file(*A):
     try:
         await NFC.share_file()
     except Exception as e:
-        await ux_show_story(title="ERROR", msg="Failed to share file. %s" % str(e))
+        await ux_show_story(
+            title="ERROR",
+            msg="Failed to share file.\n\n%s\n%s" % (e, problem_file_line(e))
+        )
 
 async def nfc_pushtx_file(*A):
     # Share a signed txn over NFC using PushTx technology
@@ -1434,7 +1437,10 @@ async def nfc_show_address(*A):
     try:
         await NFC.address_show_and_share()
     except Exception as e:
-        await ux_show_story(title="ERROR", msg="Failed to show address. %s" % str(e))
+        await ux_show_story(
+            title="ERROR",
+            msg="Failed to show address.\n\n%s\n%s" % (e, problem_file_line(e))
+        )
 
 
 async def nfc_sign_msg(*A):
@@ -1445,7 +1451,10 @@ async def nfc_sign_msg(*A):
     try:
         await NFC.start_msg_sign()
     except Exception as e:
-        await ux_show_story(title="ERROR", msg="Failed to sign message. %s" % str(e))
+        await ux_show_story(
+            title="ERROR",
+            msg="Failed to sign message.\n\n%s\n%s" % (e, problem_file_line(e))
+        )
 
 async def nfc_sign_verify(*A):
     # Receive armored data over NFC
@@ -1453,12 +1462,21 @@ async def nfc_sign_verify(*A):
     try:
         await NFC.verify_sig_nfc()
     except Exception as e:
-        await ux_show_story(title="ERROR", msg="Failed to verify signed message. %s" % str(e))
+        await ux_show_story(
+            title="ERROR",
+            msg="Failed to verify signed message.\n\n%s\n%s" % (e, problem_file_line(e))
+        )
 
 async def nfc_address_verify(*A):
     # Receive any random address (just the address) and find out if we own it.
     from glob import NFC
-    await NFC.verify_address_nfc()
+    try:
+        await NFC.verify_address_nfc()
+    except Exception as e:
+        await ux_show_story(
+            title="ERROR",
+            msg='Address verification failed.\n\n%s\n%s' % (e, problem_file_line(e))
+        )
 
 async def nfc_recv_ephemeral(*A):
     # Mk4: Share txt, txn and PSBT files over NFC.
@@ -1466,8 +1484,20 @@ async def nfc_recv_ephemeral(*A):
     try:
         await NFC.import_ephemeral_seed_words_nfc()
     except Exception as e:
-        await ux_show_story(title="ERROR", msg="Failed to import temporary seed via NFC. %s" % str(e))
+        await ux_show_story(
+            title="ERROR",
+            msg="Failed to import temporary seed via NFC.\n\n%s\n%s" % (e, problem_file_line(e))
+        )
 
+async def nfc_sign_psbt(*A):
+    from glob import NFC
+    try:
+        await NFC.start_psbt_rx()
+    except Exception as e:
+        await ux_show_story(
+            title="ERROR",
+            msg='Failed to sign PSBT.\n\n%s\n%s' % (e, problem_file_line(e))
+        )
 
 async def list_files(*A):
     fn = await file_picker(min_size=0)

--- a/shared/flow.py
+++ b/shared/flow.py
@@ -323,6 +323,7 @@ BackupStuffMenu = [
 ]
 
 NFCToolsMenu = [
+    MenuItem('Sign PSBT', f=nfc_sign_psbt),
     MenuItem('Show Address', f=nfc_show_address),
     MenuItem('Sign Message', f=nfc_sign_msg),
     MenuItem('Verify Sig File', f=nfc_sign_verify),

--- a/testing/test_nfc.py
+++ b/testing/test_nfc.py
@@ -218,13 +218,13 @@ def try_sign_nfc(cap_story, pick_menu_item, goto_home, need_keypress,
         title, story = cap_story()
         assert title == 'OK TO SEND?'
 
-        if accept != None:
+        if accept is not None:
             if accept:
                 press_select()
             else:
                 press_cancel()
 
-        if accept == False:
+        if not accept:
             time.sleep(0.050)
 
             # look for "Aborting..." ??
@@ -324,7 +324,7 @@ def try_sign_nfc(cap_story, pick_menu_item, goto_home, need_keypress,
 
         return ip, (got_psbt or got_txn), txid
 
-    yield  doit
+    yield doit
 
     # cleanup / restore
     sim_exec('from pyb import SDCard; SDCard.ejected = False')


### PR DESCRIPTION
It is extremely annoying to me that I have to remove SD card every-time I want to use NFC signing (SD card contains PSBTs). `Sign PSBT` menu item in `NFC Tools` menu solves this as it provides direct access to NFC signing.  Just 2 clicks on Q --> NFC button + ENTER

* improve exception messages for NFC Tools menu items (added `problem_file_line`)
* wrap address verification to try/except to prevent yikes
