### PR TITLE
bugfix: exiting nickname entry with nickname already saved deleted previous nickname

### DIFF
--- a/releases/Next-ChangeLog.md
+++ b/releases/Next-ChangeLog.md
@@ -6,6 +6,7 @@ This lists the new changes that have not yet been published in a normal release.
 
 - Bugfix: Delta Mode Trick PIN was never restored from backup
 - Bugfix: Proper error message for incorrect 7z headers
+- Bugfix: Exiting nickname entry with nickname already saved deleted previous nickname
 
 # Mk Specific Changes
 

--- a/shared/actions.py
+++ b/shared/actions.py
@@ -459,21 +459,27 @@ async def pick_nickname(*a):
     # Value is not stored with normal settings, it's part of "prelogin" settings
     # which are encrypted with zero-key.
     s = SettingsObject.prelogin()
-    nick = s.get('nick', '')
+    k = "nick"
+    nick = s.get(k, '')
 
     if not nick:
-        ch = await ux_show_story('''\
-You can give this Coldcard a nickname and it will be shown before login.''')
+        ch = await ux_show_story("You can give this Coldcard a nickname"
+                                 " and it will be shown before login.")
         if ch != 'y': return
 
     nn = await ux_input_text(nick, confirm_exit=False, prompt="Enter Nickname")
+
+    if nn is None or (nick == nn): return  # user exit & same value - noop
 
     from glob import dis
     dis.fullscreen("Saving...")
     dis.busy_bar(True)
 
-    nn = nn.strip() if nn else None
-    s.set('nick', nn)
+    if not nn:
+        s.remove_key(k)
+    else:
+        s.set(k, nn.strip())
+
     s.save()
     dis.busy_bar(False)
     del s

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -1029,9 +1029,12 @@ def settings_set(sim_exec):
 def settings_get(sim_exec):
 
     def doit(key, def_val=None, prelogin=False):
-        source = "from nvstore import SettingsObject;SettingsObject.prelogin()" if prelogin else "settings"
-        cmd = f"RV.write(repr({source}.get('{key}', {def_val!r})))"
-        resp = sim_exec(cmd)
+        if prelogin:
+            src = f"from nvstore import SettingsObject;RV.write(repr(SettingsObject.prelogin().get('{key}', {def_val!r})))"
+        else:
+            src = f"RV.write(repr(settings.get('{key}', {def_val!r})))"
+
+        resp = sim_exec(src)
         assert 'Traceback' not in resp, resp
         return eval(resp)
 
@@ -1051,8 +1054,9 @@ def master_settings_get(sim_exec):
 @pytest.fixture
 def settings_remove(sim_exec):
 
-    def doit(key):
-        x = sim_exec("settings.remove_key('%s')" % key)
+    def doit(key, prelogin=False):
+        source = "from nvstore import SettingsObject;SettingsObject.prelogin()" if prelogin else "settings"
+        x = sim_exec("%s.remove_key('%s')" % (source, key))
         assert x == ''
 
     return doit

--- a/testing/test_ux.py
+++ b/testing/test_ux.py
@@ -1126,6 +1126,35 @@ def test_file_picker_suffixes(pick_menu_item, goto_home, cap_story, microsd_wipe
     microsd_wipe()
 
 
+@pytest.mark.parametrize("already_set", [True, False])
+def test_nickname_cancel_preserves_existing(already_set, goto_home, pick_menu_item, need_keypress,
+                                            settings_set, settings_get, press_cancel, press_select,
+                                            settings_remove, sim_exec):
+    nick = 'CancelTest'
+
+    if already_set:
+        settings_set("nick", nick, prelogin=True)
+    else:
+        settings_remove("nick", prelogin=True)
+
+    goto_home()
+    pick_menu_item('Settings')
+    pick_menu_item('Login Settings')
+    pick_menu_item('Set Nickname')
+    if not already_set:
+        press_select()  # intro
+
+    press_cancel()
+
+    new_nick = settings_get("nick", False, prelogin=True)
+    if already_set:
+        assert nick == new_nick
+    else:
+        assert new_nick is False
+
+    settings_remove("nick")  # clean-up
+
+
 @pytest.mark.onetime
 def test_dump_menutree(sim_execfile):
     # saves to ../unix/work/menudump.txt


### PR DESCRIPTION
* fixed settings_get with prelogin arg