### PR TITLE
bugfix: master settings corrupted by using "Add current tmp" in Seed Vault

### DIFF
--- a/releases/Next-ChangeLog.md
+++ b/releases/Next-ChangeLog.md
@@ -4,7 +4,7 @@ This lists the new changes that have not yet been published in a normal release.
 
 # Shared Improvements - Both Mk4 and Q
 
-- tbd
+- Bugfix: `Add current tmp` option in `Seed Vault` corrupts master settings
 
 
 # Mk4 Specific Changes

--- a/shared/seed.py
+++ b/shared/seed.py
@@ -42,8 +42,9 @@ VaultEntry = namedtuple('VaultEntry', 'xfp encoded label origin')
 
 def seed_vault_iter():
     # iterate over all seeds in the vault; returns VaultEntry instances.
-    for tup in settings.master_get("seeds", []):
-        yield VaultEntry(*tup)
+    # raw vault entries are list type when json.loaded from flash
+    for lst in settings.master_get("seeds", []):
+        yield VaultEntry(*lst)
     
 def letter_choices(sofar='', depth=0, thres=5):
     # make a list of word completions based on indicated prefix
@@ -489,7 +490,7 @@ async def add_seed_to_vault(encoded, origin=None, label=None):
     # Save it into master settings
     rec = VaultEntry(xfp=new_xfp_str, encoded=SecretStash.storage_serialize(encoded),
                             label=(label or xfp_ui), origin=origin)
-    seeds.append(tuple(rec))
+    seeds.append(list(rec))
 
     settings.master_set("seeds", seeds)
 
@@ -974,9 +975,9 @@ class SeedVaultMenu(MenuSystem):
         seeds = settings.master_get("seeds", [])
 
         # Save it into master settings
-        seeds.append(VaultEntry(new_xfp_str,
+        seeds.append(list(VaultEntry(new_xfp_str,
                       SecretStash.storage_serialize(pa.tmp_value),
-                      xfp_ui, "unknown origin"))
+                      xfp_ui, "unknown origin")))
 
         settings.master_set("seeds", seeds)
 


### PR DESCRIPTION
* caused by `ujson.dumps` & `ujson.loads` of our custom namedtuple `VaultEntry`

```
$ ./coldcard-mpy 
MicroPython v1.12-1106-g4107246f8-dirty on 2025-04-28; coldcard-unix version
Use Ctrl-D to exit, Ctrl-E for paste mode
>>> from ucollections import namedtuple 
>>> VaultEntry = namedtuple('VaultEntry', 'xfp encoded label origin')
>>> ve = VaultEntry("ffffffff", "c"*144,"[ffffffff]", "from hell!")
>>> ve
VaultEntry(xfp='ffffffff', encoded='cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc', label='[ffffffff]', origin='from hell!')
>>> import ujson 
>>> ujson.dumps(ve)
"VaultEntry(xfp='ffffffff', encoded='cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc', label='[ffffffff]', origin='from hell!')"
>>> res = [ve, 1, 33]
>>> ujson.dumps(res)
"[VaultEntry(xfp='ffffffff', encoded='cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc', label='[ffffffff]', origin='from hell!'), 1, 33]"
>>> ujson.loads(ujson.dumps(res))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: syntax error in JSON
```
* `ujson.dumps` namedtuple no problem (but shouldn't), yet `ujson.loads` raises SyntaxError upon trying to load it
* so actual master settings are still untouched in flash memory but cannot be loaded by device as exception is thrown in `nvstore.py::SettingsObject.load()`

Adding Seed Vault entry via `Add current tmp` in latest released versions (`5.4.2` & `1.3.2Q`) causes user to corrupt/loose his master settings --> multisig wallets, notes & passwords, Seed Vault entries etc. Master secret/seed **IS NOT** affected

**DO NOT** add seed vault entries via `Add current tmp` on versions `5.4.2` & `1.3.2Q`