### PR TITLE
bugfix: enter vfs after creating it

### DIFF
--- a/releases/Next-ChangeLog.md
+++ b/releases/Next-ChangeLog.md
@@ -10,6 +10,7 @@ This lists the new changes that have not yet been published in a normal release.
   now offered for transactions of all sizes.
 - Bugfix: If all change outputs have `nValue=0` they're not shown in UX.
 - Bugfix: Disallow negative input/output amounts in PSBT.
+- Bugfix: Fix filesystem initialization after Wife LFS or Destroy Seed
 
 # Mk4 Specific Changes
 

--- a/shared/actions.py
+++ b/shared/actions.py
@@ -1459,7 +1459,7 @@ async def wipe_filesystem(*A):
 Erase internal filesystem and rebuild it. Resets contents of internal flash area \
 used for settings, address search cache, and HSM config file. Does not affect funds, \
 or seed words but will reset settings used with other temporary seeds & BIP-39 passphrases. \
-Does not affect MicroSD card, if any.'''):
+Does not affect MicroSD card, if any.''', confirm_key="4"):
         return
 
     from files import wipe_flash_filesystem

--- a/shared/mk4.py
+++ b/shared/mk4.py
@@ -11,7 +11,8 @@ def make_flash_fs():
     os.VfsLfs2.mkfs(fl)
 
     os.mount(fl, '/flash')
-    os.mkdir('/flash/settings')
+    os.chdir('/flash')
+    os.mkdir('settings')
 
 def make_psram_fs():
     # Filesystem is wiped and rebuilt on each boot before this point, but

--- a/shared/seed.py
+++ b/shared/seed.py
@@ -737,7 +737,7 @@ async def remember_ephemeral_seed():
     # address cache, settings from tmp seeds / seedvault seeds
     # rebuild fs as we want to save current tmp settings immediately
     from files import wipe_flash_filesystem
-    wipe_flash_filesystem(True)
+    wipe_flash_filesystem()
 
     dis.draw_status(bip39=0, tmp=0)
     dis.fullscreen('Saving...')


### PR DESCRIPTION
* fixes ownerhip check failures (ENODEV) after `Wipe LFS` or `Destroy Seed` without the need for reboot
