### PR TITLE
add missing word to seed xor docs

### DIFF
--- a/docs/seed-xor.md
+++ b/docs/seed-xor.md
@@ -22,7 +22,7 @@ This one more solution for your game-theory arsenal.
 
 - *Q*: I'm lazy, can I do this to my Existing Seed?
 - *A*: Yes. You can split the words you have already in your Coldcard, making
-  2, 3 or 4 new SEEDPLATES.  You could also any number of existing SEEDPLATES
+  2, 3 or 4 new SEEDPLATES. You could also use any number of existing SEEDPLATES
   you have, and combine them to make a new random wallet that is the XOR of
   their values. Effectively that makes a new random wallet.
 


### PR DESCRIPTION
i added what i'm guessing is the missing word to the xor seed docs.

i also removed a double space following a period - partly to keep the line length to 80, but it's also more consistent with the rest of the file.