### PR TITLE
`libsecp256k1` context randomization before each signing session

### DIFF
--- a/releases/Next-ChangeLog.md
+++ b/releases/Next-ChangeLog.md
@@ -7,9 +7,10 @@ This lists the new changes that have not yet been published in a normal release.
 - Enhancement: Allow JSON files in `NFC File Share`
 - Enhancement: latest [0.5.0](https://github.com/bitcoin-core/secp256k1/releases/tag/v0.5.0) libsecp256k1
 - Enhancement: Signature grinding optimizations
+- Enhancement: Improve side-channel protection. libsecp256k1 context randomization before each signing session.
 - Bugfix: UI ordered list alignment in Seed Vault menu
 - Bugfix: Do not alow to import multisig wallet duplicate with only keys shuffled
-- Bugfix: Do not read whole PSBT into memory when writing finalized transaction
+- Bugfix: Do not read whole PSBT into memory when writing finalized transaction 
 
 
 # Mk4 Specific Changes

--- a/shared/psbt.py
+++ b/shared/psbt.py
@@ -1868,9 +1868,9 @@ class psbtObject(psbtProxy):
 
             # progress
             dis.fullscreen('Signing...')
-
+            # randomize secp context before each signing session
+            ngu.secp256k1.ctx_rnd()
             # Sign individual inputs
-            sigs = 0
             success = set()
             for in_idx, txi in self.input_iter():
                 dis.progress_sofar(in_idx, self.num_inputs)

--- a/testing/test_sign.py
+++ b/testing/test_sign.py
@@ -2106,7 +2106,8 @@ def test_no_outputs_tx(fake_txn, microsd_path, goto_home, press_select, pick_men
     except: pass
 
 
-def test_send2taproot_addresss(fake_txn , start_sign, end_sign, cap_story):
+def test_send2taproot_addresss(fake_txn , start_sign, end_sign, cap_story, use_testnet):
+    use_testnet()
     psbt = fake_txn(2, 2, segwit_in=True, change_outputs=[0], outstyles=["p2tr"])
     start_sign(psbt)
     title, story = cap_story()


### PR DESCRIPTION
Regardless of how many signatures will be created in given session (max around 300 - memory limitations). Builds on top of work from [libngu](https://github.com/switck/libngu/commit/1cccb25ef7736efae4a1de83d5dbdc13a2db0e80) with new api to access ctx randomization from libsecp
