### PR TITLE
Msg sign upgrade

### DIFF
--- a/releases/Next-ChangeLog.md
+++ b/releases/Next-ChangeLog.md
@@ -26,6 +26,12 @@ This lists the new changes that have not yet been published in a normal release.
 # Mk4 Specific Changes
 
 ## 5.4.1 - 2024-??-??
+- Change: If derivation path is omitted during message signing, default is used 
+  based on address format (`m/44h/0h/0h/0/0` for p2pkh, and `m/84h/0h/0h/0/0` for p2wpkh). 
+  Default is no longer root (m).
+
+
+## 5.4.? - 2024-??-??
 
 - Enhancement: Export single sig descriptor with simple QR.
 

--- a/releases/Next-ChangeLog.md
+++ b/releases/Next-ChangeLog.md
@@ -5,12 +5,19 @@ This lists the new changes that have not yet been published in a normal release.
 
 # Shared Improvements - Both Mk4 and Q
 
+- New Feature: JSON message signing. Use JSON object to pass data to sign in form `{"msg":"<required msg>","subpath":"<optional sp>","addr_fmt": "<optional af>"}`
+- New Feature: Sign message from note text, or password note
+- New Feature: Sign message with key resulting from positive ownership check. Press (0) + enter/scan message text
+- New Feature: Sign message with key selected from Address Explorer Custom Path menu. Press (2) + enter/scan message text
 - Enhancement: Hide Secure Notes & Passwords in Deltamode. Wipe seed if notes menu accessed. 
 - Enhancement: Hide Seed Vault in Deltamode. Wipe seed if Seed Vault menu accessed. 
 - Enhancement: Add ability to switch between BIP-32 xpub, and obsolete
   SLIP-132 format in `Export XPUB`
 - Enhancement: Use the fact that master seed cannot be used as ephemeral seed, to show message 
   about successful master seed verification.
+- Change: If derivation path is omitted during message signing, default is used 
+  based on address format (`m/44h/0h/0h/0/0` for p2pkh, and `m/84h/0h/0h/0/0` for p2wpkh). 
+  Default is no longer root (m).
 - Bugfix: Sometimes see a struck screen after _Verifying..._ in boot up sequence.
   On Q, result is blank screen, on Mk4, result is three-dots screen.
 - Bugfix: Do not allow to enable/disable Seed Vault feature when in temporary seed mode.
@@ -26,12 +33,6 @@ This lists the new changes that have not yet been published in a normal release.
 # Mk4 Specific Changes
 
 ## 5.4.1 - 2024-??-??
-- Change: If derivation path is omitted during message signing, default is used 
-  based on address format (`m/44h/0h/0h/0/0` for p2pkh, and `m/84h/0h/0h/0/0` for p2wpkh). 
-  Default is no longer root (m).
-
-
-## 5.4.? - 2024-??-??
 
 - Enhancement: Export single sig descriptor with simple QR.
 
@@ -40,5 +41,8 @@ This lists the new changes that have not yet been published in a normal release.
 
 ## 1.3.1Q - 2024-??-??
 
+- New Feature: Verify Signed RFC messages via BBQr
+- New Feature: Sign message from QR scan (format has to be JSON)
+- Enhancement: Sign scanned Simple Text by pressing (0). Next screens query information about key to use. 
 - Bugfix: Properly re-draw status bar after Restore Master on COLDCARD without master seed.
 

--- a/shared/actions.py
+++ b/shared/actions.py
@@ -4,12 +4,12 @@
 #
 # Every function here is called directly by a menu item. They should all be async.
 #
-import ckcc, pyb, version, uasyncio, sys, uos
+import ckcc, pyb, version, uasyncio, sys, uos, chains
 from uhashlib import sha256
 from uasyncio import sleep_ms
 from ubinascii import hexlify as b2a_hex
 from utils import imported, problem_file_line, get_filesize, encode_seed_qr
-from utils import xfp2str, B2A, addr_fmt_label, txid_from_fname
+from utils import xfp2str, B2A, txid_from_fname
 from ux import ux_show_story, the_ux, ux_confirm, ux_dramatic_pause, ux_aborted
 from ux import ux_enter_bip32_index, ux_input_text, import_export_prompt, OK, X
 from export import make_json_wallet, make_summary_file, make_descriptor_wallet_export
@@ -1106,9 +1106,9 @@ async def electrum_skeleton(*a):
         return
 
     rv = [
-        MenuItem(addr_fmt_label(af), f=electrum_skeleton_step2,
+        MenuItem(chains.addr_fmt_label(af), f=electrum_skeleton_step2,
                  arg=(af, account_num))
-        for af in [AF_P2WPKH, AF_CLASSIC, AF_P2WPKH_P2SH]
+        for af in chains.SINGLESIG_AF
     ]
     the_ux.push(MenuSystem(rv))
 
@@ -1122,7 +1122,7 @@ def ss_descriptor_export_story(addition="", background="", acct=True):
 async def ss_descriptor_skeleton(_0, _1, item):
     # Export of descriptor data (wallet)
     int_ext, addition, f_pattern = None, "", "descriptor.txt"
-    allowed_af = [AF_P2WPKH, AF_CLASSIC, AF_P2WPKH_P2SH]
+    allowed_af = chains.SINGLESIG_AF
     if item.arg:
         int_ext, allowed_af, ll, f_pattern = item.arg
         addition = " for " + ll
@@ -1149,7 +1149,7 @@ async def ss_descriptor_skeleton(_0, _1, item):
                                             fname_pattern=f_pattern)
     else:
         rv = [
-            MenuItem(addr_fmt_label(af), f=descriptor_skeleton_step2,
+            MenuItem(chains.addr_fmt_label(af), f=descriptor_skeleton_step2,
                      arg=(af, account_num, int_ext, f_pattern))
             for af in allowed_af
         ]
@@ -1890,10 +1890,11 @@ async def sign_message_on_sd(*a):
             # min 1 line max 3 lines
             return 1 <= len(lines) <= 3
 
-    fn = await file_picker(suffix='txt', min_size=2, max_size=500, taster=is_signable,
-                           none_msg=('Must be one line of text, optionally '
+    fn = await file_picker(suffix=['txt', "json"], min_size=2, max_size=500, taster=is_signable,
+                           none_msg=('Must be txt file with one msg line, optionally '
                                      'followed by a subkey derivation path on a second line '
-                                     'and/or address format on third line.'))
+                                     'and/or address format on third line. JSON msg signing '
+                                     'format also supported'))
 
     if not fn:
         return

--- a/shared/auth.py
+++ b/shared/auth.py
@@ -16,7 +16,7 @@ from ux import ux_aborted, ux_show_story, abort_and_goto, ux_dramatic_pause, ux_
 from ux import show_qr_code, OK, X
 from usb import CCBusyError
 from utils import HexWriter, xfp2str, problem_file_line, cleanup_deriv_path
-from utils import B2A, parse_addr_fmt_str, to_ascii_printable
+from utils import B2A, parse_addr_fmt_str, to_ascii_printable, parse_msg_sign_request
 from psbt import psbtObject, FatalPSBTIssue, FraudulentChangeOutput
 from files import CardSlot
 from exceptions import HSMDenied
@@ -303,8 +303,13 @@ def validate_text_for_signing(text):
     return result
 
 class ApproveMessageSign(UserAuthorizedAction):
-    def __init__(self, text, subpath, addr_fmt, approved_cb=None):
+    def __init__(self, text, subpath, addr_fmt, approved_cb=None,
+                 msg_sign_request=None):
         super().__init__()
+
+        if msg_sign_request:
+            text, subpath, addr_fmt = parse_msg_sign_request(msg_sign_request)
+
         self.text = validate_text_for_signing(text)
         self.subpath = cleanup_deriv_path(subpath)
         self.addr_fmt = parse_addr_fmt_str(addr_fmt)
@@ -362,24 +367,7 @@ async def sign_txt_file(filename):
     # sign a one-line text file found on a MicroSD card
     # - not yet clear how to do address types other than 'classic'
     from files import CardSlot, CardMissingError
-
     from ux import the_ux
-
-    UserAuthorizedAction.cleanup()
-
-    # copy message into memory
-    with CardSlot() as card:
-        with card.open(filename, 'rt') as fd:
-            text = fd.readline().strip()
-            subpath = fd.readline().strip()
-            addr_fmt = fd.readline().strip()
-
-    if not subpath:
-        # default: top of wallet.
-        subpath = 'm'
-
-    if not addr_fmt:
-        addr_fmt = AF_CLASSIC
 
     async def done(signature, address, text):
         # complete. write out result
@@ -442,9 +430,19 @@ async def sign_txt_file(filename):
         msg = "Created new file:\n\n%s" % out_fn
         await ux_show_story(msg, title='File Signed')
 
+    UserAuthorizedAction.cleanup()
     UserAuthorizedAction.check_busy()
+
+    # copy message into memory
+    with CardSlot() as card:
+        with card.open(filename, 'rt') as fd:
+            res = fd.read()
+
     try:
-        UserAuthorizedAction.active_request = ApproveMessageSign(text, subpath, addr_fmt, approved_cb=done)
+        UserAuthorizedAction.active_request = ApproveMessageSign(
+            None, None, None, approved_cb=done,
+            msg_sign_request=res
+        )
         # do not kill the menu stack!
         the_ux.push(UserAuthorizedAction.active_request)
     except AssertionError as exc:
@@ -1039,7 +1037,7 @@ class ApproveTransaction(UserAuthorizedAction):
 
             msg.write("\n")
 
-        # if we didn't already show all outputs, then give user a chance to 
+        # if we didn't already show all outputs, then give user a chance to
         # view them individually
         return needs_txn_explorer
 
@@ -1396,7 +1394,7 @@ class ShowAddressBase(UserAuthorizedAction):
 
         else:
             # finish the Wait...
-            dis.progress_bar_show(1)     
+            dis.progress_bar_show(1)
 
         if self.restore_menu:
             self.pop_menu()

--- a/shared/chains.py
+++ b/shared/chains.py
@@ -12,6 +12,9 @@ from serializations import hash160, ser_compact_size, disassemble
 from ucollections import namedtuple
 from opcodes import OP_RETURN, OP_1, OP_16
 
+
+SINGLESIG_AF = (AF_P2WPKH, AF_CLASSIC, AF_P2WPKH_P2SH)
+
 # See SLIP 132 <https://github.com/satoshilabs/slips/blob/master/slip-0132.md>
 # for background on these version bytes. Not to be confused with SLIP-32 which involves Bech32.
 Slip132Version = namedtuple('Slip132Version', ('pub', 'priv', 'hint'))
@@ -401,6 +404,47 @@ CommonDerivations = [
             AF_P2WPKH ),           # generates bc1 bech32 addresses
 ]
 
+STD_DERIVATIONS = {
+    "p2pkh": CommonDerivations[0][1],
+    "p2sh-p2wpkh": CommonDerivations[1][1],
+    "p2wpkh-p2sh": CommonDerivations[1][1],
+    "p2wpkh": CommonDerivations[2][1],
+}
+
+def parse_addr_fmt_str(addr_fmt):
+    # accepts strings and also integers if already parsed
+    try:
+        if isinstance(addr_fmt, int):
+            if addr_fmt in [AF_P2WPKH_P2SH, AF_P2WPKH, AF_CLASSIC]:
+                return addr_fmt
+            else:
+                raise ValueError
+
+        addr_fmt = addr_fmt.lower()
+        if addr_fmt in ("p2sh-p2wpkh", "p2wpkh-p2sh"):
+            return AF_P2WPKH_P2SH
+        elif addr_fmt == "p2pkh":
+            return AF_CLASSIC
+        elif addr_fmt == "p2wpkh":
+            return AF_P2WPKH
+        else:
+            raise ValueError
+    except ValueError:
+        raise ValueError("Invalid address format: '%s'\n\n"
+                         "Choose from p2pkh, p2wpkh, p2sh-p2wpkh." % addr_fmt)
+
+
+def af_to_bip44_purpose(addr_fmt):
+    # single signature only
+    return {AF_CLASSIC: 44,
+            AF_P2WPKH_P2SH: 49,
+            AF_P2WPKH: 84}[addr_fmt]
+
+
+def addr_fmt_label(addr_fmt):
+    return {AF_CLASSIC: "Classic P2PKH",
+            AF_P2WPKH_P2SH: "P2SH-Segwit",
+            AF_P2WPKH: "Segwit P2WPKH"}[addr_fmt]
 
 def verify_recover_pubkey(sig, digest):
     # verifies a message digest against a signature and recovers

--- a/shared/export.py
+++ b/shared/export.py
@@ -405,14 +405,7 @@ def generate_electrum_wallet(addr_type, account_num):
     xfp = settings.get('xfp')
 
     # Must get the derivation path, and the SLIP32 version bytes right!
-    if addr_type == AF_CLASSIC:
-        mode = 44
-    elif addr_type == AF_P2WPKH:
-        mode = 84
-    elif addr_type == AF_P2WPKH_P2SH:
-        mode = 49
-    else:
-        raise ValueError(addr_type)
+    mode = chains.af_to_bip44_purpose(addr_type)
 
     OWNERSHIP.note_wallet_used(addr_type, account_num)
 
@@ -508,14 +501,7 @@ async def make_descriptor_wallet_export(addr_type, account_num=0, mode=None, int
     xfp = settings.get('xfp')
     dis.progress_bar_show(0.1)
     if mode is None:
-        if addr_type == AF_CLASSIC:
-            mode = 44
-        elif addr_type == AF_P2WPKH:
-            mode = 84
-        elif addr_type == AF_P2WPKH_P2SH:
-            mode = 49
-        else:
-            raise ValueError(addr_type)
+        mode = chains.af_to_bip44_purpose(addr_type)
 
     OWNERSHIP.note_wallet_used(addr_type, account_num)
 

--- a/shared/nfc.py
+++ b/shared/nfc.py
@@ -7,7 +7,7 @@
 # - has GPIO signal "??" which is multipurpose on its own pin
 # - this chip chosen because it can disable RF interaction
 #
-import utime, ngu, ndef, stash
+import utime, ngu, ndef, stash, chains
 from uasyncio import sleep_ms
 import uasyncio as asyncio
 from ustruct import pack, unpack
@@ -15,7 +15,7 @@ from ubinascii import unhexlify as a2b_hex
 from ubinascii import b2a_base64, a2b_base64
 
 from ux import ux_show_story, ux_wait_keydown, OK, X
-from utils import B2A, problem_file_line, parse_addr_fmt_str, txid_from_fname
+from utils import B2A, problem_file_line, txid_from_fname
 from public_constants import AF_CLASSIC
 from charcodes import KEY_ENTER, KEY_CANCEL
 
@@ -727,7 +727,7 @@ class NFCHandler:
         else:
             subpath, addr_fmt_str = winner
             try:
-                addr_fmt = parse_addr_fmt_str(addr_fmt_str)
+                addr_fmt = chains.parse_addr_fmt_str(addr_fmt_str)
             except AssertionError as e:
                 await ux_show_story(str(e))
                 return
@@ -738,32 +738,21 @@ class NFCHandler:
         await the_ux.interact()  # need this otherwise NFC animation takes over
 
     async def start_msg_sign(self):
-        from auth import UserAuthorizedAction, ApproveMessageSign
-        from ux import the_ux
-
-        UserAuthorizedAction.cleanup()
+        from auth import approve_msg_sign
 
         def f(m):
             m = m.decode()
             split_msg = m.split("\n")
             if 1 <= len(split_msg) <= 3:
-                return split_msg
+                return m
 
         winner = await self._nfc_reader(f, 'Unable to find correctly formated message to sign.')
-
         if not winner:
             return
 
-        UserAuthorizedAction.check_busy(ApproveMessageSign)
-        try:
-            UserAuthorizedAction.active_request = ApproveMessageSign(
-                None, None, None, approved_cb=self.msg_sign_done,
-                msg_sign_request=winner
-            )
-            the_ux.push(UserAuthorizedAction.active_request)
-        except AssertionError as exc:
-            await ux_show_story("Problem: %s\n\nMessage to be signed must be a single line of ASCII text." % exc)
-            return
+        await approve_msg_sign(None, None, None, approved_cb=self.msg_sign_done,
+                               msg_sign_request=winner)
+
 
     async def msg_sign_done(self, signature, address, text):
         from auth import rfc_signature_template_gen

--- a/shared/nfc.py
+++ b/shared/nfc.py
@@ -667,7 +667,7 @@ class NFCHandler:
             if len(m) < 70:
                 return
             m = m.decode()
-            
+
             # multi( catches both multi( and sortedmulti(
             if 'pub' in m or "multi(" in m:
                 return m
@@ -742,7 +742,7 @@ class NFCHandler:
         from ux import the_ux
 
         UserAuthorizedAction.cleanup()
-        
+
         def f(m):
             m = m.decode()
             split_msg = m.split("\n")
@@ -754,21 +754,11 @@ class NFCHandler:
         if not winner:
             return
 
-        if len(winner) == 1:
-            text = winner[0]
-            subpath = "m"
-            addr_fmt = AF_CLASSIC
-        elif len(winner) == 2:
-            text, subpath = winner
-            addr_fmt = AF_CLASSIC  # maybe default to native segwit?
-        else:
-            # len(winner) == 3
-            text, subpath, addr_fmt = winner
-
         UserAuthorizedAction.check_busy(ApproveMessageSign)
         try:
             UserAuthorizedAction.active_request = ApproveMessageSign(
-                text, subpath, addr_fmt, approved_cb=self.msg_sign_done
+                None, None, None, approved_cb=self.msg_sign_done,
+                msg_sign_request=winner
             )
             the_ux.push(UserAuthorizedAction.active_request)
         except AssertionError as exc:
@@ -784,7 +774,7 @@ class NFCHandler:
 
     async def verify_sig_nfc(self):
         from auth import verify_armored_signed_msg
-        
+
         f = lambda x: x.decode().strip() if b"SIGNED MESSAGE" in x else None
         winner = await self._nfc_reader(f, 'Unable to find signed message.')
 
@@ -794,7 +784,7 @@ class NFCHandler:
     async def verify_address_nfc(self):
         # Get an address or complete bip-21 url even and search it... slow.
         from utils import decode_bip21_text
-        
+
         def f(m):
             m = m.decode()
             what, vals = decode_bip21_text(m)
@@ -814,7 +804,7 @@ class NFCHandler:
     async def read_tapsigner_b64_backup(self):
         f = lambda x: a2b_base64(x.decode()) if 150 <= len(x) <= 280 else None
         return await self._nfc_reader(f, 'Unable to find base64 encoded TAPSIGNER backup.')
-    
+
     async def _nfc_reader(self, func, fail_msg):
         data = await self.start_nfc_rx()
         if not data: return

--- a/shared/notes.py
+++ b/shared/notes.py
@@ -298,6 +298,15 @@ class NoteContentBase:
         # single export
         await start_export([self])
 
+    async def sign_txt_msg(self, a, b, item):
+        from auth import ux_sign_msg, msg_signing_done
+        txt = item.arg
+        await ux_sign_msg(txt, approved_cb=msg_signing_done, kill_menu=False)
+
+    def sign_misc_menu_item(self):
+        return MenuItem("Sign Note Text", f=self.sign_txt_msg, arg=self.misc)
+
+
 class PasswordContent(NoteContentBase):
     # "Passwords" have a few more fields and are more structured
     flds = ['title', 'user', 'password', 'site', 'misc' ]
@@ -317,6 +326,7 @@ class PasswordContent(NoteContentBase):
             MenuItem('Edit Metadata', f=self.edit),
             MenuItem('Delete', f=self.delete),
             MenuItem('Change Password', f=self.change_pw),
+            self.sign_misc_menu_item(),
             ShortcutItem(KEY_QR, f=self.view_qr),
             ShortcutItem(KEY_NFC, f=self.share_nfc, arg='password'),
         ]
@@ -446,6 +456,7 @@ class NoteContent(NoteContentBase):
             MenuItem('Edit', f=self.edit),
             MenuItem('Delete', f=self.delete),
             MenuItem('Export', f=self.export),
+            self.sign_misc_menu_item(),
             ShortcutItem(KEY_QR, f=self.view_qr),
             ShortcutItem(KEY_NFC, f=self.share_nfc, arg='misc'),
         ]

--- a/shared/ux_q1.py
+++ b/shared/ux_q1.py
@@ -2,7 +2,7 @@
 #
 # ux_q1.py - UX/UI interactions that are Q1 specific and use big screen, keyboard.
 #
-import utime, gc, ngu, sys
+import utime, gc, ngu, sys, chains
 import uasyncio as asyncio
 from uasyncio import sleep_ms
 from charcodes import *
@@ -12,7 +12,10 @@ import bip39
 from decoders import decode_qr_result
 from ubinascii import hexlify as b2a_hex
 from ubinascii import unhexlify as a2b_hex
+from ubinascii import b2a_base64
+
 from utils import problem_file_line
+from public_constants import MSG_SIGNING_MAX_LENGTH
 from glob import numpad         # may be None depending on import order, careful
 
 class PressRelease:
@@ -951,6 +954,20 @@ class QRScannerInteraction:
                 await ux_visualize_wif(wif_str, key_pair, compressed, testnet)
                 return
 
+            if what == "vmsg":
+                data, = vals
+                from auth import verify_armored_signed_msg
+                await verify_armored_signed_msg(data)
+                return
+
+            if what == "smsg":
+                data, = vals
+                from auth import approve_msg_sign, msg_signing_done
+                await approve_msg_sign(None, None, None,
+                                       msg_sign_request=data, kill_menu=True,
+                                       approved_cb=msg_signing_done)
+                return
+
             if what == 'text' or what == 'xpub':
                 # we couldn't really decode it.
                 txt, = vals
@@ -1107,15 +1124,49 @@ async def ux_visualize_wif(wif_str, kp, compressed, testnet):
     msg += "public key sec:\n" + b2a_hex(kp.pubkey().to_bytes(not compressed)).decode() + "\n\n"
     await ux_show_story(msg, title="WIF")
 
-async def ux_visualize_textqr(txt, maxlen=200):
+async def qr_msg_sign_done(signature, address, text):
+    from ux import ux_show_story
+    from auth import rfc_signature_template_gen
+    from export import export_by_qr
+
+    sig = b2a_base64(signature).decode('ascii').strip()
+    while True:
+        ch = await ux_show_story("Press ENTER to export signature QR only, "
+                                 "(0) to export full RFC template, "
+                                 "CANCEL if done.", escape="0")
+        if ch == "x": break
+        if ch == "y":
+            await export_by_qr(sig, "Signature", "U")
+        if ch == "0":
+            armored_str = "".join(rfc_signature_template_gen(addr=address, msg=text,
+                                                             sig=sig))
+            await show_bbqr_codes("U", armored_str, "Armored MSG")
+
+async def qr_sign_msg(txt):
+    from auth import ux_sign_msg
+    await ux_sign_msg(txt, approved_cb=qr_msg_sign_done, kill_menu=True)
+
+async def ux_visualize_textqr(txt, maxlen=MSG_SIGNING_MAX_LENGTH):
     # Show simple text. Don't crash on huge things, but be
     # able to show a full xpub.
     from ux import ux_show_story
-    if len(txt) > maxlen:
+
+    txt_len = len(txt)
+    escape = "0"
+    if txt_len > maxlen:
+        escape = None
         txt = txt[0:maxlen] + '...'
 
-    await ux_show_story("%s\n\nAbove is text that was scanned. "
-            "We can't do any more with it." % txt, title="Simple Text")
+    msg = "%s\n\nAbove is text that was scanned. " % txt
+    if escape:
+        msg += " Press (0) to sign the text. "
+    else:
+        msg += "We can't do any more with it."
+
+    ch = await ux_show_story(title="Simple Text", msg=msg, escape=escape)
+    if escape and (ch == "0"):
+        await qr_sign_msg(txt)
+
 
 async def show_bbqr_codes(type_code, data, msg, already_hex=False):
     # Compress, encode and split data, then show it animated...

--- a/shared/wallet.py
+++ b/shared/wallet.py
@@ -4,7 +4,6 @@
 #
 import chains
 from descriptor import Descriptor
-from public_constants import AF_CLASSIC, AF_P2WPKH, AF_P2WPKH_P2SH
 from stash import SensitiveValues
 
 MAX_BIP32_IDX = (2 ** 31) - 1
@@ -41,17 +40,9 @@ class MasterSingleSigWallet(WalletABC):
         # - path is optional, and then we use standard path for addr_fmt
         # - path can be overriden when we come here via address explorer
 
-        if addr_fmt == AF_P2WPKH:
-            n = 'Segwit P2WPKH'
-            prefix = path or 'm/84h/{coin_type}h/{account}h'
-        elif addr_fmt == AF_CLASSIC:
-            n = 'Classic P2PKH'
-            prefix = path or 'm/44h/{coin_type}h/{account}h'
-        elif addr_fmt == AF_P2WPKH_P2SH:
-            n =  'P2WPKH-in-P2SH'
-            prefix = path or 'm/49h/{coin_type}h/{account}h'
-        else:
-            raise ValueError(addr_fmt)
+        n = chains.addr_fmt_label(addr_fmt)
+        purpose = chains.af_to_bip44_purpose(addr_fmt)
+        prefix = path or 'm/%dh/{coin_type}h/{account}h' % purpose
 
         if chain_name:
             self.chain = chains.get_chain(chain_name)

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -2258,6 +2258,7 @@ from test_drv_entro import derive_bip85_secret, activate_bip85_ephemeral
 from test_ephemeral import generate_ephemeral_words, import_ephemeral_xprv, goto_eph_seed_menu
 from test_ephemeral import ephemeral_seed_disabled_ui, restore_main_seed, confirm_tmp_seed
 from test_ephemeral import verify_ephemeral_secret_ui, get_identity_story, get_seed_value_ux, seed_vault_enable
+from test_msg import verify_msg_sign_story, sign_msg_from_text, msg_sign_export, sign_msg_from_address
 from test_multisig import import_ms_wallet, make_multisig, offer_ms_import, fake_ms_txn
 from test_multisig import make_ms_address, clear_ms, make_myself_wallet, import_multisig
 from test_se2 import goto_trick_menu, clear_all_tricks, new_trick_pin, se2_gate, new_pin_confirmed

--- a/testing/constants.py
+++ b/testing/constants.py
@@ -41,6 +41,7 @@ addr_fmt_names = {
     AF_P2WSH: 'p2wsh',
     AF_P2WPKH_P2SH: 'p2wpkh-p2sh',
     AF_P2WSH_P2SH: 'p2wsh-p2sh',
+    AF_P2TR: "p2tr",
 }
     
 

--- a/testing/msg.py
+++ b/testing/msg.py
@@ -22,11 +22,12 @@ RFC_SIGNATURE_TEMPLATE = '''\
 
 
 def parse_signed_message(msg):
-    msplit = msg.strip().split("\n")
-    assert msplit[0] == "-----BEGIN BITCOIN SIGNED MESSAGE-----"
-    assert msplit[2] == "-----BEGIN BITCOIN SIGNATURE-----"
-    assert msplit[5] == "-----END BITCOIN SIGNATURE-----"
-    return msplit[1], msplit[3], msplit[4]
+    msplit = msg.strip().rsplit("\n", 4)
+    assert msplit[0].startswith("-----BEGIN BITCOIN SIGNED MESSAGE-----\n")
+    msg = msplit[0].replace("-----BEGIN BITCOIN SIGNED MESSAGE-----\n", "")
+    assert msplit[1] == "-----BEGIN BITCOIN SIGNATURE-----"
+    assert msplit[4] == "-----END BITCOIN SIGNATURE-----"
+    return msg, msplit[2], msplit[3]
 
 
 def sig_hdr_base(addr_fmt):

--- a/testing/test_address_explorer.py
+++ b/testing/test_address_explorer.py
@@ -383,7 +383,8 @@ def test_custom_path(path_sidx, which_fmt, addr_vs_path, pick_menu_item, goto_ad
                      need_keypress, cap_menu, parse_display_screen, validate_address,
                      cap_screen_qr, qr_quality_check, nfc_read_text, get_setting,
                      press_select, press_cancel, is_q1, press_nfc, cap_story,
-                     generate_addresses_file, settings_set, set_addr_exp_start_idx):
+                     generate_addresses_file, settings_set, set_addr_exp_start_idx,
+                     sign_msg_from_address):
 
     path, start_idx = path_sidx
     settings_set('aei', True if start_idx else False)
@@ -443,8 +444,8 @@ def test_custom_path(path_sidx, which_fmt, addr_vs_path, pick_menu_item, goto_ad
 
     time.sleep(.5)          # .2 not enuf
     m = cap_menu()
-    assert m[0] == 'Classic P2PKH'
-    assert m[1] == 'Segwit P2WPKH'
+    assert m[1] == 'Classic P2PKH'
+    assert m[0] == 'Segwit P2WPKH'
     assert m[2] == 'P2SH-Segwit'
         
     fmts = {
@@ -505,6 +506,16 @@ def test_custom_path(path_sidx, which_fmt, addr_vs_path, pick_menu_item, goto_ad
         f_path, f_addr = next(addr_gen)
         assert f_path == path
         assert f_addr == addr
+        press_select()  # file written
+
+        # msg sign
+        time.sleep(.1)
+        title, body = cap_story()
+        assert "Press (0) to sign message with this key" in body
+        need_keypress('0')
+        msg = "COLDCARD the rock solid HWW"
+        sign_msg_from_address(msg, addr, path, which_fmt, "sd", True)
+        press_cancel()
     else:
         n = 10
         if (start_idx + n) > MAX_BIP32_IDX:

--- a/testing/test_bbqr.py
+++ b/testing/test_bbqr.py
@@ -373,4 +373,26 @@ def test_psbt_static(file, goto_home, cap_story, scan_a_qr, press_select,
     assert res["complete"] is True
     assert rb.hex() == res["hex"]
 
+
+def test_verify_signed_msg(goto_home, need_keypress, scan_a_qr, cap_story):
+    goto_home()
+    need_keypress(KEY_QR)
+
+    data = """\n\n\n  \t  \n-----BEGIN BITCOIN SIGNED MESSAGE-----
+5b9e372262952ed399dcdd4f5f08458a6d2811f120cddcb4267099f68f60207c  addresses.csv
+-----BEGIN BITCOIN SIGNATURE-----
+tb1qupyd58ndsh7lut0et0vtrq432jvu9jtdyws9n9
+KDOloGMDU3fv+Y3NRSe17SoO4uSKo9IUU2+baJ/pqaHZBuvmW6j5nnv/N4M5BCVawiUig/qzExZpFsA7ZKzlUmU=
+-----END BITCOIN SIGNATURE-----\n\n\n\n"""
+
+    actual_vers, parts = split_qrs(data, 'U', max_version=20)
+
+    for p in parts:
+        scan_a_qr(p)
+        time.sleep(4.0 / len(parts))       # just so we can watch
+
+    title, story = cap_story()
+    assert "Good signature by address" in story
+
+
 # EOF

--- a/testing/test_decoders.py
+++ b/testing/test_decoders.py
@@ -179,4 +179,25 @@ def test_wif(data, try_decode):
     assert compressed == tcompressed
     assert testnet == ttestnet
 
+@pytest.mark.parametrize('data', [
+    '{"msg": "coinkite"}',
+    '{"msg": "coink\n\n\tite", "subpath": "m/99h"}',
+    '{"msg": "coinkite", "subpath": "m/96420h", "addr_fmt": "p2wpkh"}',
+])
+def test_json_msg_sign(data, try_decode):
+    ft, vals = try_decode(data)
+    assert ft == "smsg"
+    assert vals[0] == data
+
+
+@pytest.mark.parametrize('data', [
+    "-----BEGIN BITCOIN SIGNED MESSAGE-----\ncoinkite\n-----BEGIN BITCOIN SIGNATURE-----\nmtHSVByP9EYZmB26jASDdPVm19gvpecb5R\nH3c6imctVKRRYC1zOBAitdb/PuoQ9j0xaR6qKXH5dQECZH5OuvvE7aoL6j/WOaR/CFq/+SvIZPAzIhvQYBizBUc=\n-----END BITCOIN SIGNATURE-----",
+    "\n\n-----BEGIN BITCOIN SIGNED MESSAGE-----\ncoinkite\n-----BEGIN BITCOIN SIGNATURE-----\nmtHSVByP9EYZmB26jASDdPVm19gvpecb5R\nH3c6imctVKRRYC1zOBAitdb/PuoQ9j0xaR6qKXH5dQECZH5OuvvE7aoL6j/WOaR/CFq/+SvIZPAzIhvQYBizBUc=\n-----END BITCOIN SIGNATURE-----",
+    "\n\n\t-----BEGIN BITCOIN SIGNED MESSAGE-----\ncoinkite\n-----BEGIN BITCOIN SIGNATURE-----\nmtHSVByP9EYZmB26jASDdPVm19gvpecb5R\nH3c6imctVKRRYC1zOBAitdb/PuoQ9j0xaR6qKXH5dQECZH5OuvvE7aoL6j/WOaR/CFq/+SvIZPAzIhvQYBizBUc=\n-----END BITCOIN SIGNATURE-----",
+])
+def test_json_msg_verify(data, try_decode):
+    ft, vals = try_decode(data)
+    assert ft == "vmsg"
+    assert vals[0] == data
+
 # EOF

--- a/testing/test_ownership.py
+++ b/testing/test_ownership.py
@@ -92,8 +92,7 @@ def test_positive(addr_fmt, offset, subaccount, testnet, from_empty, change_idx,
             menu_item = expect_name = 'Classic P2PKH'
             path = "m/44h/{ct}h/{acc}h"
         elif addr_fmt == AF_P2WPKH_P2SH:
-            expect_name = 'P2WPKH-in-P2SH'
-            menu_item = 'P2SH-Segwit'
+            menu_item = expect_name = 'P2SH-Segwit'
             path = "m/49h/{ct}h/{acc}h"
             clear_ms()
         elif addr_fmt == AF_P2WPKH:
@@ -154,25 +153,39 @@ def test_positive(addr_fmt, offset, subaccount, testnet, from_empty, change_idx,
 @pytest.mark.parametrize('valid', [ True, False] )
 @pytest.mark.parametrize('testnet', [ True, False] )
 @pytest.mark.parametrize('method', [ 'qr', 'nfc'] )
-def test_ux(valid, testnet, method, 
+@pytest.mark.parametrize('multisig', [ True, False] )
+def test_ux(valid, testnet, method,
     sim_exec, wipe_cache, make_myself_wallet, use_testnet, goto_home, pick_menu_item,
     press_cancel, press_select, settings_set, is_q1, nfc_write, need_keypress,
-    cap_screen, cap_story, load_shared_mod, scan_a_qr
+    cap_screen, cap_story, load_shared_mod, scan_a_qr, skip_if_useless_way,
+    sign_msg_from_address, multisig, import_ms_wallet, clear_ms,
 ):
-
+    skip_if_useless_way(method)
     addr_fmt = AF_CLASSIC
 
     if valid:
-        mk = BIP32Node.from_wallet_key(simulator_fixed_tprv if testnet else simulator_fixed_xprv)
-        path = "m/44h/{ct}h/{acc}h/0/3".format(acc=0, ct=(1 if testnet else 0))
-        sk = mk.subkey_for_path(path)
-        addr = sk.address(netcode="XTN" if testnet else "BTC")
+        if multisig:
+            from test_multisig import make_ms_address, HARD
+            M, N = 2, 3
+
+            expect_name = f'own_ux_test'
+            clear_ms()
+            keys = import_ms_wallet(M, N, AF_P2WSH, name=expect_name, accept=1)
+
+            # iffy: no cosigner index in this wallet, so indicated that w/ path_mapper
+            addr, scriptPubKey, script, details = make_ms_address(
+                M, keys, is_change=0, idx=50, addr_fmt=AF_P2WSH,
+                testnet=int(testnet), path_mapper=lambda cosigner: [HARD(45), 0, 50]
+            )
+        else:
+            mk = BIP32Node.from_wallet_key(simulator_fixed_tprv if testnet else simulator_fixed_xprv)
+            path = "m/44h/{ct}h/{acc}h/0/3".format(acc=0, ct=(1 if testnet else 0))
+            sk = mk.subkey_for_path(path)
+            addr = sk.address(netcode="XTN" if testnet else "BTC")
     else:
-        addr = fake_address(addr_fmt, testnet) 
+        addr = fake_address(addr_fmt, testnet)
 
     if method == 'qr':
-        if not is_q1:
-            raise pytest.skip('no QR on Mk4')
         goto_home()
         pick_menu_item('Scan Any QR Code')
         scan_a_qr(addr)
@@ -214,7 +227,17 @@ def test_ux(valid, testnet, method,
         assert title == 'Verified Address'
         assert 'Found in wallet' in story
         assert 'Derivation path' in story
-        assert 'P2PKH' in story
+
+        if multisig:
+            assert expect_name in story
+            assert "Press (0) to sign message with this key" not in story
+        else:
+            assert 'P2PKH' in story
+            assert "Press (0) to sign message with this key" in story
+            need_keypress('0')
+            msg = "coinkite CC the most solid HWW"
+            sign_msg_from_address(msg, addr, path, addr_fmt, method, testnet)
+
     else:
         assert title == 'Unknown Address'
         assert 'Searched ' in story
@@ -280,9 +303,7 @@ def test_address_explorer_saver(af, wipe_cache, settings_set, goto_address_explo
     assert title == 'Verified Address'
     assert 'Found in wallet' in story
     assert 'Derivation path' in story
-    if af == "P2SH-Segwit":
-        assert "P2WPKH-in-P2SH" in story
-    elif af == "Segwit P2WPKH":
+    if af == "Segwit P2WPKH":
         assert " P2WPKH " in story
     else:
         assert af in story


### PR DESCRIPTION
Currently we have USB signing (most convenient), SD, and NFC. All need template `msg\nsubpath\naddr_fmt`, upon which they act. New ways to start signing process always starts with something, for example message, and just fill the missing data in subsequent ux prompts. 

Three new ways to sign message besides what is already in there:

1. **after positive address ownership check**, we already have address format and subpath, so if user presses (0) we just ask for msg (can be scanned from QR or manual input) --> classic sign message flow with approval --> export prompt asking whether to export signature( or whole RFC template) to SD, Vdisk, QR (same as QR flow from 3.), or NFC.  This is super convenient on Q: user first scan address from client wallet, does address ownership check, scan msg, sign, done.

2. **`Address Explorer -> Custom Path`** - if showing just single address - msg signing is offered. Same as in 1. we have everything we need besides msg. Ask for message and classic sign message flow with approval follows, export prompt asking where to export.

3. **Scan text to sign from QR, resulting in `Simple Text`** UX (previously was "we cannot do anything with this"). Now new option to Sign this message. Next screens get information about address format and path -->  classic message signing with approval --> show export story with 2 options -> a.) just signature as QR b.) RFC template as BBQr (contains newlines).

4. new msg request format that allows non-printable characters in MSG `{"msg": "<required msg>", "subpath": "<optional path>", "addr_fmt": "<optional af>" }`. Users can scan this format from `Scan Any QR` as it is easy to spot

5. scan RFC template to verify msg

1.,2. & 4.work also on Mk4 just without QR codes. 3. is Q only.
