### PR TITLE
Wrapped segwit ownership

### DIFF
--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -185,8 +185,6 @@ We will summarize transaction outputs as "change" back into same wallet, however
 
 - only the first 1528 addresses (764 each from internal and external (change/not) paths)
   are considered
-- P2WPKH-P2SH addresses (single sig P2PWPKH wrapped in P2SH) are not searchable if you
-  have one or more multisig wallets defined, since we assume P2WPKH-P2SH is obsolete
 - if you have used an sub-account, without ever exploring it in the Address Explorer, nor
   signing a PSBT with those account numbers, we do not search it.
 - does not search Seed Vault, you'll need to load each of those and re-search

--- a/releases/Next-ChangeLog.md
+++ b/releases/Next-ChangeLog.md
@@ -21,6 +21,7 @@ This lists the new changes that have not yet been published in a normal release.
 - Bugfix: UX shows only 10 outputs with the biggest value on screen, other values available
   after a keypress.
 - Bugfix: Calculate progress bar correctly in Address Explorer after first page.
+- Bugfix: Search also Wrapped Segwit single sig addresses if P2SH address provided, not just multisig (multisig has precedence for P2SH addresses)
 
 # Mk4 Specific Changes
 


### PR DESCRIPTION
* before p2sh-p2wpkh was not searchable when multisig enrolled - now we search it but only after multisigs are searched first
