### PR TITLE
show XFP of B85 derived wallet in story

### DIFF
--- a/releases/Next-ChangeLog.md
+++ b/releases/Next-ChangeLog.md
@@ -17,6 +17,7 @@ This lists the new changes that have not yet been published in a normal release.
 - Enhancement: Mention the need to remove old duress wallets before locking down temporary seed.
 - Enhancement: Add `Theya` option to `Export Wallet`
 - Enhancement: Signing UX - show sum of outgoing value on top. Always show number of inputs/outputs.
+- Enhancement: Show master XFP of BIP-85 derived wallet in story before activation. Only words and extended private keys.
 - Bugfix: Display max 20 change outputs in main signing story. Use Transaction output explorer.
 - Bugfix: Fix PSBTv2 `PSBT_GLOBAL_TX_MODIFIABLE` parsing.
 - Bugfix: Decrypting Tapsigner backup failed even for correct key.

--- a/testing/test_drv_entro.py
+++ b/testing/test_drv_entro.py
@@ -74,12 +74,19 @@ def derive_bip85_secret(goto_home, press_select, pick_menu_item, cap_story, ente
                 assert ' '.join(got) == expect
             can_import = 'words'
 
+            seed = Mnemonic.to_seed(' '.join(got))
+            node = BIP32Node.from_master_secret(seed)
+            assert node.fingerprint().hex().upper() in title
+
         elif 'XPRV' in mode:
             assert 'Derived XPRV:' in story
             assert f"m/83696968h/32h/{index}h" in story
             if expect:
                 assert expect in story
             can_import = 'xprv'
+
+            node = BIP32Node.from_hwif(story.split("\n\n")[0].split("\n")[-1])
+            assert node.fingerprint().hex().upper() in title
 
         elif 'WIF' in mode:
             assert 'WIF (privkey)' in story


### PR DESCRIPTION
* show XFP of derived wallet without user needing to activate it as tmp `[xfp]`

![Screenshot from 2024-06-15 16-06-29](https://github.com/Coldcard/firmware/assets/25349625/cf80a5ee-20c2-475f-b2d6-606ca4bdfcec)
![Screenshot from 2024-06-15 16-07-32](https://github.com/Coldcard/firmware/assets/25349625/6ded391a-e586-4263-8c93-ebec9f0f4197)
![Screenshot from 2024-06-15 16-07-48](https://github.com/Coldcard/firmware/assets/25349625/88f3b2ca-6cec-42e1-b8af-be99b6b82122)
