### PR TITLE
add ability to switch between slip132 and bip32 representations of extended public keys in `Export XPUB`

### DIFF
--- a/releases/Next-ChangeLog.md
+++ b/releases/Next-ChangeLog.md
@@ -7,12 +7,14 @@ This lists the new changes that have not yet been published in a normal release.
 
 - Enhancement: Hide Secure Notes & Passwords in Deltamode. Wipe seed if notes menu accessed. 
 - Enhancement: Hide Seed Vault in Deltamode. Wipe seed if Seed Vault menu accessed. 
+- Enhancement: Ability to switch between BIP-32 XPUB and SLIP-132 garbage in `Export XPUB`
 - Bugfix: Sometimes see a struck screen after _Verifying..._ in boot up sequence.
   On Q, result is blank screen, on Mk4, result is three-dots screen.
 - Bugfix: Do not allow to enable/disable Seed Vault feature when in temporary seed mode
 - Bugfix: Bless Firmware causes hanging progress bar
 - Bugfix: Prevent yikes in ownership search
 - Change: Do not allow to purge settings of current active tmp seed when deleting it from Seed Vault
+
 
 
 # Mk4 Specific Changes

--- a/shared/actions.py
+++ b/shared/actions.py
@@ -1009,6 +1009,7 @@ async def export_xpub(label, _2, item):
 
     chain = chains.current_chain()
     acct = 0
+    slip132 = False  # non-slip is default from Oct 2024
 
     # decode menu code => standard derivation
     mode = item.arg
@@ -1024,24 +1025,44 @@ async def export_xpub(label, _2, item):
     else:
         remap = {44:0, 49:1, 84:2}[mode]
         _, path, addr_fmt = chains.CommonDerivations[remap]
-        path = path.format(account='{acct}', coin_type=chain.b44_cointype, change=0, idx=0)[:-4]
-
-    # always show SLIP-132 style, because defacto
-    show_slip132 = (addr_fmt != AF_CLASSIC)
+        path = path.format(account=acct, coin_type=chain.b44_cointype,
+                           change=0, idx=0)[:-4]
 
     while 1:
-        msg = '''Show QR of the XPUB for path:\n\n%s\n\n''' % path
+        msg = 'Show QR of the XPUB for path:\n\n%s\n\n' % path
+        esc = ""
+        if path != "m":
+            esc += "1"
+            msg += "Press (1) to select account other than %s. " % (acct or "zero")
+            if addr_fmt != AF_CLASSIC:
+                esc += "2"
+                slp_af = addr_fmt
+                if slip132:
+                    slp_af = AF_CLASSIC
 
-        if '{acct}' in path:
-            msg += "Press (1) to select account other than zero. "
+                slp = chain.slip132[slp_af].hint + "pub"
+                msg += " Press (2) to show %s %s." % (
+                    slp, "(BIP-32)" if slip132 else "(SLIP-132)"
+                )
         if glob.NFC:
-            msg += "Press %s to share via NFC. " % (KEY_NFC if version.has_qwerty else "(3)")
+            if version.has_qwerty:
+                esc += KEY_NFC
+                key_hint = KEY_NFC
+            else:
+                esc += "3"
+                key_hint = "(3)"
+            msg += " Press %s to share via NFC. " % key_hint
 
-        ch = await ux_show_story(msg, escape='13')
+        ch = await ux_show_story(msg, escape=esc)
         if ch == 'x': return
+        if ch == "2":
+            slip132 = not slip132
+            continue
         if ch == '1':
             acct = await ux_enter_bip32_index('Account Number:') or 0
-            path = path.format(acct=acct)
+            pth_split = path.split("/")
+            pth_split[-1] = ("%dh" % acct)
+            path = "/".join(pth_split)
             continue
 
         # assume zero account if not picked
@@ -1053,7 +1074,7 @@ async def export_xpub(label, _2, item):
         # render xpub/ypub/zpub
         with stash.SensitiveValues() as sv:
             node = sv.derive_path(path) if path != 'm' else sv.node
-            xpub = chain.serialize_public(node, addr_fmt)
+            xpub = chain.serialize_public(node, addr_fmt if slip132 else AF_CLASSIC)
 
         from ownership import OWNERSHIP
         OWNERSHIP.note_wallet_used(addr_fmt, acct)
@@ -1062,8 +1083,6 @@ async def export_xpub(label, _2, item):
             await glob.NFC.share_text(xpub)
         else:
             await show_qr_code(xpub, False)
-
-        break
 
 
 def electrum_export_story(background=False):

--- a/shared/flow.py
+++ b/shared/flow.py
@@ -176,7 +176,7 @@ XpubExportMenu = [
     #         xxxxxxxxxxxxxxxx
     MenuItem("Segwit (BIP-84)", f=export_xpub, arg=84),
     MenuItem("Classic (BIP-44)", f=export_xpub, arg=44),
-    MenuItem("P2WPKH/P2SH (49)", f=export_xpub, arg=49),
+    MenuItem("P2WPKH/P2SH "+("(BIP-49)"if version.has_qwerty else "(49)"), f=export_xpub, arg=49),
     MenuItem("Master XPUB", f=export_xpub, arg=0),
     MenuItem("Current XFP", f=export_xpub, arg=-1),
 ]


### PR DESCRIPTION
* by default BIP is shown now, in previous version slip was default and only option