### PR TITLE
Fix BBQr share of Unicode text: encode str to UTF-8 before sizing/spitting

### DIFF
--- a/shared/ux_q1.py
+++ b/shared/ux_q1.py
@@ -1211,6 +1211,11 @@ async def show_bbqr_codes(type_code, data, msg, already_hex=False):
     else:
         # default to Base32, because always best option
         encoding = '2'
+        if isinstance(data, str):
+            # 'U'/'J' payloads are UTF-8 text; b32encode consumes the UTF-8
+            # bytes, so convert now to keep length/slicing consistent (else
+            # multi-byte chars overflow target_vers -> assert below trips)
+            data = data.encode()
         data_len = len(data)
 
     # try a few select resolutions (sizes) in order such that we use either single QR


### PR DESCRIPTION

Attempt to export paper walled via QR failed with 

```                                                                                                                                                                     
Failed to share file via QR.                                                                                                                                            
ux_q1.py:1269                                                                                                                                                           
```

Line 1269 is the `assert force_version <= target_vers` in
`show_bbqr_codes()`. The first QR renders at version 31 while the planner only
budgeted version 25, so the assertion aborts the share.

This is because paperwallet contains multibyte characters,  address/WIF as box-drawing QR art, `U+2588` = 3 UTF-8 bytes each. So this is common issue which also affects a Notes & Passwords (`'J'`) export of any note containing a non-ASCII character (accents, emoji, etc.).

### Test
- Generate paper wallet mXXXX.txt
- Advanced/Tools -> File Management -> BBQr File Share -> mXXXX.txt

## Proposed fix 
Since b32encode consumes UTF-8 bytes, we should encode string to UTF-8, similar to what reference implementation does in https://github.com/coinkite/BBQr/blob/master/python/bbqr/split.py#L73-L75
