### PR TITLE
remove subpath assert in descriptor.py

### DIFF
--- a/shared/descriptor.py
+++ b/shared/descriptor.py
@@ -160,7 +160,6 @@ class Descriptor:
             raise ValueError("Key origin info is required for %s" % (key))
         key_orig_info = key[1:close_index]  # remove brackets
         key = key[close_index + 1:]
-        assert "/" in key_orig_info, "Malformed key derivation info"
         return key_orig_info, key
 
     @staticmethod


### PR DESCRIPTION
It was not my preference to jump directly to a PR to propose this change. I would have preferred to create an Issue, but you appear to have disable them for this repro.

I'm attempting to fix an error I get when trying to import a custom multisig wallet descriptor.

### repro steps:
-  Advanced/Tools > Danger Zone- Enable "Testnet Mode"
- Navigate: Settings > Multisig Wallets
- Enabled "Unsorted Multi"
- Saved the descriptor below to a file called "vault.txt" on a microSD card. The name is not important but '.txt' extension is essential or the file will not show up when importing.
- Insert the microSD card.
- Navigate: Settings > Multisig Wallets > Import from File > vault.txt
- Observe error: `Failed to import. Malformed key derivation info descriptor.py:163`

### The descriptor
```
wsh(multi(2,[ed80faab/48h/1h/0h/2h]tpubDFSeJaooCFfYxYbWYUYw5ZRwHTGxSkkBCjXTMDSDFeyMfDHQKF9fzWVeRGhxCtVxL2ArZiMNAKXoaGbFrVy1GEu9o9Ni4c71MoEWGsV5ZBS/0/*,[c0640ad9/48h/1h/0h/2h]tpubDEvqpafwUhWSK2D3b3KPLrdaBsFisxqupBJLkKrvFt468f9s5QJKZy7GheFGoMyaJQAaV72gAf5Bigc8Frymj1tTQ1mQx8yCUpeGg2QN7KT/0/*,[4923b317]tpubD6NzVbkrYhZ4WaMzUcZBkvm9ywxAR1z3aJZrnPH4e9gigfrXPazNjKw3UEUWeKWLAY1CSTQLphmv7CmEHe6jUMfnoK4f88QD8YYbGgdTcsq/0/*))
```

### The Issue

The problem is that the descriptor contains three keys, but one of them is a master public key (it has not had any hardened derivations applied to the master private key). Therefore, the 'key origin info' of this key is only the fingerprint of the master private key. You'll find [from the descriptor standard section on "key expressions"](https://github.com/bitcoin/bips/blob/master/bip-0380.mediawiki#key-expressions) that this is a valid configuration for a descriptor.
![image](https://github.com/user-attachments/assets/0e5cbc1e-62d1-41b1-9436-09baa1627382)


Therefore, the `assert` on line 163 above should not be enforced.

I was able to build and flashed my MK4 with the produced `firmware-signed.dfu`, but I still received the error pointing to the exact line I removed. I can only assume that I need to configure something else to repackage the python bundle. Please advise.

I am also not sure what could break. There is only one reference to this function as far as I could see, but likely many places that use this component and may assert that the path contains more than `m`.

Please advise of further steps I can take to validate my change. I own a couple MK4s and a Q.