### PR TITLE
Clarify allowed usage of Seed XOR standard and name

### DIFF
--- a/docs/seed-xor.md
+++ b/docs/seed-xor.md
@@ -157,6 +157,12 @@ with the others on a SEEDPLATE.
     - right to A, down to B ... take that number, and go to that column
     - down to C, that is answer: a &oplus; b &oplus; c
 
+## Open Standard
+Seed XOR is an open standard. Other software and hardware wallets are encouraged to
+implement support. No license or permission is required, including usage of the term
+"Seed XOR" when referring to implementations of this feature. Such implementations
+should match the process described in this documentation and be fully interoperable.
+
 ---
 
 # 24 Words XOR Seed Example Using 3 Parts


### PR DESCRIPTION
There is interest to add Seed XOR support to the project I work on. We already have a work-in-progress PR open in our repo to add the feature.

But there was concern that "Seed XOR" might be a protected / trademarked term.

If Seed XOR is indeed meant to be an open standard, the docs should make this clear.

I view this sort of declaration to be necessary for our work to go forward.

The suggested text here is just my best attempt to communicate that Seed XOR is indeed an open standard and that the name itself may be used in other projects' implementation of this standard.

If there is a better or clearer way to articulate this, I'm happy to amend this PR.