### PR TITLE
Repro build cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,12 @@ has been automated using Docker. Steps are as follows:
     ```shell
     git clone https://github.com/Coldcard/firmware.git
     cd firmware
+    git submodule update --init
     # DOWNLOAD https://coldcard.com/downloads
     # get a copy of binary into ./releases/2026-03-05T2052-v5.5.0-mk-coldcard.dfu
     git checkout 2026-03-05T2052-v5.5.0
     cd stm32
-    make -f MK4-Makefile repro
+    make -f MK-Makefile repro
     ```
 
 4. At the end of the process a clear confirmation message is shown, or the differences.

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ has been automated using Docker. Steps are as follows:
     cd firmware
     git submodule update --init
     # DOWNLOAD https://coldcard.com/downloads
-    # get a copy of binary into ./releases/2026-03-05T2052-v5.5.0-mk-coldcard.dfu
-    git checkout 2026-03-05T2052-v5.5.0
+    # get a copy of binary into ./releases/2026-07-01T1729-v5.5.1-mk-coldcard.dfu
+    git checkout 2026-07-01T1730-v5.5.1
     cd stm32
     make -f MK-Makefile repro
     ```

--- a/cli/signit.py
+++ b/cli/signit.py
@@ -106,6 +106,18 @@ def show_version(fname):
 
     print('{built}-v{ver}'.format(built=built, ver=ver))
 
+@main.command('sha256sum')
+@click.argument('files', nargs=-1, required=True, type=click.Path(exists=True))
+def sha256sum(files):
+    "Print SHA256 checksum of file(s); portable stand-in for sha256sum(1)/shasum."
+    for fn in files:
+        h = sha256()
+        with open(fn, 'rb') as fd:
+            for chunk in iter(lambda: fd.read(1 << 20), b''):
+                h.update(chunk)
+        # match GNU sha256sum output: "<hex>  <name>" (two spaces)
+        print("%s  %s" % (h.hexdigest(), fn))
+
 def dfu_parse(fd):
     # do just a little parsing of DFU headers, to find start/length of main binary
     # - not trying to support anything but what ../stm32/Makefile will generate

--- a/stm32/shared.mk
+++ b/stm32/shared.mk
@@ -308,6 +308,7 @@ ifeq ($(PUBLISHED_BIN),)
 	@echo ""
 else
 	@echo Comparing against: $(PUBLISHED_BIN)
+	@echo SHA256: `$(SIGNIT) sha256sum $(PUBLISHED_BIN)`
 	test -n "$(PUBLISHED_BIN)" -a -f $(PUBLISHED_BIN)
 	$(RM) -f check-fw.bin check-bootrom.bin
 	$(SIGNIT) split $(PUBLISHED_BIN) check-fw.bin check-bootrom.bin


### PR DESCRIPTION
Here are trivial cleanups for reproducible build,  Commits are tiny so feel free to squash it in to one if required.

TOC 
## Trivial cleanup for reproducible build examples
- README: Update examples to use latest's release
- README: fix repro build example


## Improve check repro human readability
- check-repro: dump published resource checksum

IMHO with explicit csum logging verification becomes more intuitive , see:
```
Comparing against: /tmp/checkout/firmware/releases/2026-07-01T1727-v1.4.1Q-q1-coldcard.dfu
SHA256: 1139f2192602711ca182cec0e40f825365f4f617dd672eb452a2aa07d3af95e7 /tmp/checkout/firmware/releases/2026-07-01T1727-v1.4.1Q-q1-coldcard.dfu
test -n "/tmp/checkout/firmware/releases/2026-07-01T1727-v1.4.1Q-q1-coldcard.dfu" -a -f /tmp/checkout/firmware/releases/2026-07-01T1727-v1.4.1Q-q1-coldcard.dfu
rm -f -f check-fw.bin check-bootrom.bin
signit split /tmp/checkout/firmware/releases/2026-07-01T1727-v1.4.1Q-q1-coldcard.dfu check-fw.bin check-bootrom.bin
start 293 for 1073152 bytes: Firmware => check-fw.bin
signit check check-fw.bin
     magic_value: 0xcc001234
       timestamp: 2026-07-01 17:28:10 UTC
  version_string: 1.4.1Q
      pubkey_num: 1
 firmware_length: 1073152
   install_flags: 0x0 =>
       hw_compat: 0x10 => Q1
         best_ts: b'\x00\x00\x00\x00\x00\x00\x00\x00'
          future: 0000000000000000 ... 0000000000000000
       signature: be7583eeef90b112 ... d840ffb353891968
sha256^2: 6a7f10b28faacbc319b9b632e1d4978664164a6ec58520ec6f12cba563a9b818

```