### PR TITLE
fix: feed full SE digest to PRNG reseed (drop 32-bit truncation)

### DIFF
--- a/shared/mk4.py
+++ b/shared/mk4.py
@@ -38,13 +38,15 @@ COLDCARD Virtual Disk
 
 def rng_seeding():
     # seed our RNG with entropy from secure elements
-    import callgate, ngu, ustruct
+    import callgate, ngu
 
     a = callgate.read_rng(1)        # SE1
     b = callgate.read_rng(2)        # SE2
 
+    # Feed the FULL 32-byte digest into the PRNG state. Truncating to 4 bytes
+    # (n[0:4]) throttled the secure-element contribution to 2**32 and left most
+    # of the generator's state words at fixed constants: see ngu.random.reseed().
     n = ngu.hash.sha256d(a+b)
-    n, = ustruct.unpack('I', n[0:4])
 
     ngu.random.reseed(n)
         


### PR DESCRIPTION
### Summary

`mk4.rng_seeding()` hashes the secure-element entropy with SHA256d but then keeps
only the first four bytes — `n, = ustruct.unpack('I', n[0:4])` — before handing it
to `ngu.random.reseed()`. That throttled the secure-element contribution to the
software RNG to 2**32, discarding 28 of the 32 digest bytes.

This change passes the **full 32-byte digest** to `reseed()`.

### Change

- `shared/mk4.py`: drop the 4-byte truncation; feed the whole SHA256d digest.
- Re-pin `external/libngu` to the companion RNG fix.

### Dependency / CI note

**Draft — depends on switck/libngu#61; will re-pin on merge.** #61 replaces the
generator with a SHA-256 Hash-DRBG and makes `reseed()` require a ≥32-byte seed
(it now rejects the old 4-byte `int` call), so this `mk4.py` change is required for
#61 to boot on-device. Until #61 merges, the pinned submodule commit lives only on
the fork and firmware CI cannot fetch it from upstream; the pin will move to the
merged #61 SHA.

### Context

Public disclosure: Block engineering, "Predictable RNG fallback and 32-bit reseed in
COLDCARD firmware." This addresses the 32-bit-reseed half. (The predictable-fallback
half is already mitigated in this tree: `stm32/COLDCARD*/rng.c` binds `rng_get()` to
the hardware TRNG with `#if MICROPY_HW_ENABLE_RNG -> #error` guarding, and the
`mpconfigboard.mk` files poison `pyb_rng_yasmarang`.)
