### PR TITLE
Allow unsorted multi to be handled as miniscript

### DIFF
--- a/shared/miniscript.py
+++ b/shared/miniscript.py
@@ -328,7 +328,7 @@ class MiniScriptWallet(BaseStorageWallet):
         else:
             name = to_ascii_printable(name)
             desc_obj = Descriptor.from_string(config.strip())
-        assert not desc_obj.is_basic_multisig, "Use Settings -> Multisig Wallets"
+        assert not desc_obj.is_sortedmulti, "Use Settings -> Multisig Wallets"
         wal = cls(desc_obj, name=name, chain_type=desc_obj.keys[0].chain_type)
         return wal
 


### PR DESCRIPTION
I did some testing and found that
`wsh(and_b(multi(2,[xfp/84h/0h/0h]xpub.../1/*,[xfp]xpub.../1/*,[xfp]xpub.../1/*),a:older(1000)))` works, so there doesn't seem to be an internal reason not to also support top level unsorted multi.