### PR TITLE
bugfix: do not allow to import duplicate ms wallet with just shuffled keys

### DIFF
--- a/releases/Next-ChangeLog.md
+++ b/releases/Next-ChangeLog.md
@@ -6,6 +6,8 @@ This lists the new changes that have not yet been published in a normal release.
 
 - Enhancement: Allow JSON files in `NFC File Share`
 - Bugfix: UI ordered list alignment in Seed Vault menu
+- Bugfix: Do not alow to import multisig wallet duplicate with only keys shuffled
+
 
 # Mk4 Specific Changes
 

--- a/shared/multisig.py
+++ b/shared/multisig.py
@@ -393,7 +393,7 @@ class MultisigWallet(WalletABC):
         c = self.find_match(self.M, self.N, lst, addr_fmt=self.addr_fmt)
         if c:
             # All details are same: M/N, paths, addr fmt
-            if self.xpubs != c.xpubs:
+            if sorted(self.xpubs) != sorted(c.xpubs):
                 return None, ['xpubs'], 0
             elif self.name == c.name:
                 return None, [], 1


### PR DESCRIPTION
Currently possible to import both `sortedmulti(2,A,B)` and `sortedmulti(2,B,A)`. Treat as duplicates and sort xpubs before comparison.