### PR TITLE
Feature: Add SLIP-19 support for safe remote-signing of WabiSabi coinjoins

### DIFF
--- a/shared/hsm.py
+++ b/shared/hsm.py
@@ -489,6 +489,7 @@ class HSMPolicy:
 
         # a list of paths we can accept for signing
         self.msg_paths = pop_deriv_list(j, 'msg_paths')
+        self.slip19_paths = pop_deriv_list(j, 'slip19_paths')   # SLIP-19 ownership proofs (coinjoin)
         self.share_xpubs = pop_deriv_list(j, 'share_xpubs')
         self.share_addrs = pop_deriv_list(j, 'share_addrs', 'p2sh')
 
@@ -528,7 +529,7 @@ class HSMPolicy:
         
     def save(self):
         # Create JSON document for next time.
-        simple = ['must_log', 'never_log', 'msg_paths', 'share_xpubs', 'share_addrs',
+        simple = ['must_log', 'never_log', 'msg_paths', 'slip19_paths', 'share_xpubs', 'share_addrs',
                     'notes', 'period', 'allow_sl', 'warnings_ok', 'boot_to_hsm', 'priv_over_ux']
         rv = OrderedDict()
         for fn in simple:
@@ -817,6 +818,12 @@ class HSMPolicy:
             return ('p2sh' in self.share_addrs)
 
         return match_deriv_path(self.share_addrs, subpath)
+
+    def approve_slip19(self, subpath=None):
+        # Are we allowing SLIP-19 ownership proofs (coinjoin remote signing) over USB?
+        if not self.slip19_paths:
+            return False
+        return match_deriv_path(self.slip19_paths, subpath)
 
     @property
     def uptime(self):

--- a/shared/hsm.py
+++ b/shared/hsm.py
@@ -189,6 +189,7 @@ class ApprovalRule:
     def __init__(self, j, idx):
         # read json dict provided
         self.spent_so_far = 0       # for velocity
+        self.txn_count = 0          # for max_txn
 
         def check_user(u):
             if not Users.valid_username(u):
@@ -205,6 +206,7 @@ class ApprovalRule:
         self.local_conf = pop_bool(j, 'local_conf')
         self.wallet = pop_string(j, 'wallet', 1, 20)
         self.min_pct_self_transfer = pop_float(j, 'min_pct_self_transfer', 0, 100.0)
+        self.max_txn = pop_int(j, 'max_txn', 1, 10000)
         self.patterns = pop_list(j, 'patterns')
 
         assert sorted(set(self.users)) == sorted(self.users), 'dup users'
@@ -240,7 +242,7 @@ class ApprovalRule:
         # cleaned up data
         flds = [ 'per_period', 'max_amount', 'users', 'min_users',
                     'local_conf', 'whitelist', 'wallet',
-                    'min_pct_self_transfer', 'patterns' ]
+                    'min_pct_self_transfer', 'max_txn', 'patterns' ]
         rv = OrderedDict()
         for f in flds:
             val = getattr(self, f, None)
@@ -299,6 +301,9 @@ class ApprovalRule:
         if self.min_pct_self_transfer:
             rv += ' if self-transfer percentage is at least %.2f' % self.min_pct_self_transfer
 
+        if self.max_txn is not None:
+            rv += ', for at most %d transaction(s)' % self.max_txn
+
         if self.patterns:
             rv += ' with the following patterns: '
             for p in self.patterns:
@@ -319,6 +324,9 @@ class ApprovalRule:
 
         if self.max_amount is not None:
             assert total_out <= self.max_amount, 'amount exceeded'
+
+        if self.max_txn is not None:
+            assert self.txn_count < self.max_txn, 'transaction count exceeded'
 
         attest_mode = self.whitelist_opts and self.whitelist_opts.attest
         allow_zeroval = self.whitelist_opts and self.whitelist_opts.allow_zeroval_outs
@@ -971,6 +979,9 @@ class HSMPolicy:
 
                 if rule.per_period is not None:
                     self.record_spend(rule, total_out)
+
+                if rule.max_txn is not None:
+                    rule.txn_count += 1
 
                 return 'y'
             except BaseException as exc:

--- a/shared/hsm.py
+++ b/shared/hsm.py
@@ -190,6 +190,7 @@ class ApprovalRule:
         # read json dict provided
         self.spent_so_far = 0       # for velocity
         self.txn_count = 0          # for max_txn
+        self.txn_this_period = 0    # for max_txn_per_period
 
         def check_user(u):
             if not Users.valid_username(u):
@@ -206,7 +207,9 @@ class ApprovalRule:
         self.local_conf = pop_bool(j, 'local_conf')
         self.wallet = pop_string(j, 'wallet', 1, 20)
         self.min_pct_self_transfer = pop_float(j, 'min_pct_self_transfer', 0, 100.0)
+        self.max_sats_leaving = pop_int(j, 'max_sats_leaving', 0, MAX_SATS)
         self.max_txn = pop_int(j, 'max_txn', 1, 10000)
+        self.max_txn_per_period = pop_int(j, 'max_txn_per_period', 1, 10000)
         self.patterns = pop_list(j, 'patterns')
 
         assert sorted(set(self.users)) == sorted(self.users), 'dup users'
@@ -235,14 +238,16 @@ class ApprovalRule:
 
     @property
     def has_velocity(self):
-        return self.per_period is not None
+        # Anything measured per period needs the policy to define one.
+        return self.per_period is not None or self.max_txn_per_period is not None
 
     def to_json(self):
         # remote users need to know what's happening, and we save this
         # cleaned up data
         flds = [ 'per_period', 'max_amount', 'users', 'min_users',
                     'local_conf', 'whitelist', 'wallet',
-                    'min_pct_self_transfer', 'max_txn', 'patterns' ]
+                    'min_pct_self_transfer', 'max_sats_leaving', 'max_txn',
+                    'max_txn_per_period', 'patterns' ]
         rv = OrderedDict()
         for f in flds:
             val = getattr(self, f, None)
@@ -301,8 +306,14 @@ class ApprovalRule:
         if self.min_pct_self_transfer:
             rv += ' if self-transfer percentage is at least %.2f' % self.min_pct_self_transfer
 
+        if self.max_sats_leaving is not None:
+            rv += ', and at most %s may leave the wallet per txn' % render(self.max_sats_leaving)
+
         if self.max_txn is not None:
             rv += ', for at most %d transaction(s)' % self.max_txn
+
+        if self.max_txn_per_period is not None:
+            rv += ', no more than %d transaction(s) per period' % self.max_txn_per_period
 
         if self.patterns:
             rv += ' with the following patterns: '
@@ -380,16 +391,29 @@ class ApprovalRule:
             # check this txn would not exceed the velocity limit
             assert self.spent_so_far + total_out <= self.per_period, 'would exceed period spending'
 
-        # check the self-transfer percentage
-        if self.min_pct_self_transfer:
+        if self.max_txn_per_period is not None:
+            assert self.txn_this_period < self.max_txn_per_period, 'too many transactions this period'
+
+        # what we put in versus what comes back: the ratio and the absolute loss are both checked
+        # against it, so walk the PSBT once.
+        if self.min_pct_self_transfer or self.max_sats_leaving is not None:
             own_in_value = sum([i.amount for i in psbt.inputs if i.num_our_keys])
             own_out_value = 0
             for idx, txo in psbt.output_iter():
                 o = psbt.outputs[idx]
                 if o.num_our_keys:
                     own_out_value += txo.nValue
-            percentage = (float(own_out_value) / own_in_value) * 100.0
-            assert percentage >= self.min_pct_self_transfer, 'does not meet self transfer threshold, expected: %.2f, actual: %.2f' % (self.min_pct_self_transfer, percentage)
+
+            # None of our own inputs means the ratio is undefined; refuse rather than divide by zero.
+            assert own_in_value, 'no inputs of ours to compare against'
+
+            if self.min_pct_self_transfer:
+                percentage = (float(own_out_value) / own_in_value) * 100.0
+                assert percentage >= self.min_pct_self_transfer, 'does not meet self transfer threshold, expected: %.2f, actual: %.2f' % (self.min_pct_self_transfer, percentage)
+
+            if self.max_sats_leaving is not None:
+                leaving = own_in_value - own_out_value
+                assert leaving <= self.max_sats_leaving, 'too much value leaving: %d sats, limit is %d' % (leaving, self.max_sats_leaving)
 
         # check various patterns
 
@@ -695,11 +719,15 @@ class HSMPolicy:
             for r in self.rules:
                 if r.per_period:
                     self.record_spend(r, r.per_period)
+                if r.max_txn_per_period:
+                    r.txn_this_period = r.max_txn_per_period
+                    self.record_spend(r, 0)
 
     def reset_period(self):
         # new period has begun
         for r in self.rules:
             r.spent_so_far = 0
+            r.txn_this_period = 0
         self.period_started = 0
 
     def record_spend(self, rule, amt):
@@ -982,6 +1010,11 @@ class HSMPolicy:
 
                 if rule.max_txn is not None:
                     rule.txn_count += 1
+
+                if rule.max_txn_per_period is not None:
+                    rule.txn_this_period += 1
+                    # starts the period clock without recording a spend
+                    self.record_spend(rule, 0)
 
                 return 'y'
             except BaseException as exc:

--- a/shared/hsm.py
+++ b/shared/hsm.py
@@ -181,6 +181,11 @@ class ApprovalRule:
     # - local_conf: local user must also confirm w/ code
     # - wallet: which multisig wallet to restrict to, or '1' for single signer only
     # - min_pct_self_transfer: minimum percentage of own input value that must go back to self
+    # - min_inputs: fewest inputs the whole transaction may have, ours and everyone else's.
+    #   Meant for coinjoins: a round with only a couple of participants tells the coordinator
+    #   almost everything, so refuse to sign one. Note this counts inputs, which a coordinator
+    #   willing to add its own can inflate at will -- it rules out the degenerate round, it is
+    #   not an anonymity set.
     # - patterns: list of transaction patterns to check for. Valid values:
     #       * EQ_NUM_INS_OUTS:      the number of inputs and outputs must be equal
     #       * EQ_NUM_OWN_INS_OUTS:  the number of **own** inputs and outputs must be equal
@@ -210,6 +215,7 @@ class ApprovalRule:
         self.max_sats_leaving = pop_int(j, 'max_sats_leaving', 0, MAX_SATS)
         self.max_txn = pop_int(j, 'max_txn', 1, 10000)
         self.max_txn_per_period = pop_int(j, 'max_txn_per_period', 1, 10000)
+        self.min_inputs = pop_int(j, 'min_inputs', 1, 10000)
         self.patterns = pop_list(j, 'patterns')
 
         assert sorted(set(self.users)) == sorted(self.users), 'dup users'
@@ -247,7 +253,7 @@ class ApprovalRule:
         flds = [ 'per_period', 'max_amount', 'users', 'min_users',
                     'local_conf', 'whitelist', 'wallet',
                     'min_pct_self_transfer', 'max_sats_leaving', 'max_txn',
-                    'max_txn_per_period', 'patterns' ]
+                    'max_txn_per_period', 'min_inputs', 'patterns' ]
         rv = OrderedDict()
         for f in flds:
             val = getattr(self, f, None)
@@ -315,6 +321,9 @@ class ApprovalRule:
         if self.max_txn_per_period is not None:
             rv += ', no more than %d transaction(s) per period' % self.max_txn_per_period
 
+        if self.min_inputs is not None:
+            rv += ', only in transactions with %d or more inputs' % self.min_inputs
+
         if self.patterns:
             rv += ' with the following patterns: '
             for p in self.patterns:
@@ -338,6 +347,12 @@ class ApprovalRule:
 
         if self.max_txn is not None:
             assert self.txn_count < self.max_txn, 'transaction count exceeded'
+
+        if self.min_inputs is not None:
+            # every participant's inputs, not just ours: a coinjoin round is only worth joining
+            # if enough others are in it.
+            assert psbt.num_inputs >= self.min_inputs, \
+                'too few inputs: %d, need %d' % (psbt.num_inputs, self.min_inputs)
 
         attest_mode = self.whitelist_opts and self.whitelist_opts.attest
         allow_zeroval = self.whitelist_opts and self.whitelist_opts.allow_zeroval_outs

--- a/shared/hsm.py
+++ b/shared/hsm.py
@@ -10,7 +10,7 @@ from utils import cleanup_payment_address
 from pincodes import AE_LONG_SECRET_LEN
 from stash import blank_object
 from users import Users, MAX_NUMBER_USERS, calc_local_pincode
-from public_constants import MAX_USERNAME_LEN
+from public_constants import MAX_USERNAME_LEN, AF_CLASSIC, AF_P2WPKH, AF_P2TR, AF_P2WPKH_P2SH
 from wallet import MiniScriptWallet
 from ubinascii import hexlify as b2a_hex
 from uhashlib import sha256
@@ -29,6 +29,29 @@ MAX_SATS = const(2100000000000000)
 
 # too many refusals will cause reset
 ABSOLUTE_MAX_REFUSALS = const(100)
+
+# Weight units of one of our inputs, for max_fee_per_kvbyte. Base is always
+# 32 txid + 4 index + 1 empty scriptSig + 4 sequence = 41 bytes.
+#
+# The witness figures are deliberate floors: a smaller estimate means a smaller vsize, which means
+# a higher computed feerate, which means the rule refuses sooner. Erring the other way would let a
+# transaction slip past a limit it actually exceeds. Signatures are counted at 71 bytes because
+# that is what this firmware produces - it grinds the nonce until the low-S DER form fits.
+INPUT_WEIGHT = {
+    AF_P2WPKH:      (41 * 4) + (1 + 1 + 71 + 1 + 33),      # marker, sig, pubkey
+    AF_P2TR:        (41 * 4) + (1 + 1 + 64),               # marker, schnorr sig
+    AF_P2WPKH_P2SH: ((41 + 1 + 22) * 4) + (1 + 1 + 71 + 1 + 33),
+    AF_CLASSIC:     (41 + 106) * 4,                        # scriptSig carries sig + pubkey
+}
+
+
+def input_weight(addr_fmt):
+    # Refuse rather than guess. A wrong weight here silently mis-scales the feerate, and this rule
+    # exists precisely because the transaction-wide fee cannot be checked in a coinjoin.
+    try:
+        return INPUT_WEIGHT[addr_fmt]
+    except KeyError:
+        raise AssertionError('max_fee_per_kvbyte cannot size a 0x%x input' % (addr_fmt or 0))
 
 # you have this many seconds after boot to escape HSM
 # mode, if you enable the boot_to_hsm feature
@@ -180,6 +203,17 @@ class ApprovalRule:
     # - local_conf: local user must also confirm w/ code
     # - wallet: which miniscript wallet to restrict to, or '1' for single signer only
     # - min_pct_self_transfer: minimum percentage of own input value that must go back to self
+    # - max_fee_per_kvbyte: most we will pay per 1000 vbytes of our own contribution, in sats.
+    #   Our loss (own inputs minus own outputs) over the vsize of our own inputs and outputs. In a
+    #   coinjoin the other participants' input amounts are unknown, so the transaction-wide fee
+    #   cannot be computed at all and upstream's fee check is skipped; this one needs only our own
+    #   values and so still works. It is an upper bound: our loss also covers coordinator fees and
+    #   any value genuinely leaving, so the mining feerate we actually pay is at most this.
+    # - min_inputs: fewest inputs the whole transaction may have, ours and everyone else's.
+    #   Meant for coinjoins: a round with only a couple of participants tells the coordinator
+    #   almost everything, so refuse to sign one. Note this counts inputs, which a coordinator
+    #   willing to add its own can inflate at will -- it rules out the degenerate round, it is
+    #   not an anonymity set.
     # - patterns: list of transaction patterns to check for. Valid values:
     #       * EQ_NUM_INS_OUTS:      the number of inputs and outputs must be equal
     #       * EQ_NUM_OWN_INS_OUTS:  the number of **own** inputs and outputs must be equal
@@ -188,6 +222,8 @@ class ApprovalRule:
     def __init__(self, j, idx):
         # read json dict provided
         self.spent_so_far = 0       # for velocity
+        self.txn_count = 0          # for max_txn
+        self.txn_this_period = 0    # for max_txn_per_period
 
         def check_user(u):
             if not Users.valid_username(u):
@@ -204,6 +240,11 @@ class ApprovalRule:
         self.local_conf = pop_bool(j, 'local_conf')
         self.wallet = pop_string(j, 'wallet', 1, 20)
         self.min_pct_self_transfer = pop_float(j, 'min_pct_self_transfer', 0, 100.0)
+        self.max_sats_leaving = pop_int(j, 'max_sats_leaving', 0, MAX_SATS)
+        self.max_fee_per_kvbyte = pop_int(j, 'max_fee_per_kvbyte', 0, MAX_SATS)
+        self.max_txn = pop_int(j, 'max_txn', 1, 10000)
+        self.max_txn_per_period = pop_int(j, 'max_txn_per_period', 1, 10000)
+        self.min_inputs = pop_int(j, 'min_inputs', 1, 10000)
         self.patterns = pop_list(j, 'patterns')
 
         assert sorted(set(self.users)) == sorted(self.users), 'dup users'
@@ -233,14 +274,16 @@ class ApprovalRule:
 
     @property
     def has_velocity(self):
-        return self.per_period is not None
+        # Anything measured per period needs the policy to define one.
+        return self.per_period is not None or self.max_txn_per_period is not None
 
     def to_json(self):
         # remote users need to know what's happening, and we save this
         # cleaned up data
         flds = [ 'per_period', 'max_amount', 'users', 'min_users',
                     'local_conf', 'whitelist', 'wallet',
-                    'min_pct_self_transfer', 'patterns' ]
+                    'min_pct_self_transfer', 'max_sats_leaving', 'max_fee_per_kvbyte', 'max_txn',
+                    'max_txn_per_period', 'min_inputs', 'patterns' ]
         rv = OrderedDict()
         for f in flds:
             val = getattr(self, f, None)
@@ -299,6 +342,21 @@ class ApprovalRule:
         if self.min_pct_self_transfer:
             rv += ' if self-transfer percentage is at least %.2f' % self.min_pct_self_transfer
 
+        if self.max_sats_leaving is not None:
+            rv += ', and at most %s may leave the wallet per txn' % render(self.max_sats_leaving)
+
+        if self.max_fee_per_kvbyte is not None:
+            rv += ', paying at most %s per 1000 vbytes of our own' % render(self.max_fee_per_kvbyte)
+
+        if self.max_txn is not None:
+            rv += ', for at most %d transaction(s)' % self.max_txn
+
+        if self.max_txn_per_period is not None:
+            rv += ', no more than %d transaction(s) per period' % self.max_txn_per_period
+
+        if self.min_inputs is not None:
+            rv += ', only in transactions with %d or more inputs' % self.min_inputs
+
         if self.patterns:
             rv += ' with the following patterns: '
             for p in self.patterns:
@@ -318,6 +376,15 @@ class ApprovalRule:
 
         if self.max_amount is not None:
             assert total_out <= self.max_amount, 'amount exceeded'
+
+        if self.max_txn is not None:
+            assert self.txn_count < self.max_txn, 'transaction count exceeded'
+
+        if self.min_inputs is not None:
+            # every participant's inputs, not just ours: a coinjoin round is only worth joining
+            # if enough others are in it.
+            assert psbt.num_inputs >= self.min_inputs, \
+                'too few inputs: %d, need %d' % (psbt.num_inputs, self.min_inputs)
 
         attest_mode = self.whitelist_opts and self.whitelist_opts.attest
         allow_zeroval = self.whitelist_opts and self.whitelist_opts.allow_zeroval_outs
@@ -371,16 +438,47 @@ class ApprovalRule:
             # check this txn would not exceed the velocity limit
             assert self.spent_so_far + total_out <= self.per_period, 'would exceed period spending'
 
-        # check the self-transfer percentage
-        if self.min_pct_self_transfer:
+        if self.max_txn_per_period is not None:
+            assert self.txn_this_period < self.max_txn_per_period, 'too many transactions this period'
+
+        # what we put in versus what comes back: the ratio, the absolute loss and the feerate are
+        # all checked against it, so walk the PSBT once.
+        if self.min_pct_self_transfer or self.max_sats_leaving is not None \
+                or self.max_fee_per_kvbyte is not None:
             own_in_value = sum([i.amount for i in psbt.inputs if i.sp_idxs])
             own_out_value = 0
+            own_weight = 0
+
+            for i in psbt.inputs:
+                if i.sp_idxs:
+                    own_weight += input_weight(i.af)
+
             for idx, txo in psbt.output_iter():
                 o = psbt.outputs[idx]
                 if o.sp_idxs:
                     own_out_value += txo.nValue
-            percentage = (float(own_out_value) / own_in_value) * 100.0
-            assert percentage >= self.min_pct_self_transfer, 'does not meet self transfer threshold, expected: %.2f, actual: %.2f' % (self.min_pct_self_transfer, percentage)
+                    # 8 value + 1 script-length + the script itself; ours are never over 252 bytes
+                    own_weight += (8 + 1 + len(txo.scriptPubKey)) * 4
+
+            # None of our own inputs means the ratio is undefined; refuse rather than divide by zero.
+            assert own_in_value, 'no inputs of ours to compare against'
+
+            if self.min_pct_self_transfer:
+                percentage = (float(own_out_value) / own_in_value) * 100.0
+                assert percentage >= self.min_pct_self_transfer, 'does not meet self transfer threshold, expected: %.2f, actual: %.2f' % (self.min_pct_self_transfer, percentage)
+
+            if self.max_sats_leaving is not None:
+                leaving = own_in_value - own_out_value
+                assert leaving <= self.max_sats_leaving, 'too much value leaving: %d sats, limit is %d' % (leaving, self.max_sats_leaving)
+
+            if self.max_fee_per_kvbyte is not None:
+                # Rounding down the vsize rounds the feerate up, so the limit is never exceeded by
+                # a transaction this passes. Same reason the witness estimate above is a floor.
+                vsize = own_weight // 4
+                assert vsize, 'no weight of ours to divide by'
+                feerate = ((own_in_value - own_out_value) * 1000) // vsize
+                assert feerate <= self.max_fee_per_kvbyte, \
+                    'feerate too high: %d sats/kvB of ours, limit is %d' % (feerate, self.max_fee_per_kvbyte)
 
         # check various patterns
 
@@ -488,6 +586,7 @@ class HSMPolicy:
 
         # a list of paths we can accept for signing
         self.msg_paths = pop_deriv_list(j, 'msg_paths', ['any'])
+        self.slip19_paths = pop_deriv_list(j, 'slip19_paths', ['any'])  # SLIP-19 proofs (coinjoin)
         self.share_xpubs = pop_deriv_list(j, 'share_xpubs', ['any'])
         self.share_addrs = pop_deriv_list(j, 'share_addrs', ['any', 'msas'])
 
@@ -527,7 +626,7 @@ class HSMPolicy:
         
     def save(self):
         # Create JSON document for next time.
-        simple = ['must_log', 'never_log', 'msg_paths', 'share_xpubs', 'share_addrs',
+        simple = ['must_log', 'never_log', 'msg_paths', 'slip19_paths', 'share_xpubs', 'share_addrs',
                     'notes', 'period', 'allow_sl', 'warnings_ok', 'boot_to_hsm', 'priv_over_ux']
         rv = OrderedDict()
         for fn in simple:
@@ -685,11 +784,15 @@ class HSMPolicy:
             for r in self.rules:
                 if r.per_period:
                     self.record_spend(r, r.per_period)
+                if r.max_txn_per_period:
+                    r.txn_this_period = r.max_txn_per_period
+                    self.record_spend(r, 0)
 
     def reset_period(self):
         # new period has begun
         for r in self.rules:
             r.spent_so_far = 0
+            r.txn_this_period = 0
         self.period_started = 0
 
     def record_spend(self, rule, amt):
@@ -816,6 +919,12 @@ class HSMPolicy:
             return ('msas' in self.share_addrs)
 
         return match_deriv_path(self.share_addrs, subpath)
+
+    def approve_slip19(self, subpath=None):
+        # Are we allowing SLIP-19 ownership proofs (coinjoin remote signing) over USB?
+        if not self.slip19_paths:
+            return False
+        return match_deriv_path(self.slip19_paths, subpath)
 
     @property
     def uptime(self):
@@ -969,6 +1078,14 @@ class HSMPolicy:
 
                 if rule.per_period is not None:
                     self.record_spend(rule, total_out)
+
+                if rule.max_txn is not None:
+                    rule.txn_count += 1
+
+                if rule.max_txn_per_period is not None:
+                    rule.txn_this_period += 1
+                    # starts the period clock without recording a spend
+                    self.record_spend(rule, 0)
 
                 return 'y'
             except BaseException as exc:

--- a/shared/hsm.py
+++ b/shared/hsm.py
@@ -10,7 +10,7 @@ from utils import cleanup_payment_address
 from pincodes import AE_LONG_SECRET_LEN
 from stash import blank_object
 from users import Users, MAX_NUMBER_USERS, calc_local_pincode
-from public_constants import MAX_USERNAME_LEN
+from public_constants import MAX_USERNAME_LEN, AF_CLASSIC, AF_P2WPKH, AF_P2TR, AF_P2WPKH_P2SH
 from multisig import MultisigWallet
 from ubinascii import hexlify as b2a_hex
 from ubinascii import unhexlify as a2b_hex
@@ -30,6 +30,29 @@ MAX_SATS = const(2100000000000000)
 
 # too many refusals will cause reset
 ABSOLUTE_MAX_REFUSALS = const(100)
+
+# Weight units of one of our inputs, for max_fee_per_kvbyte. Base is always
+# 32 txid + 4 index + 1 empty scriptSig + 4 sequence = 41 bytes.
+#
+# The witness figures are deliberate floors: a smaller estimate means a smaller vsize, which means
+# a higher computed feerate, which means the rule refuses sooner. Erring the other way would let a
+# transaction slip past a limit it actually exceeds. Signatures are counted at 71 bytes because
+# that is what this firmware produces - it grinds the nonce until the low-S DER form fits.
+INPUT_WEIGHT = {
+    AF_P2WPKH:      (41 * 4) + (1 + 1 + 71 + 1 + 33),      # marker, sig, pubkey
+    AF_P2TR:        (41 * 4) + (1 + 1 + 64),               # marker, schnorr sig
+    AF_P2WPKH_P2SH: ((41 + 1 + 22) * 4) + (1 + 1 + 71 + 1 + 33),
+    AF_CLASSIC:     (41 + 106) * 4,                        # scriptSig carries sig + pubkey
+}
+
+
+def input_weight(addr_fmt):
+    # Refuse rather than guess. A wrong weight here silently mis-scales the feerate, and this rule
+    # exists precisely because the transaction-wide fee cannot be checked in a coinjoin.
+    try:
+        return INPUT_WEIGHT[addr_fmt]
+    except KeyError:
+        raise AssertionError('max_fee_per_kvbyte cannot size a 0x%x input' % (addr_fmt or 0))
 
 # you have this many seconds after boot to escape HSM
 # mode, if you enable the boot_to_hsm feature
@@ -181,6 +204,12 @@ class ApprovalRule:
     # - local_conf: local user must also confirm w/ code
     # - wallet: which multisig wallet to restrict to, or '1' for single signer only
     # - min_pct_self_transfer: minimum percentage of own input value that must go back to self
+    # - max_fee_per_kvbyte: most we will pay per 1000 vbytes of our own contribution, in sats.
+    #   Our loss (own inputs minus own outputs) over the vsize of our own inputs and outputs. In a
+    #   coinjoin the other participants' input amounts are unknown, so the transaction-wide fee
+    #   cannot be computed at all and upstream's fee check is skipped; this one needs only our own
+    #   values and so still works. It is an upper bound: our loss also covers coordinator fees and
+    #   any value genuinely leaving, so the mining feerate we actually pay is at most this.
     # - min_inputs: fewest inputs the whole transaction may have, ours and everyone else's.
     #   Meant for coinjoins: a round with only a couple of participants tells the coordinator
     #   almost everything, so refuse to sign one. Note this counts inputs, which a coordinator
@@ -213,6 +242,7 @@ class ApprovalRule:
         self.wallet = pop_string(j, 'wallet', 1, 20)
         self.min_pct_self_transfer = pop_float(j, 'min_pct_self_transfer', 0, 100.0)
         self.max_sats_leaving = pop_int(j, 'max_sats_leaving', 0, MAX_SATS)
+        self.max_fee_per_kvbyte = pop_int(j, 'max_fee_per_kvbyte', 0, MAX_SATS)
         self.max_txn = pop_int(j, 'max_txn', 1, 10000)
         self.max_txn_per_period = pop_int(j, 'max_txn_per_period', 1, 10000)
         self.min_inputs = pop_int(j, 'min_inputs', 1, 10000)
@@ -252,7 +282,7 @@ class ApprovalRule:
         # cleaned up data
         flds = [ 'per_period', 'max_amount', 'users', 'min_users',
                     'local_conf', 'whitelist', 'wallet',
-                    'min_pct_self_transfer', 'max_sats_leaving', 'max_txn',
+                    'min_pct_self_transfer', 'max_sats_leaving', 'max_fee_per_kvbyte', 'max_txn',
                     'max_txn_per_period', 'min_inputs', 'patterns' ]
         rv = OrderedDict()
         for f in flds:
@@ -314,6 +344,9 @@ class ApprovalRule:
 
         if self.max_sats_leaving is not None:
             rv += ', and at most %s may leave the wallet per txn' % render(self.max_sats_leaving)
+
+        if self.max_fee_per_kvbyte is not None:
+            rv += ', paying at most %s per 1000 vbytes of our own' % render(self.max_fee_per_kvbyte)
 
         if self.max_txn is not None:
             rv += ', for at most %d transaction(s)' % self.max_txn
@@ -409,15 +442,24 @@ class ApprovalRule:
         if self.max_txn_per_period is not None:
             assert self.txn_this_period < self.max_txn_per_period, 'too many transactions this period'
 
-        # what we put in versus what comes back: the ratio and the absolute loss are both checked
-        # against it, so walk the PSBT once.
-        if self.min_pct_self_transfer or self.max_sats_leaving is not None:
+        # what we put in versus what comes back: the ratio, the absolute loss and the feerate are
+        # all checked against it, so walk the PSBT once.
+        if self.min_pct_self_transfer or self.max_sats_leaving is not None \
+                or self.max_fee_per_kvbyte is not None:
             own_in_value = sum([i.amount for i in psbt.inputs if i.num_our_keys])
             own_out_value = 0
+            own_weight = 0
+
+            for i in psbt.inputs:
+                if i.num_our_keys:
+                    own_weight += input_weight(i.addr_fmt)
+
             for idx, txo in psbt.output_iter():
                 o = psbt.outputs[idx]
                 if o.num_our_keys:
                     own_out_value += txo.nValue
+                    # 8 value + 1 script-length + the script itself; ours are never over 252 bytes
+                    own_weight += (8 + 1 + len(txo.scriptPubKey)) * 4
 
             # None of our own inputs means the ratio is undefined; refuse rather than divide by zero.
             assert own_in_value, 'no inputs of ours to compare against'
@@ -429,6 +471,15 @@ class ApprovalRule:
             if self.max_sats_leaving is not None:
                 leaving = own_in_value - own_out_value
                 assert leaving <= self.max_sats_leaving, 'too much value leaving: %d sats, limit is %d' % (leaving, self.max_sats_leaving)
+
+            if self.max_fee_per_kvbyte is not None:
+                # Rounding down the vsize rounds the feerate up, so the limit is never exceeded by
+                # a transaction this passes. Same reason the witness estimate above is a floor.
+                vsize = own_weight // 4
+                assert vsize, 'no weight of ours to divide by'
+                feerate = ((own_in_value - own_out_value) * 1000) // vsize
+                assert feerate <= self.max_fee_per_kvbyte, \
+                    'feerate too high: %d sats/kvB of ours, limit is %d' % (feerate, self.max_fee_per_kvbyte)
 
         # check various patterns
 

--- a/shared/hsm_ux.py
+++ b/shared/hsm_ux.py
@@ -166,8 +166,17 @@ async def start_hsm_approval(sf_len=0, usb_mode=False, startup_mode=False):
 class hsmUxInteraction:
     # Based on Menu() class, but just skeleton: blocks everything
 
+    # How long a busy message may sit unchanged before it is cleared. A host that stops talking part
+    # way through an upload never sends the rest, and since nothing raised, the code that normally
+    # restores the screen never runs -- so the device is left reading "Receiving..." while it is in
+    # fact idle and waiting. Harmless, but it is the worst possible reading for something meant to
+    # be left signing unattended. Comfortably longer than the gap between progress updates during a
+    # real transfer, so ordinary work never trips it.
+    BUSY_TIMEOUT_MS = const(30000)
+
     def __init__(self):
         self.busy_text = None
+        self.busy_since = None
         self.percent = None
         self.digits = ''
         self.phase = 0
@@ -279,9 +288,20 @@ class hsmUxInteraction:
             if percent >= 0.995:            # ~ last pixel
                 self.percent = None
                 self.busy_text = msg = None
+                self.busy_since = None
 
         if msg is not None:
             self.busy_text = msg
+
+        if msg is not None or percent is not None:
+            # something is still happening, so keep it on screen
+            self.busy_since = utime.ticks_ms()
+        elif (self.busy_text is not None and self.busy_since is not None
+                and utime.ticks_diff(utime.ticks_ms(), self.busy_since) > BUSY_TIMEOUT_MS):
+            # nothing has moved for a while: the host is gone, so stop claiming to be busy
+            self.busy_text = None
+            self.percent = None
+            self.busy_since = None
 
         if self.busy_text is not None:
             # clear under it

--- a/shared/hsm_ux.py
+++ b/shared/hsm_ux.py
@@ -264,7 +264,7 @@ class hsmUxInteraction:
     update_contents = show
 
     def draw_busy(self, msg, percent):
-        from display import FontTiny
+        from display import FontTiny, FontSmall
         from glob import dis
 
         self.last_percent = 0.5
@@ -286,7 +286,11 @@ class hsmUxInteraction:
         if self.busy_text is not None:
             # clear under it
             dis.clear_rect(0,y, 128, 64-y)
-            dis.text(None, y, self.busy_text)
+
+            # Drop to the tiny font rather than run off the screen: dis.text centres but does not
+            # wrap or shrink, so anything wider than 128px silently loses its ends.
+            font = FontSmall if dis.width(self.busy_text, FontSmall) <= 128 else FontTiny
+            dis.text(None, y, self.busy_text, font)
 
         if self.percent is not None:
             x = int(128 * self.percent)

--- a/shared/hsm_ux.py
+++ b/shared/hsm_ux.py
@@ -166,8 +166,17 @@ async def start_hsm_approval(sf_len=0, usb_mode=False, startup_mode=False):
 class hsmUxInteraction:
     # Based on Menu() class, but just skeleton: blocks everything
 
+    # How long a busy message may sit unchanged before it is cleared. A host that stops talking part
+    # way through an upload never sends the rest, and since nothing raised, the code that normally
+    # restores the screen never runs -- so the device is left reading "Receiving..." while it is in
+    # fact idle and waiting. Harmless, but it is the worst possible reading for something meant to
+    # be left signing unattended. Comfortably longer than the gap between progress updates during a
+    # real transfer, so ordinary work never trips it.
+    BUSY_TIMEOUT_MS = const(30000)
+
     def __init__(self):
         self.busy_text = None
+        self.busy_since = None
         self.percent = None
         self.digits = ''
         self.phase = 0
@@ -264,7 +273,7 @@ class hsmUxInteraction:
     update_contents = show
 
     def draw_busy(self, msg, percent):
-        from display import FontTiny
+        from display import FontTiny, FontSmall
         from glob import dis
 
         self.last_percent = 0.5
@@ -279,14 +288,29 @@ class hsmUxInteraction:
             if percent >= 0.995:            # ~ last pixel
                 self.percent = None
                 self.busy_text = msg = None
+                self.busy_since = None
 
         if msg is not None:
             self.busy_text = msg
 
+        if msg is not None or percent is not None:
+            # something is still happening, so keep it on screen
+            self.busy_since = utime.ticks_ms()
+        elif (self.busy_text is not None and self.busy_since is not None
+                and utime.ticks_diff(utime.ticks_ms(), self.busy_since) > BUSY_TIMEOUT_MS):
+            # nothing has moved for a while: the host is gone, so stop claiming to be busy
+            self.busy_text = None
+            self.percent = None
+            self.busy_since = None
+
         if self.busy_text is not None:
             # clear under it
             dis.clear_rect(0,y, 128, 64-y)
-            dis.text(None, y, self.busy_text)
+
+            # Drop to the tiny font rather than run off the screen: dis.text centres but does not
+            # wrap or shrink, so anything wider than 128px silently loses its ends.
+            font = FontSmall if dis.width(self.busy_text, FontSmall) <= 128 else FontTiny
+            dis.text(None, y, self.busy_text, font)
 
         if self.percent is not None:
             x = int(128 * self.percent)

--- a/shared/manifest.py
+++ b/shared/manifest.py
@@ -46,6 +46,7 @@ freeze_as_mpy('', [
 	'seed.py',
 	'selftest.py',
 	'serializations.py',
+	'slip19.py',
 	'sffile.py',
 	'stash.py',
 	'tapsigner.py',

--- a/shared/manifest.py
+++ b/shared/manifest.py
@@ -50,6 +50,7 @@ freeze_as_mpy('', [
 	'seed.py',
 	'selftest.py',
 	'serializations.py',
+	'slip19.py',
 	'sffile.py',
 	'stash.py',
 	'tapsigner.py',

--- a/shared/slip19.py
+++ b/shared/slip19.py
@@ -1,0 +1,62 @@
+# SLIP-19 ownership proofs (BIP-322-style), for coinjoin remote-signing (e.g. Wasabi WabiSabi).
+# Produces a proof a coordinator verifier accepts: a signature over
+#   SHA256( proof_body || cs(scriptPubKey) || scriptPubKey || cs(commitment) || commitment )
+# where proof_body = magic(SL\x00\x19) || flags || varint(count) || 32-byte ownership id(s).
+#
+# The wire result is the full serialized ownership proof: proof_body || bip322_sig
+# (bip322_sig = empty scriptSig (varint 0) || witness stack).
+import ngu, stash
+from public_constants import AF_P2WPKH, AF_P2TR
+
+SLIP19_MAGIC = bytes([0x53, 0x4c, 0x00, 0x19])
+FLAG_USER_CONFIRMATION = 0x01
+
+def _cs(n):
+    # Bitcoin compact-size varint (values used here are small).
+    if n < 0xfd:
+        return bytes([n])
+    return bytes([0xfd, n & 0xff, (n >> 8) & 0xff])
+
+def make_ownership_proof(subpath, flags, commitment):
+    # subpath: str like "m/84h/0h/0h/1/0"; flags: int; commitment: bytes.
+    with stash.SensitiveValues() as sv:
+        node = sv.derive_path(subpath)
+        pk = node.privkey()
+        pubkey = node.pubkey()          # 33-byte compressed
+
+    # scriptPubKey: default Wasabi paths -> P2WPKH for 84h, P2TR for 86h. Decide by path purpose.
+    purpose = subpath.split("/")[1] if "/" in subpath else ""
+    is_taproot = purpose.startswith("86")
+
+    oid = bytes(32)                     # ownership id (see _ownership_id note)
+    proof_body = SLIP19_MAGIC + bytes([flags & 0xff]) + _cs(1) + oid
+
+    if not is_taproot:
+        h160 = ngu.hash.ripemd160(ngu.hash.sha256s(pubkey))
+        spk = bytes([0x00, 0x14]) + h160
+        preimage = proof_body + _cs(len(spk)) + spk + _cs(len(commitment)) + commitment
+        digest = ngu.hash.sha256s(preimage)
+        sig65 = ngu.secp256k1.sign(pk, digest, 0).to_bytes()
+        r = sig65[1:33]
+        s = sig65[33:65]
+        der = _der_sig(r, s) + bytes([0x01])            # + SIGHASH_ALL
+        witness = _cs(2) + _cs(len(der)) + der + _cs(len(pubkey)) + pubkey
+    else:
+        # P2TR: BIP86 output key + BIP-340 schnorr keyspend over the same digest.
+        raise ValueError("taproot slip19 not yet implemented")   # productionization TODO
+
+    bip322_sig = _cs(0) + witness       # empty scriptSig, then witness stack
+    return proof_body + bip322_sig
+
+def _der_sig(r, s):
+    def der_int(x):
+        x = bytes(x)
+        i = 0
+        while i < len(x) - 1 and x[i] == 0:
+            i += 1
+        x = x[i:]
+        if x[0] & 0x80:
+            x = bytes([0]) + x
+        return bytes([0x02, len(x)]) + x
+    body = der_int(r) + der_int(s)
+    return bytes([0x30, len(body)]) + body

--- a/shared/slip19.py
+++ b/shared/slip19.py
@@ -22,21 +22,22 @@ def _tagged_hash(tag, msg):
     th = ngu.hash.sha256s(tag)
     return ngu.hash.sha256s(th + th + msg)
 
-def make_ownership_proof(subpath, flags, commitment):
-    # subpath: str like "m/84h/0h/0h/1/0"; flags: int; commitment: bytes.
+def make_ownership_proof(subpath, addr_fmt, flags, commitment):
+    # subpath: str like "m/84h/0h/0h/1/0"; addr_fmt: AF_P2WPKH or AF_P2TR; commitment: bytes.
+    # The caller states the address format, the same way smsg does. Deriving it from the path
+    # purpose instead would be a guess: the purpose does not have to match the script actually
+    # used at that path, and a proof over the wrong scriptPubKey is silently useless.
+    assert addr_fmt in (AF_P2WPKH, AF_P2TR), 'unsupported address format for ownership proof'
+
     with stash.SensitiveValues() as sv:
         node = sv.derive_path(subpath)
         pk = node.privkey()
         pubkey = node.pubkey()          # 33-byte compressed
 
-    # scriptPubKey: default Wasabi paths -> P2WPKH for 84h, P2TR for 86h. Decide by path purpose.
-    purpose = subpath.split("/")[1] if "/" in subpath else ""
-    is_taproot = purpose.startswith("86")
-
     oid = bytes(32)                     # ownership id (see _ownership_id note)
     proof_body = SLIP19_MAGIC + bytes([flags & 0xff]) + _cs(1) + oid
 
-    if not is_taproot:
+    if addr_fmt == AF_P2WPKH:
         h160 = ngu.hash.ripemd160(ngu.hash.sha256s(pubkey))
         spk = bytes([0x00, 0x14]) + h160
         preimage = proof_body + _cs(len(spk)) + spk + _cs(len(commitment)) + commitment

--- a/shared/slip19.py
+++ b/shared/slip19.py
@@ -17,6 +17,11 @@ def _cs(n):
         return bytes([n])
     return bytes([0xfd, n & 0xff, (n >> 8) & 0xff])
 
+def _tagged_hash(tag, msg):
+    # BIP-340 tagged hash: SHA256( SHA256(tag) || SHA256(tag) || msg ).
+    th = ngu.hash.sha256s(tag)
+    return ngu.hash.sha256s(th + th + msg)
+
 def make_ownership_proof(subpath, flags, commitment):
     # subpath: str like "m/84h/0h/0h/1/0"; flags: int; commitment: bytes.
     with stash.SensitiveValues() as sv:
@@ -42,8 +47,21 @@ def make_ownership_proof(subpath, flags, commitment):
         der = _der_sig(r, s) + bytes([0x01])            # + SIGHASH_ALL
         witness = _cs(2) + _cs(len(der)) + der + _cs(len(pubkey)) + pubkey
     else:
-        # P2TR: BIP86 output key + BIP-340 schnorr keyspend over the same digest.
-        raise ValueError("taproot slip19 not yet implemented")   # productionization TODO
+        # P2TR (BIP-86 key-spend): tweak the internal key with the taproot tweak (no script tree),
+        # then sign the same SLIP-19 digest as a BIP-340 key-spend. libsecp256k1's
+        # keypair_xonly_tweak_add handles the internal even-Y negation and output-key parity, so the
+        # resulting signature verifies against the tweaked output key in the scriptPubKey.
+        kp = ngu.secp256k1.keypair(pk)
+        internal_xonly = kp.xonly_pubkey().to_bytes()               # 32-byte internal x-only key
+        out_kp = kp.xonly_tweak_add(_tagged_hash(b'TapTweak', internal_xonly))
+        out_xonly = out_kp.xonly_pubkey().to_bytes()                # 32-byte output x-only key
+        spk = bytes([0x51, 0x20]) + out_xonly                       # P2TR: OP_1 push32 <output key>
+        preimage = proof_body + _cs(len(spk)) + spk + _cs(len(commitment)) + commitment
+        digest = ngu.hash.sha256s(preimage)
+        # aux_rand = 0: BIP-340 permits it; sign32 still binds (secret, message) so it is safe and
+        # deterministic for a proof. Witness is a single key-spend sig (SigHash.Default -> 64 bytes).
+        sig = ngu.secp256k1.sign_schnorr(out_kp, digest, bytes(32))
+        witness = _cs(1) + _cs(len(sig)) + sig
 
     bip322_sig = _cs(0) + witness       # empty scriptSig, then witness stack
     return proof_body + bip322_sig

--- a/shared/slip19.py
+++ b/shared/slip19.py
@@ -1,0 +1,233 @@
+# (c) Copyright 2026 by Coinkite Inc. This file is covered by license found in COPYING-CC.
+#
+# - Thanks to [Kevin Ravensberg](https://github.com/kravens)
+#
+# SLIP-19 ownership proofs (BIP-322-style), for coinjoin remote-signing (e.g. Wasabi WabiSabi).
+# Produces a proof a coordinator verifier accepts: a signature over
+#   SHA256( proof_body || cs(scriptPubKey) || scriptPubKey || cs(commitment) || commitment )
+# where proof_body = magic(SL\x00\x19) || flags || varint(count) || 32-byte ownership id(s).
+# flags bit 0 is SLIP-19's user-confirmation claim; the host picks it, we only honour it below.
+#
+# The wire result is the full serialized ownership proof: proof_body || bip322_sig
+# (bip322_sig = empty scriptSig (varint 0) || witness stack).
+#
+# Two ways in, both over the 'slp9' USB command:
+# - HSM mode: the policy's slip19_paths list is the standing consent, so the proof is returned
+#   at once (unattended coinjoin signing).
+# - otherwise: a human approves each proof on screen, exactly like message signing, and the
+#   host collects the result with 'slok'. Only then can the user-confirmation flag be honest.
+import ngu, stash, chains
+from public_constants import AF_P2WPKH, AF_P2TR
+from serializations import ser_compact_size, ser_string, ser_string_vector, ser_sig_der
+from precomp_tag_hash import TAP_TWEAK_H
+from auth import UserAuthorizedAction
+from ux import OK, X, ux_show_story, abort_and_goto
+
+SLIP19_MAGIC = bytes([0x53, 0x4c, 0x00, 0x19])
+
+# --- SLIP-19 ownership identifier -------------------------------------------------
+# id = HMAC-SHA256(key = k, msg = scriptPubKey), where
+#   k          = Key(m/"SLIP-0019"/"Ownership identification key")   [SLIP-19]
+# derived per SLIP-21:
+#   m          = HMAC-SHA512(key=b"Symmetric key seed", msg=seed)
+#   Child(N,l) = HMAC-SHA512(key=N[0:32], msg=b"\x00" + l)
+#   Key(N)     = N[32:64]
+# The key is cached against a hash of the root chain code: 256 bits of HMAC output, so unlike
+# the 32-bit fingerprint it cannot collide between two seeds, and it changes with the BIP-39
+# passphrase too, so a cached key can never leak across wallets.
+_oid_key_cache = None
+
+
+def _ownership_id_key(sv):
+    global _oid_key_cache
+
+    ident = ngu.hash.sha256s(sv.node.chain_code())
+    if _oid_key_cache is not None and _oid_key_cache[0] == ident:
+        return _oid_key_cache[1]
+
+    # SLIP-21 needs the seed the BIP-32 tree was built from, not the tree itself.
+    if sv.mode == 'master':
+        seed = bytes(sv.raw)
+    elif sv.mode == 'words':
+        # Re-derives through PBKDF2 (seconds); that cost is why the key is cached.
+        import bip39
+        seed = bip39.master_secret(bip39.b2a_words(sv.raw), sv._bip39pw)
+    else:
+        # An xprv-imported secret has no seed, so no ownership identifier exists for it. Refuse
+        # rather than emit a proof carrying a made-up id.
+        raise ValueError('ownership proofs need a seed; this wallet was imported as xprv')
+
+    try:
+        root = ngu.hmac.hmac_sha512(b'Symmetric key seed', seed)
+    finally:
+        # Only this one HMAC needs the seed, so it does not outlive the block. The
+        # intermediate nodes are seed-derived too, so each is blanked once consumed.
+        stash.blank_object(seed)
+
+    n1 = ngu.hmac.hmac_sha512(root[0:32], b'\x00' + b'SLIP-0019')
+    stash.blank_object(root)
+    n2 = ngu.hmac.hmac_sha512(n1[0:32], b'\x00' + b'Ownership identification key')
+    stash.blank_object(n1)
+    k = bytes(n2[32:64])
+    stash.blank_object(n2)
+
+    _oid_key_cache = (ident, k)
+    return k
+
+
+def ownership_id(spk, sv):
+    # SLIP-19 ownership identifier for one of this wallet's scriptPubKeys.
+    return bytes(ngu.hmac.hmac_sha256(_ownership_id_key(sv), spk))
+
+
+def _script_and_key(node, addr_fmt):
+    # For the key at this node: (scriptPubKey, what signs for it).
+    # - P2WPKH: (privkey, compressed pubkey), for an ECDSA/DER witness
+    # - P2TR (BIP-86 key-spend): the tweaked keypair, for a BIP-340 witness
+    # Anything else would be signed as taproot below, so it is refused here.
+    assert addr_fmt in (AF_P2WPKH, AF_P2TR), 'unsupported address format for ownership proof'
+
+    chain = chains.current_chain()
+
+    if addr_fmt == AF_P2WPKH:
+        pubkey = node.pubkey()          # 33-byte compressed
+        spk, _ = chain.script_pubkey(AF_P2WPKH, pubkey=pubkey)
+        return spk, (node.privkey(), pubkey)
+
+    # Key-spend only, no script tree, so the tweak is over the internal key alone - the same
+    # BIP-86 case psbt.py signs. libsecp256k1's keypair_xonly_tweak_add handles the internal
+    # even-Y negation and the output-key parity, so the signature verifies against the output
+    # key that chains.taptweak() puts in the scriptPubKey.
+    kp = ngu.secp256k1.keypair(node.privkey())
+    internal_xonly = kp.xonly_pubkey().to_bytes()               # 32-byte internal x-only key
+    out_kp = kp.xonly_tweak_add(ngu.hash.sha256t(TAP_TWEAK_H, internal_xonly, True))
+    spk, _ = chain.script_pubkey(AF_P2TR, pubkey=internal_xonly)
+    return spk, out_kp
+
+
+def make_ownership_proof(subpath, addr_fmt, flags, commitment):
+    # subpath: str like "m/84h/0h/0h/1/0"; addr_fmt: AF_P2WPKH or AF_P2TR; commitment: bytes.
+    with stash.SensitiveValues() as sv:
+        node = sv.derive_path(subpath)
+        spk, signer = _script_and_key(node, addr_fmt)
+        oid = ownership_id(spk, sv)
+
+    proof_body = SLIP19_MAGIC + bytes([flags & 0xff]) + ser_compact_size(1) + oid
+    preimage = proof_body + ser_string(spk) + ser_string(commitment)
+    digest = ngu.hash.sha256s(preimage)
+
+    if addr_fmt == AF_P2WPKH:
+        pk, pubkey = signer
+        sig65 = ngu.secp256k1.sign(pk, digest, 0).to_bytes()
+        der = ser_sig_der(sig65[1:33], sig65[33:65])                   # DER + SIGHASH_ALL
+        witness = ser_string_vector([der, pubkey])
+    else:
+        # aux_rand = 0: BIP-340 permits it; sign32 still binds (secret, message) so it is safe and
+        # deterministic for a proof. Witness is a single key-spend sig (SigHash.Default -> 64 bytes).
+        sig = ngu.secp256k1.sign_schnorr(signer, digest, bytes(32))
+        witness = ser_string_vector([sig])
+
+    bip322_sig = ser_compact_size(0) + witness       # empty scriptSig, then witness stack
+    return proof_body + bip322_sig
+
+
+# --- USB entry points --------------------------------------------------------------
+
+PROOF_TEMPLATE = '''\
+Sign ownership proof?
+
+Proves to a coinjoin coordinator that this Coldcard owns:
+
+{subpath} =>
+{addr}
+
+Commitment (SHA256):
+{commit}
+
+Nothing is spent. The coordinator checks the coin is yours before letting it into a round.
+
+Press %s to continue, otherwise %s to cancel.''' % (OK, X)
+
+
+class ApproveOwnershipProof(UserAuthorizedAction):
+    # Outside HSM mode: show the human what is about to be proven, and sign only if they agree.
+    # Result is collected by the host over 'slok', which is the only poll command that may have it.
+    is_slip19 = True
+
+    def __init__(self, subpath, addr_fmt, flags, commitment):
+        super().__init__()
+        self.subpath = subpath
+        self.addr_fmt = addr_fmt
+        self.flags = flags
+        self.commitment = commitment
+
+        from glob import dis
+        dis.fullscreen('Wait...')
+
+        with stash.SensitiveValues() as sv:
+            node = sv.derive_path(subpath)
+            spk, _ = _script_and_key(node, addr_fmt)
+            self.address = sv.chain.render_address(spk)
+
+        dis.progress_bar_show(1)
+
+    async def interact(self):
+        from utils import show_single_address, B2A
+
+        story = PROOF_TEMPLATE.format(subpath=self.subpath,
+                                      addr=show_single_address(self.address),
+                                      commit=B2A(ngu.hash.sha256s(self.commitment)))
+
+        # 12 chars is all the Mk4 title bar fits (see ux_confirm in ux.py)
+        ch = await ux_show_story(story, title='Ownership')
+
+        if ch != 'y':
+            self.refused = True
+        else:
+            from glob import dis
+            dis.fullscreen('Signing...')
+            self.result = make_ownership_proof(self.subpath, self.addr_fmt, self.flags,
+                                               self.commitment)
+
+        self.done()
+
+
+def usb_ownership_proof(subpath, addr_fmt, flags, commitment):
+    # Handle the 'slp9' USB command. Returns the full response (b'biny' + proof) when it can be
+    # answered at once (HSM mode), or None once on-screen approval has been started.
+    from utils import cleanup_deriv_path
+    from glob import dis, hsm_active
+    from exceptions import HSMDenied
+
+    # Reject before deriving anything: the approval screen below renders an address for this
+    # format, and the caller states the format rather than it being guessed from the path.
+    assert addr_fmt in (AF_P2WPKH, AF_P2TR), 'unsupported address format for ownership proof'
+
+    # One canonical path is used for BOTH the policy check and the derivation, so a caller
+    # cannot get one string approved and a different key signed.
+    subpath = cleanup_deriv_path(subpath)
+    commitment = bytes(commitment)
+
+    if not hsm_active:
+        # A human decides. The confirmation flag, if the host asked for it, is then a claim that
+        # somebody did in fact confirm.
+        UserAuthorizedAction.check_busy()
+        UserAuthorizedAction.active_request = ApproveOwnershipProof(subpath, addr_fmt, flags,
+                                                                    commitment)
+        abort_and_goto(UserAuthorizedAction.active_request)
+        return None
+
+    if not hsm_active.approve_slip19(subpath):
+        raise HSMDenied
+
+    # Say what the device is doing. Unattended signing is otherwise silent, so there is no way
+    # to tell a working coinjoin session from an idle one by looking at the Coldcard. This lands
+    # on the HSM status screen's busy line.
+    dis.fullscreen('Signing ownership proof')
+    try:
+        return b'biny' + make_ownership_proof(subpath, addr_fmt, flags, commitment)
+    finally:
+        # A finished progress bar is how the busy line gets cleared again.
+        dis.progress_bar(1)
+
+# EOF

--- a/shared/slip19.py
+++ b/shared/slip19.py
@@ -17,6 +17,57 @@ def _cs(n):
         return bytes([n])
     return bytes([0xfd, n & 0xff, (n >> 8) & 0xff])
 
+# --- SLIP-19 ownership identifier -------------------------------------------------
+# id = HMAC-SHA256(key = k, msg = scriptPubKey), where
+#   k          = Key(m/"SLIP-0019"/"Ownership identification key")   [SLIP-19]
+# derived per SLIP-21:
+#   m          = HMAC-SHA512(key=b"Symmetric key seed", msg=seed)
+#   Child(N,l) = HMAC-SHA512(key=N[0:32], msg=b"\x00" + l)
+#   Key(N)     = N[32:64]
+# The key is cached against the master fingerprint. A different seed - including the same
+# words under a different BIP-39 passphrase - yields a different xfp, so a cached key can
+# never leak across wallets.
+_oid_key_cache = None
+
+
+def _master_seed(sv):
+    # SLIP-21 needs the seed the BIP-32 tree was built from, not the tree itself.
+    if sv.mode == 'master':
+        return bytes(sv.raw)
+    if sv.mode == 'words':
+        # Re-derives through PBKDF2 (seconds); that cost is why the key is cached.
+        import bip39
+        return bip39.master_secret(bip39.b2a_words(sv.raw), sv._bip39pw)
+    # An xprv-imported secret has no seed, so no ownership identifier exists for it. Refuse
+    # rather than emit a proof carrying a made-up id.
+    raise ValueError('ownership proofs need a seed; this wallet was imported as xprv')
+
+
+def _ownership_id_key():
+    global _oid_key_cache
+
+    from glob import settings
+    xfp = settings.get('xfp', 0)
+    if _oid_key_cache is not None and _oid_key_cache[0] == xfp:
+        return _oid_key_cache[1]
+
+    with stash.SensitiveValues() as sv:
+        seed = _master_seed(sv)
+
+    n = ngu.hmac.hmac_sha512(b'Symmetric key seed', seed)
+    n = ngu.hmac.hmac_sha512(n[0:32], b'\x00' + b'SLIP-0019')
+    n = ngu.hmac.hmac_sha512(n[0:32], b'\x00' + b'Ownership identification key')
+    k = bytes(n[32:64])
+
+    _oid_key_cache = (xfp, k)
+    return k
+
+
+def ownership_id(spk):
+    # SLIP-19 ownership identifier for one of this wallet's scriptPubKeys.
+    return bytes(ngu.hmac.hmac_sha256(_ownership_id_key(), spk))
+
+
 def _tagged_hash(tag, msg):
     # BIP-340 tagged hash: SHA256( SHA256(tag) || SHA256(tag) || msg ).
     th = ngu.hash.sha256s(tag)
@@ -34,12 +85,10 @@ def make_ownership_proof(subpath, addr_fmt, flags, commitment):
         pk = node.privkey()
         pubkey = node.pubkey()          # 33-byte compressed
 
-    oid = bytes(32)                     # ownership id (see _ownership_id note)
-    proof_body = SLIP19_MAGIC + bytes([flags & 0xff]) + _cs(1) + oid
-
     if addr_fmt == AF_P2WPKH:
         h160 = ngu.hash.ripemd160(ngu.hash.sha256s(pubkey))
         spk = bytes([0x00, 0x14]) + h160
+        proof_body = SLIP19_MAGIC + bytes([flags & 0xff]) + _cs(1) + ownership_id(spk)
         preimage = proof_body + _cs(len(spk)) + spk + _cs(len(commitment)) + commitment
         digest = ngu.hash.sha256s(preimage)
         sig65 = ngu.secp256k1.sign(pk, digest, 0).to_bytes()
@@ -57,6 +106,7 @@ def make_ownership_proof(subpath, addr_fmt, flags, commitment):
         out_kp = kp.xonly_tweak_add(_tagged_hash(b'TapTweak', internal_xonly))
         out_xonly = out_kp.xonly_pubkey().to_bytes()                # 32-byte output x-only key
         spk = bytes([0x51, 0x20]) + out_xonly                       # P2TR: OP_1 push32 <output key>
+        proof_body = SLIP19_MAGIC + bytes([flags & 0xff]) + _cs(1) + ownership_id(spk)
         preimage = proof_body + _cs(len(spk)) + spk + _cs(len(commitment)) + commitment
         digest = ngu.hash.sha256s(preimage)
         # aux_rand = 0: BIP-340 permits it; sign32 still binds (secret, message) so it is safe and

--- a/shared/slip19.py
+++ b/shared/slip19.py
@@ -53,11 +53,19 @@ def _ownership_id_key():
 
     with stash.SensitiveValues() as sv:
         seed = _master_seed(sv)
+        try:
+            root = ngu.hmac.hmac_sha512(b'Symmetric key seed', seed)
+        finally:
+            # Only this one HMAC needs the seed, so it does not outlive the block. The
+            # intermediate nodes are seed-derived too, so each is blanked once consumed.
+            stash.blank_object(seed)
 
-    n = ngu.hmac.hmac_sha512(b'Symmetric key seed', seed)
-    n = ngu.hmac.hmac_sha512(n[0:32], b'\x00' + b'SLIP-0019')
-    n = ngu.hmac.hmac_sha512(n[0:32], b'\x00' + b'Ownership identification key')
-    k = bytes(n[32:64])
+    n1 = ngu.hmac.hmac_sha512(root[0:32], b'\x00' + b'SLIP-0019')
+    stash.blank_object(root)
+    n2 = ngu.hmac.hmac_sha512(n1[0:32], b'\x00' + b'Ownership identification key')
+    stash.blank_object(n1)
+    k = bytes(n2[32:64])
+    stash.blank_object(n2)
 
     _oid_key_cache = (xfp, k)
     return k

--- a/shared/usb.py
+++ b/shared/usb.py
@@ -60,6 +60,9 @@ HSM_WHITELIST = frozenset({
     'gslr',                     # read storage locker; hsm mode only, limited usage
 })
 
+# SLIP-19 proof flag asserting a human approved this input (mirrors slip19.FLAG_USER_CONFIRMATION).
+SLIP19_USER_CONFIRMATION = const(0x01)
+
 # HSM related commands that are not allowed if 'hsmcmd' is disabled.
 HSM_DISABLE_CMDS = frozenset({
     "user",
@@ -462,18 +465,27 @@ class USBHandler:
 
         if cmd == 'slp9':
             # SLIP-19 ownership proof, for coinjoin remote signing (Wasabi WabiSabi).
-            flags, len_subpath, len_commit = unpack_from('<III', args)
-            assert len(args) == (12 + len_subpath + len_commit), 'badlen'
+            addr_fmt, flags, len_subpath, len_commit = unpack_from('<IIII', args)
+            assert len(args) == (16 + len_subpath + len_commit), 'badlen'
             from utils import cleanup_deriv_path
-            subpath = cleanup_deriv_path(args[12:12+len_subpath])
-            commitment = bytes(args[12+len_subpath:])
+            # One canonical path is used for BOTH the policy check and the derivation below, so a
+            # caller cannot get one string approved and a different key signed.
+            subpath = cleanup_deriv_path(args[16:16+len_subpath])
+            commitment = bytes(args[16+len_subpath:])
 
             from glob import hsm_active
-            if hsm_active and not hsm_active.approve_slip19(subpath):
-                raise HSMDenied
+            if hsm_active:
+                if not hsm_active.approve_slip19(subpath):
+                    raise HSMDenied
+            elif flags & SLIP19_USER_CONFIRMATION:
+                # The confirmation flag is an assertion to the coordinator that a human approved
+                # this input. Outside HSM mode nobody has, and the host picks the flag, so refuse
+                # rather than sign a claim we cannot back. Under HSM the approved policy is the
+                # standing consent, which is the whole point of the policy.
+                raise ValueError('user confirmation flag requires an approved HSM policy')
 
             from slip19 import make_ownership_proof
-            return b'biny' + make_ownership_proof(subpath, flags, commitment)
+            return b'biny' + make_ownership_proof(subpath, addr_fmt, flags, commitment)
 
         if cmd == 'p2sh':
             # show P2SH (probably multisig) address on screen (also provides it back)

--- a/shared/usb.py
+++ b/shared/usb.py
@@ -55,6 +55,7 @@ HSM_WHITELIST = frozenset({
     'stok', 'smok',             # completion check: sign txn or msg
     'xpub', 'msck',             # quick status checks
     'p2sh', 'show',             # limited by HSM policy
+    'slp9',                     # SLIP-19 ownership proof; limited by slip19_paths policy
     'user',                     # auth HSM user, other user cmds not allowed
     'gslr',                     # read storage locker; hsm mode only, limited usage
 })
@@ -463,7 +464,8 @@ class USBHandler:
             # SLIP-19 ownership proof, for coinjoin remote signing (Wasabi WabiSabi).
             flags, len_subpath, len_commit = unpack_from('<III', args)
             assert len(args) == (12 + len_subpath + len_commit), 'badlen'
-            subpath = bytes(args[12:12+len_subpath]).decode()
+            from utils import cleanup_deriv_path
+            subpath = cleanup_deriv_path(args[12:12+len_subpath])
             commitment = bytes(args[12+len_subpath:])
 
             from glob import hsm_active

--- a/shared/usb.py
+++ b/shared/usb.py
@@ -459,6 +459,20 @@ class USBHandler:
             sign_msg(msg, subpath, addr_fmt)
             return None
 
+        if cmd == 'slp9':
+            # SLIP-19 ownership proof, for coinjoin remote signing (Wasabi WabiSabi).
+            flags, len_subpath, len_commit = unpack_from('<III', args)
+            assert len(args) == (12 + len_subpath + len_commit), 'badlen'
+            subpath = bytes(args[12:12+len_subpath]).decode()
+            commitment = bytes(args[12+len_subpath:])
+
+            from glob import hsm_active
+            if hsm_active and not hsm_active.approve_slip19(subpath):
+                raise HSMDenied
+
+            from slip19 import make_ownership_proof
+            return b'biny' + make_ownership_proof(subpath, flags, commitment)
+
         if cmd == 'p2sh':
             # show P2SH (probably multisig) address on screen (also provides it back)
             # - must provide redeem script, and list of [xfp+path]

--- a/shared/usb.py
+++ b/shared/usb.py
@@ -481,7 +481,7 @@ class USBHandler:
             subpath = cleanup_deriv_path(args[16:16+len_subpath])
             commitment = bytes(args[16+len_subpath:])
 
-            from glob import hsm_active
+            from glob import dis, hsm_active
             if hsm_active:
                 if not hsm_active.approve_slip19(subpath):
                     raise HSMDenied
@@ -493,7 +493,18 @@ class USBHandler:
                 raise ValueError('user confirmation flag requires an approved HSM policy')
 
             from slip19 import make_ownership_proof
-            return b'biny' + make_ownership_proof(subpath, addr_fmt, flags, commitment)
+
+            # Say what the device is doing. Unattended signing is otherwise silent, so there is no
+            # way to tell a working coinjoin session from an idle one by looking at the Coldcard.
+            # In HSM mode this lands on the status screen's busy line; leave the normal UX alone.
+            if hsm_active:
+                dis.fullscreen('Signing ownership proof')
+            try:
+                return b'biny' + make_ownership_proof(subpath, addr_fmt, flags, commitment)
+            finally:
+                if hsm_active:
+                    # A finished progress bar is how the busy line gets cleared again.
+                    dis.progress_bar(1)
 
         if cmd == 'p2sh':
             # show P2SH (probably multisig) address on screen (also provides it back)

--- a/shared/usb.py
+++ b/shared/usb.py
@@ -362,10 +362,18 @@ class USBHandler:
 
         if is_devmode and cmd[0].isupper():
             # special hacky commands to support testing w/ the simulator
+            #
+            # EVAL/EXEC are arbitrary code execution and XKEY injects keypresses, so they must
+            # not also be a way around HSM mode. HSM exists so the device can be left unattended
+            # with a host that may be compromised - which is exactly what unattended coinjoin
+            # signing is. The simulator keeps them, because the test suite drives HSM over this
+            # same path.
+            if hsm_active and not is_simulator():
+                raise HSMDenied
             try:
                 from usb_test_commands import do_usb_command
                 return do_usb_command(cmd, args)
-            except: 
+            except:
                 pass
 
         if hsm_active:

--- a/shared/usb.py
+++ b/shared/usb.py
@@ -58,6 +58,7 @@ HSM_WHITELIST = frozenset({
     'stok', 'smok',             # completion check: sign txn or msg
     'xpub',                     # quick status checks
     'show', 'msas',             # limited by HSM policy
+    'slp9',                     # SLIP-19 ownership proof; limited by slip19_paths policy
     'user',                     # auth HSM user, other user cmds not allowed
     'gslr',                     # read storage locker; hsm mode only, limited usage
 })
@@ -573,6 +574,17 @@ class USBHandler:
             sign_msg(msg, subpath, addr_fmt)
             return None
 
+        if cmd == 'slp9':
+            # SLIP-19 ownership proof, for coinjoin remote signing (Wasabi WabiSabi).
+            # - under HSM, the policy is the consent and the proof comes back right away
+            # - otherwise the user approves on-screen, and the host collects it with 'slok'
+            addr_fmt, flags, len_subpath, len_commit = unpack_from('<IIII', args)
+            assert len(args) == (16 + len_subpath + len_commit), 'badlen'
+
+            from slip19 import usb_ownership_proof
+            return usb_ownership_proof(args[16:16+len_subpath], addr_fmt, flags,
+                                       args[16+len_subpath:])
+
         if cmd == 'show':
             # simple cases, older code: text subpath
             from auth import usb_show_address
@@ -703,7 +715,7 @@ class USBHandler:
                              input_method="usb", miniscript_wallet=w)
             return None
 
-        if cmd == 'stok' or cmd == 'bkok' or cmd == 'smok' or cmd == 'pwok':
+        if cmd in ('stok', 'bkok', 'smok', 'pwok', 'slok'):
             # Have we finished (whatever) the transaction,
             # which needed user approval? If so, provide result.
             from auth import UserAuthorizedAction
@@ -711,6 +723,11 @@ class USBHandler:
             req = UserAuthorizedAction.active_request
             if not req:
                 return b'err_No active request'
+
+            if getattr(req, 'is_slip19', False) != (cmd == 'slok'):
+                # an ownership proof is collected by 'slok' and nothing else, so neither poll
+                # can consume the other's result
+                return b'err_Wrong completion command'
 
             if req.refused:
                 UserAuthorizedAction.cleanup()
@@ -730,6 +747,11 @@ class USBHandler:
                 xpub = req.result
                 UserAuthorizedAction.cleanup()
                 return b'asci' + bytes(xpub, 'ascii')
+            elif cmd == 'slok':
+                # SLIP-19 ownership proof approved on-screen: hand over the serialized proof
+                proof = req.result
+                UserAuthorizedAction.cleanup()
+                return b'biny' + proof
             elif cmd == 'smok':
                 # signed message done: just give them the signature
                 addr, sig = req.address, req.result

--- a/testing/test_devmode_hsm.py
+++ b/testing/test_devmode_hsm.py
@@ -1,0 +1,47 @@
+# (c) Copyright 2026 by Coinkite Inc. This file is covered by license found in COPYING-CC.
+#
+# The devmode test commands (EVAL/EXEC/XKEY) must not be a way around HSM mode.
+#
+# HSM mode exists so a Coldcard can be left unattended with a host that may be compromised --
+# unattended coinjoin signing is exactly that situation. The test commands are arbitrary code
+# execution, so if they are dispatched ahead of the HSM whitelist, any host software can read
+# the seed off a device that the user believes is locked down.
+#
+# The simulator keeps the hatch open under HSM on purpose, because the rest of the test suite
+# drives HSM through it. So to exercise the real-hardware branch we make the simulator stop
+# claiming to be a simulator, and check the very next command is refused.
+#
+# NOTE: marked onetime -- once is_simulator() returns False the hatch is shut, so this test
+# cannot undo its own patch. It needs a fresh simulator afterwards, and the suite runner
+# excludes onetime by default.
+#
+import pytest
+
+
+@pytest.mark.onetime
+def test_devmode_commands_refused_under_hsm(dev):
+    def raw(cmd, arg=b""):
+        return dev.send_recv(cmd + arg, encrypt=False)
+
+    def text(v):
+        return (v if isinstance(v, str) else v.decode(errors="replace")).strip()
+
+    # Baseline: the hatch is open with HSM off, which is what the other tests rely on.
+    assert text(raw(b"EVAL", b"1+1")).endswith("2")
+
+    # Claim to be real hardware, and turn HSM on.
+    armed = text(raw(b"EXEC", b"""
+import glob, usb
+glob.hsm_active = True
+usb.is_simulator = lambda: False
+RV.write(b\x27armed\x27)
+"""))
+    assert armed.endswith("armed")
+
+    # Every arbitrary-code path must now be refused rather than served.
+    for cmd, arg in [(b"EVAL", b"1+1"), (b"EXEC", b"RV.write(b\x27x\x27)"), (b"XKEY", b"y")]:
+        with pytest.raises(Exception) as ee:
+            raw(cmd, arg)
+        assert "Not allowed in HSM mode" in str(ee.value), (cmd, str(ee.value))
+
+# EOF

--- a/testing/test_hsm.py
+++ b/testing/test_hsm.py
@@ -81,7 +81,7 @@ def compute_policy_hash(policy):
                 rv = type_(value)
         return rv
 
-    top_keys = [('must_log', bool), ('never_log', bool), ('msg_paths', Deriv), ('share_xpubs', Deriv), ('share_addrs', Deriv),
+    top_keys = [('must_log', bool), ('never_log', bool), ('msg_paths', Deriv), ('slip19_paths', Deriv), ('share_xpubs', Deriv), ('share_addrs', Deriv),
                     ('notes', str), ('period', int), ('allow_sl', int), ('warnings_ok', bool), ('boot_to_hsm', str), ('priv_over_ux', bool)]
 
     canonical = OrderedDict()

--- a/testing/test_hsm.py
+++ b/testing/test_hsm.py
@@ -92,7 +92,7 @@ def compute_policy_hash(policy):
 
     rules_keys = [ ('per_period', int), ('max_amount', int), ('users', list), ('min_users', int),
                 ('local_conf', bool), ('whitelist', list), ('wallet', str), ('min_pct_self_transfer', float),
-                ('max_sats_leaving', int), ('max_txn', int), ('max_txn_per_period', int), ('patterns', list), ('whitelist_opts', WhitelistOpts) ]
+                ('max_sats_leaving', int), ('max_txn', int), ('max_txn_per_period', int), ('min_inputs', int), ('patterns', list), ('whitelist_opts', WhitelistOpts) ]
 
     canonical["rules"] = []
     for rule in policy.get("rules", []):

--- a/testing/test_hsm.py
+++ b/testing/test_hsm.py
@@ -92,7 +92,7 @@ def compute_policy_hash(policy):
 
     rules_keys = [ ('per_period', int), ('max_amount', int), ('users', list), ('min_users', int),
                 ('local_conf', bool), ('whitelist', list), ('wallet', str), ('min_pct_self_transfer', float),
-                ('max_txn', int), ('patterns', list), ('whitelist_opts', WhitelistOpts) ]
+                ('max_sats_leaving', int), ('max_txn', int), ('max_txn_per_period', int), ('patterns', list), ('whitelist_opts', WhitelistOpts) ]
 
     canonical["rules"] = []
     for rule in policy.get("rules", []):

--- a/testing/test_hsm.py
+++ b/testing/test_hsm.py
@@ -92,7 +92,7 @@ def compute_policy_hash(policy):
 
     rules_keys = [ ('per_period', int), ('max_amount', int), ('users', list), ('min_users', int),
                 ('local_conf', bool), ('whitelist', list), ('wallet', str), ('min_pct_self_transfer', float),
-                ('max_sats_leaving', int), ('max_txn', int), ('max_txn_per_period', int), ('min_inputs', int), ('patterns', list), ('whitelist_opts', WhitelistOpts) ]
+                ('max_sats_leaving', int), ('max_fee_per_kvbyte', int), ('max_txn', int), ('max_txn_per_period', int), ('min_inputs', int), ('patterns', list), ('whitelist_opts', WhitelistOpts) ]
 
     canonical["rules"] = []
     for rule in policy.get("rules", []):

--- a/testing/test_hsm.py
+++ b/testing/test_hsm.py
@@ -92,7 +92,7 @@ def compute_policy_hash(policy):
 
     rules_keys = [ ('per_period', int), ('max_amount', int), ('users', list), ('min_users', int),
                 ('local_conf', bool), ('whitelist', list), ('wallet', str), ('min_pct_self_transfer', float),
-                ('patterns', list), ('whitelist_opts', WhitelistOpts) ]
+                ('max_txn', int), ('patterns', list), ('whitelist_opts', WhitelistOpts) ]
 
     canonical["rules"] = []
     for rule in policy.get("rules", []):

--- a/testing/test_hsm.py
+++ b/testing/test_hsm.py
@@ -81,7 +81,7 @@ def compute_policy_hash(policy):
                 rv = type_(value)
         return rv
 
-    top_keys = [('must_log', bool), ('never_log', bool), ('msg_paths', Deriv), ('share_xpubs', Deriv), ('share_addrs', Deriv),
+    top_keys = [('must_log', bool), ('never_log', bool), ('msg_paths', Deriv), ('slip19_paths', Deriv), ('share_xpubs', Deriv), ('share_addrs', Deriv),
                     ('notes', str), ('period', int), ('allow_sl', int), ('warnings_ok', bool), ('boot_to_hsm', str), ('priv_over_ux', bool)]
 
     canonical = OrderedDict()
@@ -92,7 +92,7 @@ def compute_policy_hash(policy):
 
     rules_keys = [ ('per_period', int), ('max_amount', int), ('users', list), ('min_users', int),
                 ('local_conf', bool), ('whitelist', list), ('wallet', str), ('min_pct_self_transfer', float),
-                ('patterns', list), ('whitelist_opts', WhitelistOpts) ]
+                ('max_sats_leaving', int), ('max_fee_per_kvbyte', int), ('max_txn', int), ('max_txn_per_period', int), ('min_inputs', int), ('patterns', list), ('whitelist_opts', WhitelistOpts) ]
 
     canonical["rules"] = []
     for rule in policy.get("rules", []):

--- a/testing/test_hsm_busy_timeout.py
+++ b/testing/test_hsm_busy_timeout.py
@@ -1,0 +1,63 @@
+# (c) Copyright 2026 by Coinkite Inc. This file is covered by license found in COPYING-CC.
+#
+# The HSM screen should stop claiming to be busy once the host has stopped talking.
+#
+# A host that dies part way through an upload never sends the rest. Nothing raises, so the
+# restore_menu() in usb.py that normally clears the progress screen never runs, and the device is
+# left reading "Receiving..." while it sits idle waiting for a packet that will not arrive. The
+# device is fine -- a fresh upload at offset 0 resets the transfer -- but for something meant to be
+# left signing unattended, "looks hung forever" is the wrong thing to show.
+#
+# Run with:  py.test test_hsm_busy_timeout.py --sim
+#
+import pytest
+from test_hsm import hsm_reset, hsm_status, start_hsm, enable_hsm_commands
+
+SIMPLE_POLICY = dict(warnings_ok=True, rules=[dict(min_pct_self_transfer=95)])
+
+
+def busy_state(sim_eval):
+    return sim_eval('__import__("hsm_ux").hsm_ux_obj.busy_text')
+
+
+def test_busy_text_expires_when_nothing_moves(dev, start_hsm, hsm_reset, sim_exec, sim_eval):
+    start_hsm(SIMPLE_POLICY)
+
+    # Put the screen in the state an interrupted upload leaves it in, then age it past the limit by
+    # winding the timestamp back rather than waiting 30 seconds of wall clock.
+    sim_exec('''
+import utime
+from hsm_ux import hsm_ux_obj, hsmUxInteraction
+hsm_ux_obj.draw_busy("Receiving...", 0)
+hsm_ux_obj.busy_since = utime.ticks_add(utime.ticks_ms(), -(hsmUxInteraction.BUSY_TIMEOUT_MS + 1000))
+RV.write(repr(hsm_ux_obj.busy_text).encode())
+''')
+
+    # The redraw the HSM loop performs every 100ms is what notices.
+    sim_exec('from hsm_ux import hsm_ux_obj; hsm_ux_obj.draw_busy(None, None); RV.write(b"ok")')
+
+    assert 'None' in busy_state(sim_eval), "stale message survived the timeout"
+
+    hsm_reset()
+
+
+def test_busy_text_survives_while_work_continues(dev, start_hsm, hsm_reset, sim_exec, sim_eval):
+    # The other half of it: progress updates have to keep the message alive, or a slow transfer
+    # would clear its own indicator and the screen would lie in the other direction.
+    start_hsm(SIMPLE_POLICY)
+
+    sim_exec('''
+import utime
+from hsm_ux import hsm_ux_obj, hsmUxInteraction
+hsm_ux_obj.draw_busy("Receiving...", 0)
+hsm_ux_obj.busy_since = utime.ticks_add(utime.ticks_ms(), -(hsmUxInteraction.BUSY_TIMEOUT_MS + 1000))
+hsm_ux_obj.draw_busy(None, 0.5)     # a chunk arrived: still working
+hsm_ux_obj.draw_busy(None, None)    # the idle redraw
+RV.write(b"ok")
+''')
+
+    assert 'Receiving' in busy_state(sim_eval), "an active transfer lost its indicator"
+
+    hsm_reset()
+
+# EOF

--- a/testing/test_hsm_max_feerate.py
+++ b/testing/test_hsm_max_feerate.py
@@ -1,0 +1,98 @@
+# (c) Copyright 2026 by Coinkite Inc. This file is covered by license found in COPYING-CC.
+#
+# max_fee_per_kvbyte: a cap on what we pay per 1000 vbytes of our own contribution.
+#
+# The other value rules bound our loss in sats, absolutely or as a share of what we put in. Neither
+# says anything about whether that loss is a reasonable price for the bytes we are adding, and in a
+# coinjoin nothing else does either: the other participants' input amounts are unknown, so the
+# transaction-wide fee cannot be computed and upstream's fee check is skipped entirely. This rule
+# needs only our own values, so it still works there.
+#
+# It measures (own inputs - own outputs) / (vsize of our own inputs and outputs). That is an upper
+# bound on the mining feerate we pay, because our loss also absorbs coordinator fees and any value
+# genuinely leaving. Erring high is the safe direction: the rule can refuse a transaction that is
+# really cheaper, but it cannot pass one that is really more expensive.
+#
+# Run with:  py.test test_hsm_max_feerate.py --sim
+#
+import pytest
+from test_hsm import (hsm_reset, hsm_status, start_hsm, attempt_psbt, tweak_rule,
+                      enable_hsm_commands)
+
+# One p2wpkh input (41*4 base + 107 witness = 271 WU) plus one p2wpkh output of ours
+# ((8 + 1 + 22) * 4 = 124 WU) is 395 WU, so 98 vbytes after the rule rounds down.
+# Every case below uses that shape, which makes the expected feerate exactly loss * 1000 // 98.
+OUR_VSIZE = 98
+
+
+def test_feerate_cap_is_shown_and_enforced(dev, start_hsm, fake_txn, attempt_psbt, hsm_reset):
+    # 100,000 sats per 1000 vbytes, i.e. 100 sat/vB.
+    policy = dict(warnings_ok=True, rules=[dict(max_fee_per_kvbyte=100000)])
+
+    stat = start_hsm(policy)
+    assert 'per 1000 vbytes' in stat.summary
+
+    # Losing 9,800 sats over 98 vbytes is exactly 100,000 sats/kvB: at the limit, so allowed.
+    assert (9800 * 1000) // OUR_VSIZE == 100000
+    at_limit = fake_txn(1, [(None, 99990200, True, None), (None, 9800, False, None)],
+                        dev.master_xpub, fee=0)
+    attempt_psbt(at_limit)
+
+    # Twice the loss over the same bytes is twice the feerate.
+    over = fake_txn(1, [(None, 99980000, True, None), (None, 20000, False, None)],
+                    dev.master_xpub, fee=0)
+    attempt_psbt(over, 'feerate too high')
+
+    hsm_reset()
+
+
+def test_feerate_catches_what_the_ratio_permits(dev, start_hsm, fake_txn, attempt_psbt, hsm_reset):
+    # The two rules measure different things and neither implies the other. A 1% loss satisfies a
+    # 95% self-transfer floor comfortably, but on a 1 BTC input that 1% is 1,000,000 sats for 99
+    # vbytes - about 10,000 sat/vB, which no honest transaction pays.
+    policy = dict(warnings_ok=True,
+                  rules=[dict(min_pct_self_transfer=95, max_fee_per_kvbyte=100000)])
+
+    start_hsm(policy)
+
+    passes_ratio_fails_feerate = fake_txn(
+        1, [(None, 99000000, True, None), (None, 1000000, False, None)],
+        dev.master_xpub, fee=0)
+    attempt_psbt(passes_ratio_fails_feerate, 'feerate too high')
+
+    hsm_reset()
+
+
+def test_legacy_inputs_are_sized_too(dev, start_hsm, fake_txn, attempt_psbt, hsm_reset):
+    # A p2pkh input is 588 WU against p2wpkh's 272, so the same loss spread over a bigger input is
+    # a lower feerate. Guards against the weight table being wired only for the coinjoin case.
+    # 588 + (8 + 1 + 25) * 4 = 724 WU -> 181 vbytes.
+    policy = dict(warnings_ok=True, rules=[dict(max_fee_per_kvbyte=100000)])
+
+    start_hsm(policy)
+
+    assert (18100 * 1000) // 181 == 100000
+    at_limit = fake_txn(1, [(None, 99981900, True, None), (None, 18100, False, None)],
+                        dev.master_xpub, addr_fmt="p2pkh", fee=0)
+    attempt_psbt(at_limit)
+
+    over = fake_txn(1, [(None, 99960000, True, None), (None, 40000, False, None)],
+                    dev.master_xpub, addr_fmt="p2pkh", fee=0)
+    attempt_psbt(over, 'feerate too high')
+
+    hsm_reset()
+
+
+def test_absent_cap_changes_nothing(dev, start_hsm, fake_txn, attempt_psbt, hsm_reset):
+    # Existing policies must behave exactly as before.
+    policy = dict(warnings_ok=True, rules=[dict(min_pct_self_transfer=95)])
+
+    start_hsm(policy)
+
+    psbt = fake_txn(1, [(None, 95000000, True, None), (None, 5000000, False, None)],
+                    dev.master_xpub, fee=0)
+    attempt_psbt(psbt)
+
+    hsm_reset()
+
+# EOF

--- a/testing/test_hsm_max_feerate.py
+++ b/testing/test_hsm_max_feerate.py
@@ -1,0 +1,99 @@
+# (c) Copyright 2026 by Coinkite Inc. This file is covered by license found in COPYING-CC.
+#
+# max_fee_per_kvbyte: a cap on what we pay per 1000 vbytes of our own contribution.
+#
+# The other value rules bound our loss in sats, absolutely or as a share of what we put in. Neither
+# says anything about whether that loss is a reasonable price for the bytes we are adding, and in a
+# coinjoin nothing else does either: the other participants' input amounts are unknown, so the
+# transaction-wide fee cannot be computed and upstream's fee check is skipped entirely. This rule
+# needs only our own values, so it still works there.
+#
+# It measures (own inputs - own outputs) / (vsize of our own inputs and outputs). That is an upper
+# bound on the mining feerate we pay, because our loss also absorbs coordinator fees and any value
+# genuinely leaving. Erring high is the safe direction: the rule can refuse a transaction that is
+# really cheaper, but it cannot pass one that is really more expensive.
+#
+# Run with:  py.test test_hsm_max_feerate.py --sim
+#
+import pytest
+from test_hsm import (hsm_reset, hsm_status, start_hsm, attempt_psbt, tweak_rule,
+                      enable_hsm_commands)
+
+# One p2wpkh input (41*4 base + 107 witness = 271 WU) plus one p2wpkh output of ours
+# ((8 + 1 + 22) * 4 = 124 WU) is 395 WU, so 98 vbytes after the rule rounds down.
+# Every case below uses that shape, which makes the expected feerate exactly loss * 1000 // 98.
+OUR_VSIZE = 98
+
+
+def test_feerate_cap_is_shown_and_enforced(dev, start_hsm, fake_txn, attempt_psbt, hsm_reset):
+    # 100,000 sats per 1000 vbytes, i.e. 100 sat/vB.
+    policy = dict(warnings_ok=True, rules=[dict(max_fee_per_kvbyte=100000)])
+
+    stat = start_hsm(policy)
+    assert 'per 1000 vbytes' in stat.summary
+
+    # Losing 9,800 sats over 98 vbytes is exactly 100,000 sats/kvB: at the limit, so allowed.
+    assert (9800 * 1000) // OUR_VSIZE == 100000
+    at_limit = fake_txn(1, 2, dev.master_xpub, segwit_in=True, outstyles=['p2wpkh'],
+                        outvals=[99990200, 9800], change_outputs=[0], fee=0)
+    attempt_psbt(at_limit)
+
+    # Twice the loss over the same bytes is twice the feerate.
+    over = fake_txn(1, 2, dev.master_xpub, segwit_in=True, outstyles=['p2wpkh'],
+                    outvals=[99980000, 20000], change_outputs=[0], fee=0)
+    attempt_psbt(over, 'feerate too high')
+
+    hsm_reset()
+
+
+def test_feerate_catches_what_the_ratio_permits(dev, start_hsm, fake_txn, attempt_psbt, hsm_reset):
+    # The two rules measure different things and neither implies the other. A 1% loss satisfies a
+    # 95% self-transfer floor comfortably, but on a 1 BTC input that 1% is 1,000,000 sats for 99
+    # vbytes - about 10,000 sat/vB, which no honest transaction pays.
+    policy = dict(warnings_ok=True,
+                  rules=[dict(min_pct_self_transfer=95, max_fee_per_kvbyte=100000)])
+
+    start_hsm(policy)
+
+    passes_ratio_fails_feerate = fake_txn(1, 2, dev.master_xpub, segwit_in=True,
+                                          outstyles=['p2wpkh'],
+                                          outvals=[99000000, 1000000],
+                                          change_outputs=[0], fee=0)
+    attempt_psbt(passes_ratio_fails_feerate, 'feerate too high')
+
+    hsm_reset()
+
+
+def test_legacy_inputs_are_sized_too(dev, start_hsm, fake_txn, attempt_psbt, hsm_reset):
+    # A p2pkh input is 588 WU against p2wpkh's 272, so the same loss spread over a bigger input is
+    # a lower feerate. Guards against the weight table being wired only for the coinjoin case.
+    # 588 + (8 + 1 + 25) * 4 = 724 WU -> 181 vbytes.
+    policy = dict(warnings_ok=True, rules=[dict(max_fee_per_kvbyte=100000)])
+
+    start_hsm(policy)
+
+    assert (18100 * 1000) // 181 == 100000
+    at_limit = fake_txn(1, 2, dev.master_xpub, outvals=[99981900, 18100],
+                        change_outputs=[0], fee=0)
+    attempt_psbt(at_limit)
+
+    over = fake_txn(1, 2, dev.master_xpub, outvals=[99960000, 40000],
+                    change_outputs=[0], fee=0)
+    attempt_psbt(over, 'feerate too high')
+
+    hsm_reset()
+
+
+def test_absent_cap_changes_nothing(dev, start_hsm, fake_txn, attempt_psbt, hsm_reset):
+    # Existing policies must behave exactly as before.
+    policy = dict(warnings_ok=True, rules=[dict(min_pct_self_transfer=95)])
+
+    start_hsm(policy)
+
+    psbt = fake_txn(1, 2, dev.master_xpub, segwit_in=True, outstyles=['p2wpkh'],
+                    outvals=[95000000, 5000000], change_outputs=[0], fee=0)
+    attempt_psbt(psbt)
+
+    hsm_reset()
+
+# EOF

--- a/testing/test_hsm_max_sats.py
+++ b/testing/test_hsm_max_sats.py
@@ -1,0 +1,69 @@
+# (c) Copyright 2026 by Coinkite Inc. This file is covered by license found in COPYING-CC.
+#
+# max_sats_leaving: an absolute cap on how much of our own value may leave in one transaction.
+#
+# min_pct_self_transfer is a ratio, so what it permits scales with the amount being mixed, while
+# mining fees scale the other way: they are a large share of a small coin and a trivial share of a
+# big one. A percentage tight enough to protect large amounts therefore refuses ordinary rounds on
+# small ones. The two together fix that — the ratio binds on small amounts, the absolute cap binds
+# on large ones — which is why they are ANDed rather than offered as alternatives.
+#
+# Run with:  py.test test_hsm_max_sats.py --sim
+#
+import pytest
+from test_hsm import (hsm_reset, hsm_status, start_hsm, attempt_psbt, tweak_rule,
+                      enable_hsm_commands)
+
+
+def test_absolute_cap_is_shown_and_enforced(dev, start_hsm, fake_txn, attempt_psbt, hsm_reset):
+    # 1 BTC in. Cap is 100k sats, so 10k leaving is fine and 1M is not.
+    policy = dict(warnings_ok=True, rules=[dict(max_sats_leaving=100000)])
+
+    stat = start_hsm(policy)
+    assert 'may leave the wallet' in stat.summary
+
+    ok = fake_txn(1, [(None, 99990000, True, None), (None, 10000, False, None)],
+                    dev.master_xpub, fee=0)
+    attempt_psbt(ok)
+
+    too_much = fake_txn(1, [(None, 99000000, True, None), (None, 1000000, False, None)],
+                    dev.master_xpub, fee=0)
+    attempt_psbt(too_much, 'too much value leaving')
+
+    hsm_reset()
+
+
+def test_cap_and_floor_are_both_enforced(dev, start_hsm, fake_txn, attempt_psbt, hsm_reset):
+    # The point of the pair. 95% alone lets 5% of a 1 BTC input walk (5M sats); the cap stops it.
+    # The cap alone would let a small transaction lose almost all of itself; the floor stops that.
+    # A transaction has to satisfy both.
+    policy = dict(warnings_ok=True,
+                  rules=[dict(min_pct_self_transfer=95, max_sats_leaving=100000)])
+
+    start_hsm(policy)
+
+    within_both = fake_txn(1, [(None, 99990000, True, None), (None, 10000, False, None)],
+                    dev.master_xpub, fee=0)
+    attempt_psbt(within_both)
+
+    # Exactly 95% comes back, so the ratio is satisfied, but 5,000,000 sats leaving is not.
+    passes_ratio_fails_cap = fake_txn(1, [(None, 95000000, True, None), (None, 5000000, False, None)],
+                    dev.master_xpub, fee=0)
+    attempt_psbt(passes_ratio_fails_cap, 'too much value leaving')
+
+    hsm_reset()
+
+
+def test_absent_cap_changes_nothing(dev, start_hsm, fake_txn, attempt_psbt, hsm_reset):
+    # Existing policies must behave exactly as before.
+    policy = dict(warnings_ok=True, rules=[dict(min_pct_self_transfer=95)])
+
+    start_hsm(policy)
+
+    psbt = fake_txn(1, [(None, 95000000, True, None), (None, 5000000, False, None)],
+                    dev.master_xpub, fee=0)
+    attempt_psbt(psbt)
+
+    hsm_reset()
+
+# EOF

--- a/testing/test_hsm_max_sats.py
+++ b/testing/test_hsm_max_sats.py
@@ -1,0 +1,69 @@
+# (c) Copyright 2026 by Coinkite Inc. This file is covered by license found in COPYING-CC.
+#
+# max_sats_leaving: an absolute cap on how much of our own value may leave in one transaction.
+#
+# min_pct_self_transfer is a ratio, so what it permits scales with the amount being mixed, while
+# mining fees scale the other way: they are a large share of a small coin and a trivial share of a
+# big one. A percentage tight enough to protect large amounts therefore refuses ordinary rounds on
+# small ones. The two together fix that — the ratio binds on small amounts, the absolute cap binds
+# on large ones — which is why they are ANDed rather than offered as alternatives.
+#
+# Run with:  py.test test_hsm_max_sats.py --sim
+#
+import pytest
+from test_hsm import (hsm_reset, hsm_status, start_hsm, attempt_psbt, tweak_rule,
+                      enable_hsm_commands)
+
+
+def test_absolute_cap_is_shown_and_enforced(dev, start_hsm, fake_txn, attempt_psbt, hsm_reset):
+    # 1 BTC in. Cap is 100k sats, so 10k leaving is fine and 1M is not.
+    policy = dict(warnings_ok=True, rules=[dict(max_sats_leaving=100000)])
+
+    stat = start_hsm(policy)
+    assert 'may leave the wallet' in stat.summary
+
+    ok = fake_txn(1, 2, dev.master_xpub, outvals=[99990000, 10000],
+                  change_outputs=[0], fee=0)
+    attempt_psbt(ok)
+
+    too_much = fake_txn(1, 2, dev.master_xpub, outvals=[99000000, 1000000],
+                        change_outputs=[0], fee=0)
+    attempt_psbt(too_much, 'too much value leaving')
+
+    hsm_reset()
+
+
+def test_cap_and_floor_are_both_enforced(dev, start_hsm, fake_txn, attempt_psbt, hsm_reset):
+    # The point of the pair. 95% alone lets 5% of a 1 BTC input walk (5M sats); the cap stops it.
+    # The cap alone would let a small transaction lose almost all of itself; the floor stops that.
+    # A transaction has to satisfy both.
+    policy = dict(warnings_ok=True,
+                  rules=[dict(min_pct_self_transfer=95, max_sats_leaving=100000)])
+
+    start_hsm(policy)
+
+    within_both = fake_txn(1, 2, dev.master_xpub, outvals=[99990000, 10000],
+                           change_outputs=[0], fee=0)
+    attempt_psbt(within_both)
+
+    # Exactly 95% comes back, so the ratio is satisfied, but 5,000,000 sats leaving is not.
+    passes_ratio_fails_cap = fake_txn(1, 2, dev.master_xpub, outvals=[95000000, 5000000],
+                                      change_outputs=[0], fee=0)
+    attempt_psbt(passes_ratio_fails_cap, 'too much value leaving')
+
+    hsm_reset()
+
+
+def test_absent_cap_changes_nothing(dev, start_hsm, fake_txn, attempt_psbt, hsm_reset):
+    # Existing policies must behave exactly as before.
+    policy = dict(warnings_ok=True, rules=[dict(min_pct_self_transfer=95)])
+
+    start_hsm(policy)
+
+    psbt = fake_txn(1, 2, dev.master_xpub, outvals=[95000000, 5000000],
+                    change_outputs=[0], fee=0)
+    attempt_psbt(psbt)
+
+    hsm_reset()
+
+# EOF

--- a/testing/test_hsm_max_txn.py
+++ b/testing/test_hsm_max_txn.py
@@ -59,4 +59,32 @@ def test_max_txn_combines_with_the_self_transfer_floor(dev, start_hsm, fake_txn,
 
     hsm_reset()
 
+
+def test_rate_limit_is_shown_and_enforced(dev, start_hsm, fake_txn, attempt_psbt, hsm_reset):
+    # max_txn bounds the total but not the rate, so a coordinator that keeps proposing rounds can
+    # burn the whole budget in minutes and farm a mining fee off each one. Rate is its own axis.
+    policy = dict(warnings_ok=True, period=60,
+                  rules=[dict(max_txn=10, max_txn_per_period=2)])
+
+    stat = start_hsm(policy)
+    assert '2 transaction(s) per period' in stat.summary
+
+    psbt = fake_txn(1, 1, dev.master_xpub, fee=0)
+    attempt_psbt(psbt)
+    attempt_psbt(psbt)
+    # Budget still has 8 left, but the period does not.
+    attempt_psbt(psbt, 'too many transactions this period')
+
+    hsm_reset()
+
+
+def test_rate_limit_needs_a_period(dev, start_hsm, hsm_reset):
+    # Anything measured per period is meaningless without one, and the policy already refuses that
+    # combination for the sats velocity limit.
+    policy = dict(warnings_ok=True, rules=[dict(max_txn_per_period=2)])
+
+    with pytest.raises(Exception) as ee:
+        start_hsm(policy)
+    assert 'period' in str(ee.value).lower()
+
 # EOF

--- a/testing/test_hsm_max_txn.py
+++ b/testing/test_hsm_max_txn.py
@@ -1,0 +1,90 @@
+# (c) Copyright 2026 by Coinkite Inc. This file is covered by license found in COPYING-CC.
+#
+# max_txn: a device-side limit on how many transactions one approved HSM policy may sign.
+#
+# min_pct_self_transfer bounds what a single transaction can move, not the total. Without a count
+# on the device, a host that had been taken over can keep presenting fresh transactions that each
+# sit just inside the floor and drain the wallet a slice at a time. The budget that should stop
+# that otherwise lives in the host, which is the thing being assumed compromised.
+#
+# Run with:  py.test test_hsm_max_txn.py --sim
+#
+import pytest
+from test_hsm import (hsm_reset, hsm_status, start_hsm, attempt_psbt, tweak_rule,
+                      enable_hsm_commands)
+
+
+def test_max_txn_is_shown_and_enforced(dev, start_hsm, fake_txn, attempt_psbt, hsm_reset):
+    # Two transactions allowed, so the third must be refused by the device itself.
+    policy = dict(rules=[dict(max_txn=2)])
+
+    stat = start_hsm(policy)
+    # The user has to be able to see the limit they are approving.
+    assert 'at most 2 transaction' in stat.summary
+
+    psbt = fake_txn(1, 1, dev.master_xpub, fee=0)
+    attempt_psbt(psbt)
+    attempt_psbt(psbt)
+    attempt_psbt(psbt, 'transaction count exceeded')
+
+    hsm_reset()
+
+
+def test_max_txn_absent_means_unlimited(dev, start_hsm, fake_txn, attempt_psbt, hsm_reset):
+    # Policies that do not ask for a count keep behaving exactly as before.
+    policy = dict(rules=[dict()])
+
+    start_hsm(policy)
+
+    psbt = fake_txn(1, 1, dev.master_xpub, fee=0)
+    for _ in range(3):
+        attempt_psbt(psbt)
+
+    hsm_reset()
+
+
+def test_max_txn_combines_with_the_self_transfer_floor(dev, start_hsm, fake_txn, attempt_psbt,
+                                                       hsm_reset):
+    # The pair is the point: the floor caps each transaction, the count caps how many there can
+    # be, so the total a compromised host can move is bounded.
+    policy = dict(warnings_ok=True, rules=[dict(min_pct_self_transfer=99, max_txn=1)])
+
+    stat = start_hsm(policy)
+    assert 'at most 1 transaction' in stat.summary
+    assert 'self-transfer' in stat.summary
+
+    psbt = fake_txn(1, [(None, None, True, None)], dev.master_xpub, fee=0)
+    attempt_psbt(psbt)
+    attempt_psbt(psbt, 'transaction count exceeded')
+
+    hsm_reset()
+
+
+def test_rate_limit_is_shown_and_enforced(dev, start_hsm, fake_txn, attempt_psbt, hsm_reset):
+    # max_txn bounds the total but not the rate, so a coordinator that keeps proposing rounds can
+    # burn the whole budget in minutes and farm a mining fee off each one. Rate is its own axis.
+    policy = dict(warnings_ok=True, period=60,
+                  rules=[dict(max_txn=10, max_txn_per_period=2)])
+
+    stat = start_hsm(policy)
+    assert '2 transaction(s) per period' in stat.summary
+
+    psbt = fake_txn(1, 1, dev.master_xpub, fee=0)
+    attempt_psbt(psbt)
+    attempt_psbt(psbt)
+    # Budget still has 8 left, but the period does not.
+    attempt_psbt(psbt, 'too many transactions this period')
+
+    hsm_reset()
+
+
+def test_rate_limit_needs_a_period(dev, start_hsm, hsm_reset):
+    # Anything measured per period is meaningless without one, and the policy already refuses that
+    # combination for the sats velocity limit.
+    policy = dict(warnings_ok=True, rules=[dict(max_txn_per_period=2)])
+
+    with pytest.raises(Exception) as ee:
+        start_hsm(policy)
+    assert 'period' in str(ee.value).lower()
+
+# EOF

--- a/testing/test_hsm_max_txn.py
+++ b/testing/test_hsm_max_txn.py
@@ -1,0 +1,62 @@
+# (c) Copyright 2026 by Coinkite Inc. This file is covered by license found in COPYING-CC.
+#
+# max_txn: a device-side limit on how many transactions one approved HSM policy may sign.
+#
+# min_pct_self_transfer bounds what a single transaction can move, not the total. Without a count
+# on the device, a host that had been taken over can keep presenting fresh transactions that each
+# sit just inside the floor and drain the wallet a slice at a time. The budget that should stop
+# that otherwise lives in the host, which is the thing being assumed compromised.
+#
+# Run with:  py.test test_hsm_max_txn.py --sim
+#
+import pytest
+from test_hsm import (hsm_reset, hsm_status, start_hsm, attempt_psbt, tweak_rule,
+                      enable_hsm_commands)
+
+
+def test_max_txn_is_shown_and_enforced(dev, start_hsm, fake_txn, attempt_psbt, hsm_reset):
+    # Two transactions allowed, so the third must be refused by the device itself.
+    policy = dict(rules=[dict(max_txn=2)])
+
+    stat = start_hsm(policy)
+    # The user has to be able to see the limit they are approving.
+    assert 'at most 2 transaction' in stat.summary
+
+    psbt = fake_txn(1, 1, dev.master_xpub, fee=0)
+    attempt_psbt(psbt)
+    attempt_psbt(psbt)
+    attempt_psbt(psbt, 'transaction count exceeded')
+
+    hsm_reset()
+
+
+def test_max_txn_absent_means_unlimited(dev, start_hsm, fake_txn, attempt_psbt, hsm_reset):
+    # Policies that do not ask for a count keep behaving exactly as before.
+    policy = dict(rules=[dict()])
+
+    start_hsm(policy)
+
+    psbt = fake_txn(1, 1, dev.master_xpub, fee=0)
+    for _ in range(3):
+        attempt_psbt(psbt)
+
+    hsm_reset()
+
+
+def test_max_txn_combines_with_the_self_transfer_floor(dev, start_hsm, fake_txn, attempt_psbt,
+                                                       hsm_reset):
+    # The pair is the point: the floor caps each transaction, the count caps how many there can
+    # be, so the total a compromised host can move is bounded.
+    policy = dict(warnings_ok=True, rules=[dict(min_pct_self_transfer=99, max_txn=1)])
+
+    stat = start_hsm(policy)
+    assert 'at most 1 transaction' in stat.summary
+    assert 'self-transfer' in stat.summary
+
+    psbt = fake_txn(1, 1, dev.master_xpub, change_outputs=[0], fee=0)
+    attempt_psbt(psbt)
+    attempt_psbt(psbt, 'transaction count exceeded')
+
+    hsm_reset()
+
+# EOF

--- a/testing/test_hsm_min_inputs.py
+++ b/testing/test_hsm_min_inputs.py
@@ -1,0 +1,82 @@
+# (c) Copyright 2026 by Coinkite Inc. This file is covered by license found in COPYING-CC.
+#
+# min_inputs: refuse to sign a transaction that too few parties are taking part in.
+#
+# For a coinjoin the host decides which round to join, and a host that has been taken over can
+# pick a round with nobody in it but us and a coordinator that then learns the whole mapping. The
+# device is handed the entire round transaction, so it can count the participants itself rather
+# than take the host's word for it.
+#
+# What this does NOT give you is an anonymity set. A coordinator willing to register its own
+# inputs can pad a round to any count while still knowing every link. The rule rules out the
+# degenerate round; it does not make a padded one private.
+#
+# Run with:  py.test test_hsm_min_inputs.py --sim
+#
+import pytest
+from test_hsm import (hsm_reset, hsm_status, start_hsm, attempt_psbt, tweak_rule,
+                      enable_hsm_commands)
+
+
+def test_min_inputs_is_shown_and_enforced(dev, start_hsm, fake_txn, attempt_psbt, hsm_reset):
+    policy = dict(rules=[dict(min_inputs=3)])
+
+    stat = start_hsm(policy)
+    # The user has to be able to see the limit they are approving.
+    assert '3 or more inputs' in stat.summary
+
+    attempt_psbt(fake_txn(2, 1, dev.master_xpub, fee=0), 'too few inputs: 2, need 3')
+    attempt_psbt(fake_txn(3, 1, dev.master_xpub, fee=0))
+
+    hsm_reset()
+
+
+def test_min_inputs_counts_everyone(dev, start_hsm, fake_txn, attempt_psbt, hsm_reset):
+    # The whole point: it is every participant's inputs, not the subset we happen to own. One
+    # input of ours alongside four strangers is a round worth joining; four of ours alone is not.
+    # Had the rule counted only our own inputs these two would have come out the other way round.
+    policy = dict(warnings_ok=True, rules=[dict(min_inputs=5)])
+
+    start_hsm(policy)
+
+    def disown_all_but_first(psbt):
+        # drop the derivation info so the device sees the rest as somebody else's
+        for i in psbt.inputs[1:]:
+            i.bip32_paths = {}
+            i.taproot_bip32_paths = {}
+
+    attempt_psbt(fake_txn(5, 1, dev.master_xpub, fee=0, psbt_hacker=disown_all_but_first))
+
+    attempt_psbt(fake_txn(4, 1, dev.master_xpub, fee=0), 'too few inputs: 4, need 5')
+
+    hsm_reset()
+
+
+def test_min_inputs_absent_means_no_floor(dev, start_hsm, fake_txn, attempt_psbt, hsm_reset):
+    # Policies that do not ask for it keep behaving exactly as before, including a lone input.
+    policy = dict(rules=[dict()])
+
+    start_hsm(policy)
+
+    attempt_psbt(fake_txn(1, 1, dev.master_xpub, fee=0))
+
+    hsm_reset()
+
+
+def test_min_inputs_pairs_with_the_self_transfer_floor(dev, start_hsm, fake_txn, attempt_psbt,
+                                                       hsm_reset):
+    # The two bound different things: the floor caps what a round may cost us, min_inputs caps how
+    # pointless a round may be. A cheap round with nobody in it still buys no privacy.
+    policy = dict(warnings_ok=True, rules=[dict(min_pct_self_transfer=99, min_inputs=4)])
+
+    stat = start_hsm(policy)
+    assert '4 or more inputs' in stat.summary
+    assert 'self-transfer' in stat.summary
+
+    # Costs us nothing, but it is a round of two.
+    attempt_psbt(fake_txn(2, [(None, None, True, None)], dev.master_xpub, fee=0),
+                 'too few inputs: 2, need 4')
+
+    hsm_reset()
+
+# EOF

--- a/testing/test_hsm_min_inputs.py
+++ b/testing/test_hsm_min_inputs.py
@@ -1,0 +1,82 @@
+# (c) Copyright 2026 by Coinkite Inc. This file is covered by license found in COPYING-CC.
+#
+# min_inputs: refuse to sign a transaction that too few parties are taking part in.
+#
+# For a coinjoin the host decides which round to join, and a host that has been taken over can
+# pick a round with nobody in it but us and a coordinator that then learns the whole mapping. The
+# device is handed the entire round transaction, so it can count the participants itself rather
+# than take the host's word for it.
+#
+# What this does NOT give you is an anonymity set. A coordinator willing to register its own
+# inputs can pad a round to any count while still knowing every link. The rule rules out the
+# degenerate round; it does not make a padded one private.
+#
+# Run with:  py.test test_hsm_min_inputs.py --sim
+#
+import pytest
+from test_hsm import (hsm_reset, hsm_status, start_hsm, attempt_psbt, tweak_rule,
+                      enable_hsm_commands)
+
+
+def test_min_inputs_is_shown_and_enforced(dev, start_hsm, fake_txn, attempt_psbt, hsm_reset):
+    policy = dict(rules=[dict(min_inputs=3)])
+
+    stat = start_hsm(policy)
+    # The user has to be able to see the limit they are approving.
+    assert '3 or more inputs' in stat.summary
+
+    attempt_psbt(fake_txn(2, 1, dev.master_xpub, fee=0), 'too few inputs: 2, need 3')
+    attempt_psbt(fake_txn(3, 1, dev.master_xpub, fee=0))
+
+    hsm_reset()
+
+
+def test_min_inputs_counts_everyone(dev, start_hsm, fake_txn, attempt_psbt, hsm_reset):
+    # The whole point: it is every participant's inputs, not the subset we happen to own. One
+    # input of ours alongside four strangers is a round worth joining; four of ours alone is not.
+    # Had the rule counted only our own inputs these two would have come out the other way round.
+    policy = dict(warnings_ok=True, rules=[dict(min_inputs=5)])
+
+    start_hsm(policy)
+
+    def disown_all_but_first(psbt):
+        # drop the derivation info so the device sees the rest as somebody else's
+        for i in psbt.inputs[1:]:
+            i.bip32_paths = {}
+            i.taproot_bip32_paths = {}
+
+    attempt_psbt(fake_txn(5, 1, dev.master_xpub, fee=0, psbt_hacker=disown_all_but_first))
+
+    attempt_psbt(fake_txn(4, 1, dev.master_xpub, fee=0), 'too few inputs: 4, need 5')
+
+    hsm_reset()
+
+
+def test_min_inputs_absent_means_no_floor(dev, start_hsm, fake_txn, attempt_psbt, hsm_reset):
+    # Policies that do not ask for it keep behaving exactly as before, including a lone input.
+    policy = dict(rules=[dict()])
+
+    start_hsm(policy)
+
+    attempt_psbt(fake_txn(1, 1, dev.master_xpub, fee=0))
+
+    hsm_reset()
+
+
+def test_min_inputs_pairs_with_the_self_transfer_floor(dev, start_hsm, fake_txn, attempt_psbt,
+                                                       hsm_reset):
+    # The two bound different things: the floor caps what a round may cost us, min_inputs caps how
+    # pointless a round may be. A cheap round with nobody in it still buys no privacy.
+    policy = dict(warnings_ok=True, rules=[dict(min_pct_self_transfer=99, min_inputs=4)])
+
+    stat = start_hsm(policy)
+    assert '4 or more inputs' in stat.summary
+    assert 'self-transfer' in stat.summary
+
+    # Costs us nothing, but it is a round of two.
+    attempt_psbt(fake_txn(2, 1, dev.master_xpub, change_outputs=[0], fee=0),
+                 'too few inputs: 2, need 4')
+
+    hsm_reset()
+
+# EOF

--- a/testing/test_hsm_taproot_coinjoin.py
+++ b/testing/test_hsm_taproot_coinjoin.py
@@ -1,0 +1,41 @@
+# (c) Copyright 2026 by Coinkite Inc. This file is covered by license found in COPYING-CC.
+#
+# End to end on the edge line: a taproot coin is proven with slp9 under an HSM policy, then a
+# taproot coinjoin-shaped PSBT is signed unattended under the same policy, and the feerate rule
+# sizes the P2TR inputs rather than refusing to size them.
+#
+# Run with:  py.test test_hsm_taproot_coinjoin.py --sim
+#
+import pytest
+from test_hsm import hsm_reset, hsm_status, start_hsm, attempt_psbt, enable_hsm_commands
+from test_slip19 import slp9_request, check_proof_shape, AF_P2TR, TAPROOT_PATH, FLAG_USER_CONFIRMATION
+
+BTC = 100_000_000
+
+
+def test_taproot_round_signs_under_policy(dev, start_hsm, hsm_reset, fake_txn, attempt_psbt):
+    policy = dict(warnings_ok=True,
+                  slip19_paths=["m/86h/0h/0h/1/*"],
+                  rules=[dict(min_pct_self_transfer=95, max_sats_leaving=2_000_000,
+                              max_fee_per_kvbyte=100_000, min_inputs=2)])
+    start_hsm(policy)
+
+    # input registration: the proof for a taproot coin comes straight back under the policy
+    proof = dev.send_recv(slp9_request(TAPROOT_PATH, AF_P2TR, FLAG_USER_CONFIRMATION), timeout=None)
+    check_proof_shape(proof, flags=FLAG_USER_CONFIRMATION, witness_items=1)
+
+    # the round: two of our taproot inputs, our taproot change back, one foreign taproot output.
+    # ~158 vbytes of ours, 10,000 sats lost -> ~63,000 sats/kvB, inside every limit
+    ok = fake_txn(2, [["p2tr", 2*BTC - 10_000, True], ["p2tr", 10_000]],
+                  dev.master_xpub, addr_fmt="p2tr", fee=0)
+    attempt_psbt(ok)
+
+    # same shape, 1,000,000 sats lost: ratio (99.5%) and absolute cap both pass, so the only rule
+    # that can refuse is the feerate one -- which means it sized the P2TR inputs.
+    pricey = fake_txn(2, [["p2tr", 2*BTC - 1_000_000, True], ["p2tr", 1_000_000]],
+                      dev.master_xpub, addr_fmt="p2tr", fee=0)
+    attempt_psbt(pricey, 'feerate too high')
+
+    hsm_reset()
+
+# EOF

--- a/testing/test_slip19.py
+++ b/testing/test_slip19.py
@@ -9,7 +9,9 @@ from hashlib import sha256
 from ckcc.protocol import CCProtocolPacker
 
 # The HSM harness fixtures live next door; importing them here makes pytest resolve them.
-from test_hsm import hsm_reset, hsm_status, start_hsm
+# enable_hsm_commands is autouse in test_hsm and must be pulled in explicitly, otherwise these
+# tests only pass when some earlier module happens to have left hsmcmd enabled on the simulator.
+from test_hsm import hsm_reset, hsm_status, start_hsm, enable_hsm_commands
 
 AF_P2WPKH = 0x07
 AF_P2TR = 0x23

--- a/testing/test_slip19.py
+++ b/testing/test_slip19.py
@@ -1,0 +1,117 @@
+# (c) Copyright 2026 by Coinkite Inc. This file is covered by license found in COPYING-CC.
+#
+# SLIP-19 ownership proofs (slp9) and their HSM policy gate.
+#
+# Run with:  py.test test_slip19.py
+#
+import pytest, struct, json
+from hashlib import sha256
+from ckcc.protocol import CCProtocolPacker
+
+# The HSM harness fixtures live next door; importing them here makes pytest resolve them.
+from test_hsm import hsm_reset, hsm_status, start_hsm
+
+AF_P2WPKH = 0x07
+AF_P2TR = 0x23
+AF_CLASSIC = 0x01
+
+SLIP19_MAGIC = bytes([0x53, 0x4c, 0x00, 0x19])
+FLAG_USER_CONFIRMATION = 0x01
+
+COMMITMENT = b'test-slip19-commitment'
+SEGWIT_PATH = b"m/84h/0h/0h/1/0"
+TAPROOT_PATH = b"m/86h/0h/0h/1/0"
+
+
+def slp9_request(subpath, addr_fmt, flags, commitment=COMMITMENT):
+    # '<4sIIII>': tag, addr_fmt, flags, len(subpath), len(commitment)
+    return (b'slp9' + struct.pack('<IIII', addr_fmt, flags, len(subpath), len(commitment))
+            + subpath + commitment)
+
+
+@pytest.fixture
+def slp9(dev):
+    def doit(subpath=SEGWIT_PATH, addr_fmt=AF_P2WPKH, flags=0, commitment=COMMITMENT):
+        return dev.send_recv(slp9_request(subpath, addr_fmt, flags, commitment))
+    return doit
+
+
+def check_proof_shape(proof, flags, witness_items):
+    # proof_body = magic || flags || varint(count) || 32-byte ownership id
+    assert proof[0:4] == SLIP19_MAGIC
+    assert proof[4] == flags
+    assert proof[5] == 1
+    assert len(proof) > 38
+    # bip322_sig follows: empty scriptSig, then the witness stack
+    assert proof[38] == 0
+    assert proof[39] == witness_items
+
+
+@pytest.mark.parametrize('addr_fmt, subpath, witness_items', [
+    (AF_P2WPKH, SEGWIT_PATH, 2),        # DER signature + pubkey
+    (AF_P2TR, TAPROOT_PATH, 1),         # single BIP-340 key-spend signature
+])
+def test_slp9_proof_shapes(slp9, addr_fmt, subpath, witness_items):
+    # Both supported script types produce a well-formed proof outside HSM mode,
+    # so long as they do not claim a user confirmation that never happened.
+    proof = slp9(subpath=subpath, addr_fmt=addr_fmt, flags=0)
+    check_proof_shape(proof, flags=0, witness_items=witness_items)
+
+
+def test_slp9_is_deterministic(slp9):
+    # Same key, same commitment => same proof (RFC6979 / BIP-340 with zero aux).
+    assert slp9() == slp9()
+
+
+def test_slp9_binds_commitment(slp9):
+    # The commitment is inside the signed digest, so changing it changes the signature.
+    assert slp9(commitment=b'aaa') != slp9(commitment=b'bbb')
+
+
+def test_slp9_rejects_unsupported_addr_fmt(slp9):
+    # The address format is stated by the caller and validated, not guessed from the path.
+    with pytest.raises(Exception) as ee:
+        slp9(addr_fmt=AF_CLASSIC)
+    assert 'unsupported address format' in str(ee.value)
+
+
+def test_slp9_confirmation_flag_needs_hsm(slp9):
+    # The flag asserts to a coordinator that a human approved this input. Outside HSM mode
+    # nobody did, and the host chooses the flag, so the device must refuse to make the claim.
+    with pytest.raises(Exception) as ee:
+        slp9(flags=FLAG_USER_CONFIRMATION)
+    assert 'user confirmation' in str(ee.value)
+
+
+def test_slp9_rejects_junk_path(slp9):
+    with pytest.raises(Exception):
+        slp9(subpath=b"m/84h/0h/zz/1/0")
+
+
+@pytest.mark.parametrize('policy_paths, subpath, allowed', [
+    (["m/84h/0h/0h/1/*"], SEGWIT_PATH, True),
+    (["m/84h/0h/0h/0/*"], SEGWIT_PATH, False),      # wrong branch
+    (["m/86h/0h/0h/1/*"], TAPROOT_PATH, True),
+    ([], SEGWIT_PATH, False),                        # no slip19_paths => never allowed
+])
+def test_slp9_hsm_path_gate(slp9, start_hsm, hsm_reset, policy_paths, subpath, allowed):
+    # Under a policy, only whitelisted paths may be proven, and the confirmation flag is
+    # permitted because the approved policy is the user's standing consent.
+    policy = dict(warnings_ok=True, rules=[dict(min_pct_self_transfer=99)])
+    if policy_paths:
+        policy['slip19_paths'] = policy_paths
+    start_hsm(policy)
+
+    addr_fmt = AF_P2TR if subpath == TAPROOT_PATH else AF_P2WPKH
+    if allowed:
+        proof = slp9(subpath=subpath, addr_fmt=addr_fmt, flags=FLAG_USER_CONFIRMATION)
+        check_proof_shape(proof, flags=FLAG_USER_CONFIRMATION,
+                          witness_items=1 if subpath == TAPROOT_PATH else 2)
+    else:
+        with pytest.raises(Exception) as ee:
+            slp9(subpath=subpath, addr_fmt=addr_fmt, flags=FLAG_USER_CONFIRMATION)
+        assert 'Not allowed in HSM mode' in str(ee.value)
+
+    hsm_reset()
+
+# EOF

--- a/testing/test_slip19.py
+++ b/testing/test_slip19.py
@@ -1,17 +1,14 @@
 # (c) Copyright 2026 by Coinkite Inc. This file is covered by license found in COPYING-CC.
 #
-# SLIP-19 ownership proofs (slp9) and their HSM policy gate.
+# SLIP-19 ownership proofs (slp9) outside HSM mode, and the identifier itself.
 #
-# Run with:  py.test test_slip19.py
+# Nothing here needs HSM, so it runs on the Q as well as the Mk4. The policy gate is in
+# test_slip19_hsm.py, which pulls in the HSM harness and therefore skips on the Q.
 #
-import pytest, struct, json, time
+# Run with:  py.test test_slip19.py --sim
+#
+import pytest, struct, time
 from hashlib import sha256
-from ckcc.protocol import CCProtocolPacker
-
-# The HSM harness fixtures live next door; importing them here makes pytest resolve them.
-# enable_hsm_commands is autouse in test_hsm and must be pulled in explicitly, otherwise these
-# tests only pass when some earlier module happens to have left hsmcmd enabled on the simulator.
-from test_hsm import hsm_reset, hsm_status, start_hsm, enable_hsm_commands
 
 AF_P2WPKH = 0x07
 AF_P2TR = 0x23
@@ -136,33 +133,6 @@ def test_slp9_result_is_only_for_slok(dev, press_select):
 def test_slp9_rejects_junk_path(slp9):
     with pytest.raises(Exception):
         slp9(subpath=b"m/84h/0h/zz/1/0")
-
-
-@pytest.mark.parametrize('policy_paths, subpath, allowed', [
-    (["m/84h/0h/0h/1/*"], SEGWIT_PATH, True),
-    (["m/84h/0h/0h/0/*"], SEGWIT_PATH, False),      # wrong branch
-    (["m/86h/0h/0h/1/*"], TAPROOT_PATH, True),
-    ([], SEGWIT_PATH, False),                        # no slip19_paths => never allowed
-])
-def test_slp9_hsm_path_gate(slp9, start_hsm, hsm_reset, policy_paths, subpath, allowed):
-    # Under a policy, only whitelisted paths may be proven, and the confirmation flag is
-    # permitted because the approved policy is the user's standing consent.
-    policy = dict(warnings_ok=True, rules=[dict(min_pct_self_transfer=99)])
-    if policy_paths:
-        policy['slip19_paths'] = policy_paths
-    start_hsm(policy)
-
-    addr_fmt = AF_P2TR if subpath == TAPROOT_PATH else AF_P2WPKH
-    if allowed:
-        proof = slp9(subpath=subpath, addr_fmt=addr_fmt, flags=FLAG_USER_CONFIRMATION)
-        check_proof_shape(proof, flags=FLAG_USER_CONFIRMATION,
-                          witness_items=1 if subpath == TAPROOT_PATH else 2)
-    else:
-        with pytest.raises(Exception) as ee:
-            slp9(subpath=subpath, addr_fmt=addr_fmt, flags=FLAG_USER_CONFIRMATION)
-        assert 'Not allowed in HSM mode' in str(ee.value)
-
-    hsm_reset()
 
 
 # --- the ownership identifier itself ---------------------------------------------

--- a/testing/test_slip19.py
+++ b/testing/test_slip19.py
@@ -116,4 +116,44 @@ def test_slp9_hsm_path_gate(slp9, start_hsm, hsm_reset, policy_paths, subpath, a
 
     hsm_reset()
 
+
+# --- the ownership identifier itself ---------------------------------------------
+#
+# Official SLIP-19 vector 1: BIP-39 seed "all all ... all", no passphrase, P2WPKH at
+# m/84h/0h/0h/1/0. The identifier is defined over the scriptPubKey alone, so it does
+# not depend on which chain the simulator happens to be set to.
+
+VECTOR_WORDS = "all all all all all all all all all all all all"
+VECTOR_SPK = bytes.fromhex("0014b2f771c370ccf219cd3059cda92bdf7f00cf2103")
+VECTOR_OID = bytes.fromhex("a122407efc198211c81af4450f40b235d54775efd934d16b9e31c6ce9bad5707")
+
+
+def test_ownership_id_matches_official_vector(set_seed_words, sim_eval):
+    # Pin the derivation against the published vector, so a change to the SLIP-21 label
+    # path or the HMAC ordering fails here rather than in somebody wallet.
+    set_seed_words(VECTOR_WORDS)
+
+    rv = sim_eval("__import__(\"binascii\").hexlify("
+                  "__import__(\"slip19\").ownership_id(%r)).decode()" % VECTOR_SPK)
+    assert rv.strip().strip("\x27\"") == VECTOR_OID.hex()
+
+
+def test_slp9_carries_the_real_ownership_id(set_seed_words, slp9):
+    # End to end: the id inside the proof is the spec value for the key the device just
+    # derived, not the 32 zero bytes this replaced, which told a coordinator nothing.
+    set_seed_words(VECTOR_WORDS)
+
+    oid = slp9(subpath=SEGWIT_PATH, addr_fmt=AF_P2WPKH)[6:38]
+    assert oid != bytes(32)
+    assert oid == VECTOR_OID
+
+
+def test_ownership_id_is_bound_to_the_script(set_seed_words, slp9):
+    # One seed, two scripts: the identifiers must differ, or the id is not identifying.
+    set_seed_words(VECTOR_WORDS)
+
+    segwit = slp9(subpath=SEGWIT_PATH, addr_fmt=AF_P2WPKH)[6:38]
+    taproot = slp9(subpath=TAPROOT_PATH, addr_fmt=AF_P2TR)[6:38]
+    assert segwit != taproot
+
 # EOF

--- a/testing/test_slip19.py
+++ b/testing/test_slip19.py
@@ -1,0 +1,208 @@
+# (c) Copyright 2026 by Coinkite Inc. This file is covered by license found in COPYING-CC.
+#
+# SLIP-19 ownership proofs (slp9) and their HSM policy gate.
+#
+# Run with:  py.test test_slip19.py
+#
+import pytest, struct, json, time
+from hashlib import sha256
+from ckcc.protocol import CCProtocolPacker
+
+# The HSM harness fixtures live next door; importing them here makes pytest resolve them.
+# enable_hsm_commands is autouse in test_hsm and must be pulled in explicitly, otherwise these
+# tests only pass when some earlier module happens to have left hsmcmd enabled on the simulator.
+from test_hsm import hsm_reset, hsm_status, start_hsm, enable_hsm_commands
+
+AF_P2WPKH = 0x07
+AF_P2TR = 0x23
+AF_CLASSIC = 0x01
+
+SLIP19_MAGIC = bytes([0x53, 0x4c, 0x00, 0x19])
+FLAG_USER_CONFIRMATION = 0x01
+
+COMMITMENT = b'test-slip19-commitment'
+SEGWIT_PATH = b"m/84h/0h/0h/1/0"
+TAPROOT_PATH = b"m/86h/0h/0h/1/0"
+
+
+def slp9_request(subpath, addr_fmt, flags, commitment=COMMITMENT):
+    # '<4sIIII>': tag, addr_fmt, flags, len(subpath), len(commitment)
+    return (b'slp9' + struct.pack('<IIII', addr_fmt, flags, len(subpath), len(commitment))
+            + subpath + commitment)
+
+
+def poll_slok(dev):
+    rv = None
+    while rv is None:
+        time.sleep(0.050)
+        rv = dev.send_recv(b'slok', timeout=None)
+    return rv
+
+
+@pytest.fixture
+def slp9(dev, press_select):
+    # Outside HSM mode a human approves each proof, so the device answers with nothing and the
+    # host collects the result with 'slok'. Under a policy the proof comes straight back.
+    def doit(subpath=SEGWIT_PATH, addr_fmt=AF_P2WPKH, flags=0, commitment=COMMITMENT):
+        rv = dev.send_recv(slp9_request(subpath, addr_fmt, flags, commitment), timeout=None)
+        if rv is not None:
+            return rv
+
+        press_select()
+        return poll_slok(dev)
+    return doit
+
+
+def check_proof_shape(proof, flags, witness_items):
+    # proof_body = magic || flags || varint(count) || 32-byte ownership id
+    assert proof[0:4] == SLIP19_MAGIC
+    assert proof[4] == flags
+    assert proof[5] == 1
+    assert len(proof) > 38
+    # bip322_sig follows: empty scriptSig, then the witness stack
+    assert proof[38] == 0
+    assert proof[39] == witness_items
+
+
+@pytest.mark.parametrize('addr_fmt, subpath, witness_items', [
+    (AF_P2WPKH, SEGWIT_PATH, 2),        # DER signature + pubkey
+    (AF_P2TR, TAPROOT_PATH, 1),         # single BIP-340 key-spend signature
+])
+def test_slp9_proof_shapes(slp9, addr_fmt, subpath, witness_items):
+    # Both supported script types produce a well-formed proof once approved on screen.
+    proof = slp9(subpath=subpath, addr_fmt=addr_fmt, flags=0)
+    check_proof_shape(proof, flags=0, witness_items=witness_items)
+
+
+def test_slp9_is_deterministic(slp9):
+    # Same key, same commitment => same proof (RFC6979 / BIP-340 with zero aux).
+    assert slp9() == slp9()
+
+
+def test_slp9_binds_commitment(slp9):
+    # The commitment is inside the signed digest, so changing it changes the signature.
+    assert slp9(commitment=b'aaa') != slp9(commitment=b'bbb')
+
+
+def test_slp9_rejects_unsupported_addr_fmt(slp9):
+    # The address format is stated by the caller and validated, not guessed from the path.
+    with pytest.raises(Exception) as ee:
+        slp9(addr_fmt=AF_CLASSIC)
+    assert 'unsupported address format' in str(ee.value)
+
+
+def test_slp9_outside_hsm_asks_on_screen(dev, cap_story, press_select):
+    # No policy, so a human must see what is being proven before it is signed. The story names
+    # the path and the address the proof is about.
+    dev.send_recv(slp9_request(SEGWIT_PATH, AF_P2WPKH, FLAG_USER_CONFIRMATION), timeout=None)
+
+    title, story = cap_story()
+    assert 'Ownership' in title
+    assert SEGWIT_PATH.decode() in story
+    assert sha256(COMMITMENT).hexdigest() in story.lower()
+
+    press_select()
+    proof = poll_slok(dev)
+
+    # somebody did confirm, so the flag is now a claim the device can back
+    check_proof_shape(proof, flags=FLAG_USER_CONFIRMATION, witness_items=2)
+
+
+def test_slp9_outside_hsm_can_be_refused(dev, press_cancel):
+    # Refusing must produce no proof at all, not an unsigned or partial one.
+    from ckcc_protocol.protocol import CCUserRefused
+
+    dev.send_recv(slp9_request(SEGWIT_PATH, AF_P2WPKH, 0), timeout=None)
+    press_cancel()
+
+    with pytest.raises(CCUserRefused):
+        poll_slok(dev)
+
+
+def test_slp9_result_is_only_for_slok(dev, press_select):
+    # A pending proof must not be collectable as if it were a signed message: smok would
+    # otherwise hand back the proof wrapped in a message-signature response.
+    dev.send_recv(slp9_request(SEGWIT_PATH, AF_P2WPKH, 0), timeout=None)
+    press_select()
+
+    with pytest.raises(Exception) as ee:
+        dev.send_recv(b'smok', timeout=None)
+    assert 'Wrong completion command' in str(ee.value)
+
+    # and the proof is still there for its own poll
+    check_proof_shape(poll_slok(dev), flags=0, witness_items=2)
+
+
+def test_slp9_rejects_junk_path(slp9):
+    with pytest.raises(Exception):
+        slp9(subpath=b"m/84h/0h/zz/1/0")
+
+
+@pytest.mark.parametrize('policy_paths, subpath, allowed', [
+    (["m/84h/0h/0h/1/*"], SEGWIT_PATH, True),
+    (["m/84h/0h/0h/0/*"], SEGWIT_PATH, False),      # wrong branch
+    (["m/86h/0h/0h/1/*"], TAPROOT_PATH, True),
+    ([], SEGWIT_PATH, False),                        # no slip19_paths => never allowed
+])
+def test_slp9_hsm_path_gate(slp9, start_hsm, hsm_reset, policy_paths, subpath, allowed):
+    # Under a policy, only whitelisted paths may be proven, and the confirmation flag is
+    # permitted because the approved policy is the user's standing consent.
+    policy = dict(warnings_ok=True, rules=[dict(min_pct_self_transfer=99)])
+    if policy_paths:
+        policy['slip19_paths'] = policy_paths
+    start_hsm(policy)
+
+    addr_fmt = AF_P2TR if subpath == TAPROOT_PATH else AF_P2WPKH
+    if allowed:
+        proof = slp9(subpath=subpath, addr_fmt=addr_fmt, flags=FLAG_USER_CONFIRMATION)
+        check_proof_shape(proof, flags=FLAG_USER_CONFIRMATION,
+                          witness_items=1 if subpath == TAPROOT_PATH else 2)
+    else:
+        with pytest.raises(Exception) as ee:
+            slp9(subpath=subpath, addr_fmt=addr_fmt, flags=FLAG_USER_CONFIRMATION)
+        assert 'Not allowed in HSM mode' in str(ee.value)
+
+    hsm_reset()
+
+
+# --- the ownership identifier itself ---------------------------------------------
+#
+# Official SLIP-19 vector 1: BIP-39 seed "all all ... all", no passphrase, P2WPKH at
+# m/84h/0h/0h/1/0. The identifier is defined over the scriptPubKey alone, so it does
+# not depend on which chain the simulator happens to be set to.
+
+VECTOR_WORDS = "all all all all all all all all all all all all"
+VECTOR_SPK = bytes.fromhex("0014b2f771c370ccf219cd3059cda92bdf7f00cf2103")
+VECTOR_OID = bytes.fromhex("a122407efc198211c81af4450f40b235d54775efd934d16b9e31c6ce9bad5707")
+
+
+def test_ownership_id_matches_official_vector(set_seed_words, sim_exec):
+    # Pin the derivation against the published vector, so a change to the SLIP-21 label
+    # path or the HMAC ordering fails here rather than in somebody wallet.
+    set_seed_words(VECTOR_WORDS)
+
+    rv = sim_exec("import slip19, stash, binascii\n"
+                  "with stash.SensitiveValues() as sv:\n"
+                  "    RV.write(binascii.hexlify(slip19.ownership_id(%r, sv)))" % VECTOR_SPK)
+    assert rv.strip().endswith(VECTOR_OID.hex())
+
+
+def test_slp9_carries_the_real_ownership_id(set_seed_words, slp9):
+    # End to end: the id inside the proof is the spec value for the key the device just
+    # derived, not the 32 zero bytes this replaced, which told a coordinator nothing.
+    set_seed_words(VECTOR_WORDS)
+
+    oid = slp9(subpath=SEGWIT_PATH, addr_fmt=AF_P2WPKH)[6:38]
+    assert oid != bytes(32)
+    assert oid == VECTOR_OID
+
+
+def test_ownership_id_is_bound_to_the_script(set_seed_words, slp9):
+    # One seed, two scripts: the identifiers must differ, or the id is not identifying.
+    set_seed_words(VECTOR_WORDS)
+
+    segwit = slp9(subpath=SEGWIT_PATH, addr_fmt=AF_P2WPKH)[6:38]
+    taproot = slp9(subpath=TAPROOT_PATH, addr_fmt=AF_P2TR)[6:38]
+    assert segwit != taproot
+
+# EOF

--- a/testing/test_slip19_hsm.py
+++ b/testing/test_slip19_hsm.py
@@ -1,0 +1,44 @@
+# (c) Copyright 2026 by Coinkite Inc. This file is covered by license found in COPYING-CC.
+#
+# The HSM policy gate for SLIP-19 ownership proofs: slip19_paths decides which paths may be
+# proven unattended. Kept apart from test_slip19.py because importing the HSM harness makes the
+# whole module skip on the Q, and the rest of slp9 does not need HSM.
+#
+# Run with:  py.test test_slip19_hsm.py --sim
+#
+import pytest
+
+# enable_hsm_commands is autouse in test_hsm and must be pulled in explicitly, otherwise these
+# tests only pass when some earlier module happens to have left hsmcmd enabled on the simulator.
+from test_hsm import hsm_reset, hsm_status, start_hsm, enable_hsm_commands
+from test_slip19 import (slp9, check_proof_shape, AF_P2WPKH, AF_P2TR, SEGWIT_PATH, TAPROOT_PATH,
+                         FLAG_USER_CONFIRMATION)
+
+
+@pytest.mark.parametrize('policy_paths, subpath, allowed', [
+    (["m/84h/0h/0h/1/*"], SEGWIT_PATH, True),
+    (["m/84h/0h/0h/0/*"], SEGWIT_PATH, False),      # wrong branch
+    (["m/86h/0h/0h/1/*"], TAPROOT_PATH, True),
+    ([], SEGWIT_PATH, False),                        # no slip19_paths => never allowed
+])
+def test_slp9_hsm_path_gate(slp9, start_hsm, hsm_reset, policy_paths, subpath, allowed):
+    # Under a policy, only whitelisted paths may be proven, and the confirmation flag is
+    # permitted because the approved policy is the user's standing consent.
+    policy = dict(warnings_ok=True, rules=[dict(min_pct_self_transfer=99)])
+    if policy_paths:
+        policy['slip19_paths'] = policy_paths
+    start_hsm(policy)
+
+    addr_fmt = AF_P2TR if subpath == TAPROOT_PATH else AF_P2WPKH
+    if allowed:
+        proof = slp9(subpath=subpath, addr_fmt=addr_fmt, flags=FLAG_USER_CONFIRMATION)
+        check_proof_shape(proof, flags=FLAG_USER_CONFIRMATION,
+                          witness_items=1 if subpath == TAPROOT_PATH else 2)
+    else:
+        with pytest.raises(Exception) as ee:
+            slp9(subpath=subpath, addr_fmt=addr_fmt, flags=FLAG_USER_CONFIRMATION)
+        assert 'Not allowed in HSM mode' in str(ee.value)
+
+    hsm_reset()
+
+# EOF

--- a/testing/test_slip19_indicator.py
+++ b/testing/test_slip19_indicator.py
@@ -1,0 +1,59 @@
+# (c) Copyright 2026 by Coinkite Inc. This file is covered by license found in COPYING-CC.
+#
+# The HSM screen should say when the device is signing an ownership proof.
+#
+# Unattended coinjoin signing is silent by design, so without this there is no way to tell a working
+# session from an idle one by looking at the Coldcard. PSBT signing already announces itself through
+# the busy line; ownership proofs did not.
+#
+# Run with:  py.test test_slip19_indicator.py --sim
+#
+import pytest, struct
+from test_hsm import hsm_reset, hsm_status, start_hsm, enable_hsm_commands
+
+AF_P2WPKH = 0x07
+SEGWIT_PATH = b"m/84h/0h/0h/1/0"
+COMMITMENT = b'indicator-check'
+
+
+def slp9_request(subpath, addr_fmt=AF_P2WPKH, flags=0, commitment=COMMITMENT):
+    return (b'slp9' + struct.pack('<IIII', addr_fmt, flags, len(subpath), len(commitment))
+            + subpath + commitment)
+
+
+def test_busy_line_fits_the_screen(sim_eval):
+    # dis.text centres but neither wraps nor shrinks, so a message wider than the 128px screen
+    # silently loses its ends. The message we show is wider than that in the normal font.
+    small = int(sim_eval(
+        '__import__("glob").dis.width("Signing ownership proof", __import__("display").FontSmall)'))
+    tiny = int(sim_eval(
+        '__import__("glob").dis.width("Signing ownership proof", __import__("display").FontTiny)'))
+
+    assert small > 128, "test is pointless if the message already fits in the normal font"
+    assert tiny <= 128, "the fallback font has to actually fit, or the text is still clipped"
+
+
+def test_proof_announces_itself_on_the_hsm_screen(dev, start_hsm, hsm_reset, sim_exec):
+    policy = dict(warnings_ok=True, slip19_paths=["m/84h/0h/0h/1/*"],
+                  rules=[dict(min_pct_self_transfer=95)])
+    start_hsm(policy)
+
+    # The busy line is written during signing and cleared after, so sampling it afterwards proves
+    # nothing. Wrap the display call to record what it was asked to show.
+    # Record the call without delegating: what matters is that the device announced itself, and
+    # calling through to the real screen from a replaced bound method upsets MicroPython.
+    sim_exec('''
+import glob
+glob.dis._seen = []
+glob.dis.fullscreen = lambda msg, percent=None: glob.dis._seen.append(msg)
+RV.write(b'armed')
+''')
+
+    dev.send_recv(slp9_request(SEGWIT_PATH))
+
+    seen = sim_exec('import glob; RV.write(repr(glob.dis._seen).encode())')
+    assert 'ownership proof' in seen.lower(), seen
+
+    hsm_reset()
+
+# EOF


### PR DESCRIPTION
# SLIP-19 ownership proofs + HSM support for coinjoin remote signing

Adds what a Coldcard needs to sign coinjoins: SLIP-19 ownership proofs over USB, five policy rules
bounding what unattended signing may do, two screen changes so an unattended device reads honestly,
and one safety fix found while testing on hardware.

Rebased onto `new_edge` (6.6.1X) at doc-hex's suggestion, because Wasabi rounds are taproot and only
the edge line signs P2TR. 4 commits, 13 files, +1079/−13. The 5.6.0-based version this replaces is
kept at tag `slip19-5.6.0-final` and branch `archive/slip19-on-5.6.0` on my fork.

Verified in the simulator on this base; the hardware numbers below were measured on a retail Mk4
running the 5.6.0 version, and the proofs are byte-identical across the two bases.

Happy to split this: the proofs stand alone, and the policy rules could follow as a second PR.

## What it adds

**`slp9` USB command** — a serialized SLIP-19 ownership proof for a derivation path. P2WPKH (ECDSA)
and P2TR (BIP-340 key-spend, BIP-86 tweak). The caller states the address format rather than the
device inferring it from the path purpose, which need not match the script actually used.

The taproot half is why this belongs on edge: proving ownership of a P2TR coin is only useful on a
build that can then sign the round's PSBT. The proof uses this branch's own primitives —
`chains.taptweak()` through `script_pubkey()` for the output key, and `TAP_TWEAK_H` with
`ngu.hash.sha256t()` for the tweak, the same shape `psbt.py` signs key-path inputs with.

**Real SLIP-19 ownership identifiers**, derived per SLIP-21 from the seed, pinned against the
published vectors. An xprv-imported secret has no seed, so proofs are refused rather than given a
fabricated id.

**Two ways to authorise a proof.** Under an HSM policy, `slip19_paths` whitelists the paths and the
proof comes straight back — unattended signing. Without a policy the user approves each proof on
screen, like message signing: `slp9` returns nothing, the screen shows path, address and
SHA-256(commitment), and the host collects the proof with `slok`. Refusing returns `refu`.
So the SLIP-19 user-confirmation flag is only ever set when somebody actually confirmed.

**Five HSM rules bounding unattended signing.** `min_pct_self_transfer` bounds the ratio one
transaction moves; nothing bounded the total, the rate, the price per byte, or whether the round was
worth joining. Each is absent-means-off, shown in the on-screen summary, and in `to_json` so the
policy hash covers it.

| rule | bounds |
| --- | --- |
| `max_txn` | transactions one approved policy may sign, counted per session |
| `max_txn_per_period` | how fast those may be spent, using the existing period |
| `max_sats_leaving` | own value leaving in one transaction, absolute |
| `max_fee_per_kvbyte` | own loss per 1000 vbytes of our own contribution |
| `min_inputs` | fewest inputs the transaction may have, counting every participant |

Why not the existing velocity limits: `per_period` and `max_amount` measure non-change outputs,
which in a coinjoin are the *other participants'* outputs, so any value tight enough to matter
refuses honest rounds. These five measure our own inputs and outputs, or the transaction itself.
`max_fee_per_kvbyte` needs only our own values, because in a coinjoin `calculate_fee()` is `None`
and the transaction-wide fee check is skipped entirely.

## Screen honesty

**Signing indicator.** The HSM screen says "Signing ownership proof" while it works; unattended
signing was otherwise indistinguishable from idle.

**The busy line expires.** If a host stops talking mid-upload nothing raises, so `restore_menu()`
never runs and the screen keeps reading "Receiving..." on an idle device. Nothing is broken — a
fresh `upld` at offset 0 resets the transfer — but an indicator that says "working" when it is not
is the one thing an unattended device must not do. Progress updates refresh the line; 30s of no
movement clears it.

## Safety fix

**Master seed blanking.** `_master_seed` handed back a copy of the 64-byte BIP-39 seed, which
nothing else in the firmware extracts. It is blanked as soon as the one HMAC that needs it has run,
along with each seed-derived intermediate, using the same `blank_object()` the rest of `stash.py`
uses.

## Testing

32 new tests across seven files, on the simulator: proof shapes, determinism, commitment binding,
the HSM path gate, the on-screen approval and refusal, and the ownership id pinned to official
vector 1 (mutation-checked against a wrong SLIP-21 label, the wrong half of the node, and a wrong
root label). Each of the five rules is shown on screen and enforced, absent means off, and composes
with the self-transfer floor; `min_inputs` is mutation-checked against counting only our own inputs.

On this base, with a simulator built from it: `test_slip19.py` 16 passed, and the six rule/screen
suites 20 passed, 36 together.

`test_usb.py` (32 failed, 43 passed, 1 skipped) and `test_hsm.py` (58 failed, 121 passed, 9 errors)
give **identical counts on bare `new_edge` without this branch applied**, checked by rebuilding the
simulator from `38c17eb0` and rerunning. Those failures are my local environment, not this change.

The proofs are byte-identical to the 5.6.0 version for the same seed, path and commitment — P2WPKH
and P2TR both — which is what says the switch to `chains.taptweak()` changed nothing observable.

**On hardware (Mk4).** Proofs accepted at input registration; PSBTs signed unattended under the
policy; coinjoins confirmed on regtest and mainnet, including a round signing five of our own inputs
in one PSBT. Every rule exercised from both sides — refusals at 77%/93.3%/97.8%/98.9%
self-transfer, `max_sats_leaving` at 125,415 against a 100,000 cap, `max_txn_per_period` once the
hourly count was reached, `max_fee_per_kvbyte` at 23,570 against 5,000, `min_inputs` refusing a
4-input round against a floor of 21 and signing a 13-input round against a floor of 3.

## Known limit: signing speed

A coinjoin PSBT costs ~2.7 ms per PSBT byte on an Mk4, end to end, over five mainnet rounds. A
~14 KB PSBT signs in 40s and confirmed on mainnet, but a typical ~40 KB round takes 100–117s and
misses a ~90s coordinator signing phase. The device signs correctly every time; it is simply not
asked early enough.

Nothing here addresses that, and it should not: the cost is in `psbt.py`, which re-deserializes the
unsigned transaction on each of five traversals, and rewriting that touches every signing flow you
have. Flagging it because it decides where unattended coinjoin signing is usable today (~20 KB
PSBTs, ~150 inputs), and a single-pass rewrite looks worth roughly 2x if you ever want it.

## Notes for review

- `hsmcmd` must be enabled for the HSM path; a factory-fresh unit ships with it off. The
  user-approved path needs no policy and no `hsmcmd`.
- Mk4 only for HSM: `version.py` clears `supports_hsm` on Q1. The attended approval path has no such
  restriction, and `test_slip19.py` passes on the Q simulator (12 cases): title bar, 24-char address
  groups and the ENTER/CANCEL prompt all come out right. The policy gate lives in `test_slip19_hsm.py`
  so that it, not the whole module, skips on Q.
- `slp9` is deliberately **not** in `HOBBLED_CMDS`: a proof moves no funds. Say the word if you would
  rather a spending policy blocked it too.
- `approve_transaction` returns early for `por322` PSBTs before the rules loop, so the five counters
  never see one. Coinjoin PSBTs are not `por322`, so I left that alone — but BIP-322 proof-of-reserves
  and SLIP-19 ownership proofs are neighbours, and you may want them reconciled.
- `ckcc-protocol` has no packer for `slp9`/`slok` yet, so hosts use raw `send_recv` today.
- `compute_policy_hash` in `testing/test_hsm.py` mirrors the firmware's `to_json` field order, so
  `slip19_paths` and the five rules had to be added there too, in the same order.
- The busy-line timeout is in `hsm_ux.py`, so it only applies under a policy. The same stale screen
  is reachable outside HSM, but that path has a user present. Say the word if you want it general.
