### PR TITLE
Recognize BBQr Binary 7z blob as paper-backup 

### DIFF
--- a/shared/decoders.py
+++ b/shared/decoders.py
@@ -149,6 +149,16 @@ def decode_qr_result(got, expect_secret=False, expect_text=False, expect_bbqr=Fa
                 raise QRDecodeExplained("Truncated KT RX")
 
             return 'teleport', (ty, got)
+
+        elif ty == 'B':
+            # Binary BBQr: today the only meaningful payload is a Coldcard
+            # paper-backup, identified by the 7z magic header. Reassembled
+            # blob lives at PSRAM offset 0 (BBQrPsramStorage).
+            if final_size >= 6 and bytes(got[:6]) == b'7z\xbc\xaf\x27\x1c':
+                return 'paper_backup', (final_size,)
+            msg = TYPE_LABELS.get(ty, 'Unknown FileType')
+            raise QRDecodeExplained("Sorry, %s not useful." % msg)
+
         else:
             msg = TYPE_LABELS.get(ty, 'Unknown FileType')
             raise QRDecodeExplained("Sorry, %s not useful." % msg)

--- a/shared/ux_q1.py
+++ b/shared/ux_q1.py
@@ -1025,6 +1025,20 @@ class QRScannerInteraction:
             from teleport import kt_incoming
             await kt_incoming(*vals)
 
+        elif what == 'paper_backup':
+            # Encrypted Coldcard backup delivered as a printed sheet of BBQr
+            # codes. The reassembled .7z blob is already in PSRAM at offset 0
+            # (BBQrPsramStorage default); vals[0] is its byte length. Reuse
+            # the existing USB-style restore_complete() path which expects
+            # an int length and reads from PSRAM via SFFile.
+            # A full backup is a master-seed artifact: restore as master on a
+            # blank device (the real recovery case), else as a temporary seed.
+            # Mirrors restore_backup_dev(); the menu-level `tmp` is ignored
+            # because it is always True on a running (seeded) device, which
+            # would dead-end at "Cannot use master seed as temporary".
+            from backups import restore_complete
+            await restore_complete(vals[0], temporary=not pa.is_secret_blank())
+
         else:
             await ux_show_story(what, title='Unhandled')
 


### PR DESCRIPTION
Coldcard Q is a perfect airgap secret storage device, thanks to [SeedVault](https://coldcard.com/docs/temporary-seeds/#seed-vault), [Secure notes/Passwords](https://coldcard.com/docs/secure_notes/) features.
It is much safer than standard phone password storage apps, which makes it perfect
for storing important but rarely accessed secrets like
- Inheritance instructions
- Disaster recovery codes for accounts recovery (email, cloud account, etc)

The only disadvantage of airgap secret storage is that user themselfs is responsible for backup maintenance.
Standard practice of engraving master seed on a steel plate no longer works because CC state is more 
complicate than just master seed, so [full backup](https://github.com/Coldcard/firmware/blob/master/docs/backup-files.md) is required.

Currently the only native backup medium available for Coldcard is microSD cards.
Even high quality SLC card has lifeexpectancy up to 10years, which may be not enouth.
That is why I created [bbqr-paperark](https://github.com/dmonakhov/bbqr-paperark), which allow to use paper as an archive medium.
Paper gives use at 30+ years of storage guarantee and allow to implement [the 3-2-1 backup strategy](https://www.backblaze.com/blog/the-3-2-1-backup-strategy/) with two medium types, SDCard + paper backup.

It is not a good idea to bloat Coldcard code base to support paper backup creation on device, but adding 7 lines of code to support backup recovery via QR code is great compromise for user experience.
- Backup creation is usually performed by experiance user so external tool is OK.
- Backup restore is stressful situation and may be performed by non tech person, so it should be supported naively  by  ColdCard.

Pairs with a standalone offline [CLI](https://github.com/dmonakhov/bbqr-paperark/)  that produces printable BBQr sheets from .7z backups; the device only needs this import-side recognition[1]

## Example
Please find an example backup  https://github.com/dmonakhov/bbqr-paperark/blob/main/example

- `backup.7z` - a real Coldcard (Testnet) backup
- `backup.paperark.pdf` - the printable BBQr sheet produced by `encode`
- `backup.paperark.bbqr.txt` - the ground-truth sidecar (one BBQr part per line)

Its 12-word backup password is:

    pitch sheriff father soap satoshi hazard coil inch cook lumber funny rifle

References:
- [1] CLI tool https://github.com/dmonakhov/bbqr-paperark/
- [2] PDF backup example: https://github.com/dmonakhov/bbqr-paperark/blob/main/examples/backup.paperark.pdf

