### PR TITLE
Limit number of change outputs shown in signing UX

### DIFF
--- a/releases/Next-ChangeLog.md
+++ b/releases/Next-ChangeLog.md
@@ -9,13 +9,15 @@ This lists the new changes that have not yet been published in a normal release.
   the blockchain. See `Tools > NFC Push Tx` to enable and select service provider, or your
   own webpage. More at <https://pushtx.org>. You can also use this to broadcast on any
   transaction on the MicroSD card (See `Tools > NFC Tools > Push Transaction`)
-- New Feature: Transaction output explorer: allows view output details of larger (10+ output)
+- New Feature: Transaction output explorer: allows view all output details of larger txn (10+ output)
   transactions before signing.
 - New Feature: New setting to enable always showing XFP as first item in home menu.
 - Enhancement: Add `Sign PSBT` shortcut to `NFC Tools` menu
 - Enhancement: Stricter p2sh-p2wpkh validation checks.
 - Enhancement: Mention the need to remove old duress wallets before locking down temporary seed.
 - Enhancement: Add `Theya` option to `Export Wallet`
+- Enhancement: Signing UX - show sum of outgoing value on top. Always show number of inputs/outputs.
+- Bugfix: Display max 20 change outputs in main signing story. Use Transaction output explorer.
 - Bugfix: Fix PSBTv2 `PSBT_GLOBAL_TX_MODIFIABLE` parsing.
 - Bugfix: Decrypting Tapsigner backup failed even for correct key.
 - Bugfix: Clear any pending keystrokes before PSBT approval screen.

--- a/testing/test_multisig.py
+++ b/testing/test_multisig.py
@@ -2967,7 +2967,7 @@ def test_bare_cc_ms_qr_import(N, make_multisig, scan_a_qr, clear_ms, goto_home,
 @pytest.mark.parametrize("data", [
     # (out_style, amount, is_change)
     [("p2wsh", 1000000, 0)] * 99,
-    [("p2sh", 1000000, 1)] * 11,
+    [("p2sh", 1000000, 1)] * 33,
     [("p2wsh-p2sh", 1000000, 1)] * 18 + [("p2wsh", 50000000, 0)] * 12,
     [("p2sh", 1000000, 1), ("p2wsh-p2sh", 50000000, 0), ("p2wsh", 800000, 1)] * 14,
 ])

--- a/testing/test_sign.py
+++ b/testing/test_sign.py
@@ -2929,12 +2929,12 @@ def test_sorting_outputs_by_size(fake_txn, start_sign, cap_story, use_testnet,
 @pytest.mark.parametrize("data", [
     # (out_style, amount, is_change)
     [("p2pkh", 1000000, 0)] * 99,
-    [("p2wpkh", 1000000, 1)] * 11,
+    [("p2wpkh", 1000000, 1),("p2wpkh-p2sh", 800000, 1)] * 27,
     [("p2pkh", 1000000, 1)] * 11 + [("p2wpkh", 50000000, 0)] * 16,
     [("p2pkh", 1000000, 1), ("p2wpkh", 50000000, 0), ("p2wpkh-p2sh", 800000, 1)] * 11,
 ])
 def test_txout_explorer(psbtv2, chain, data, fake_txn, start_sign,
-                        settings_set, txout_explorer):
+                        settings_set, txout_explorer, cap_story):
     settings_set("chain", chain)
     outstyles = []
     outvals = []


### PR DESCRIPTION
* limit to 10 outputs and 20 change outputs in main signing story - use txn explorer to explore bigger txs
* add outgoing value and number of ins/outs to signing UX

![Screenshot from 2024-06-17 16-22-24](https://github.com/Coldcard/firmware/assets/25349625/d881649c-0781-420a-a989-0d83ab8faaa3)
![Screenshot from 2024-06-17 16-21-52](https://github.com/Coldcard/firmware/assets/25349625/b62fe1ce-8402-4e31-beb4-8b1100ee707c)
![Screenshot from 2024-06-17 16-20-54](https://github.com/Coldcard/firmware/assets/25349625/d7767839-c6a2-44a7-acb5-50eb9d911597)
![Screenshot from 2024-06-17 16-20-14](https://github.com/Coldcard/firmware/assets/25349625/63fcc927-18d0-4cb8-98cd-10fe7b3c7e58)
![Screenshot from 2024-06-17 16-19-31](https://github.com/Coldcard/firmware/assets/25349625/36dc4c7a-20f9-44b5-be7b-50d5ab69bc29)
