### PR TITLE
feat: add Fully Noded, compatible with FN v1.2.0

### DIFF
--- a/shared/flow.py
+++ b/shared/flow.py
@@ -184,6 +184,7 @@ XpubExportMenu = [
 WalletExportMenu = [  
     #         xxxxxxxxxxxxxxxx
     MenuItem("Bitcoin Core", f=bitcoin_core_skeleton),
+    MenuItem("Fully Noded", f=named_generic_skeleton, arg="Fully Noded"),
     MenuItem("Sparrow Wallet", f=named_generic_skeleton, arg="Sparrow"),
     MenuItem("Nunchuk", f=named_generic_skeleton, arg="Nunchuk"),
     MenuItem("Zeus", f=ss_descriptor_skeleton,


### PR DESCRIPTION
FN v1.2.0 offers full multisig and single sig support for Coldcard Q1 bbqr wallet and psbt's flow. This PR adds Fully Noded to the list of wallet export options.

<img width="519" alt="coldcard_fullynoded" src="https://github.com/user-attachments/assets/0ad4c6fd-f85a-4a08-b9e3-2ee381f60487">



