### PR TITLE
Don't restore cached backup password (bkpw) from backup file

### DIFF
--- a/shared/backups.py
+++ b/shared/backups.py
@@ -201,6 +201,13 @@ def restore_from_dict_ll(vals, raw):
 
         k = key[8:]
 
+        if k == 'bkpw':
+            # never import a cached backup password from a backup file.
+            # write-side (render_backup_contents) strips bkpw, so a present
+            # value means a tampered/crafted file trying to fixate the
+            # password used for all FUTURE backups - drop it.
+            continue
+
         if k == 'sd2fa':
             # do NOT restore sd2fa as SD card can be lost or damaged
             # new version of firmware 5.1.3+ will not back sd2fa


### PR DESCRIPTION
## Summary

`render_backup_contents()` deliberately strips the cached backup password
`bkpw` from generated backups, but `restore_from_dict_ll()` has no matching
filter and re-imports any `setting.bkpw` line from a backup file. A crafted or
tampered backup with `setting.bkpw = "<known words>"` thus plants an attacker-
known backup password on restore. `bkpw` is a `MASTER_FIELD`, so it persists,
and `make_complete_backup` then offers it as the default next-backup password
(quiz skipped, only a first/last-word hint shown). Result: all FUTURE backups
are silently encrypted with a password the attacker knows. Password fixation;
bypasses an existing precaution.

## Affected
AFAIU all versions are affected, at least 


## Impact

Tampering a backup only needs its decryption password, which already exposes
the master secret inside - so the master seed is not what this bug leaks. But now days cold card state is more than just master seed.

The fixated, attacker-known password is reused for all FUTURE backups, leaking
secrets added AFTER restore that the attacker did not know at craft time like
- SeedVaults ( affected models: MK4,5 Q1)
-  SecretNotes( only Q1 affected) ,
## Fix

Mirror the write-side strip in `restore_from_dict_ll`, beside sd2fa/ccc:

```python
        if k == 'bkpw':
            # never import a cached backup password from a backup file;
            # a present value means a tampered file fixating future backups.
            continue
```

Legitimate backups never contain `bkpw`, so this only drops injected values.
Tests already assert `bkpw` absent after restore (`test_backup.py:377,456`), so
no breakage.

## Reproduction (simulator)

1. Add `setting.bkpw = [12 known words]` before `# EOF` in a decrypted backup.
2. Restore (start simulatore w/o seed ```./simulator.py --q1 -l```,  Import Existing -> Restore Backup
3. After reboot `settings.get('bkpw')` returns the injected value; a new Backup
   defaults to those words. With the fix: `bkpw` absent, fresh random password.

