### PR TITLE
rng: recover the TRNG after a seed/clock error instead of failing forever

### DIFF
--- a/shared/keyboard.py
+++ b/shared/keyboard.py
@@ -97,7 +97,14 @@ class FullKeyboard(NumpadBase):
     def _start_scan(self):
         # reset and re-start scanning keys
         self.lp_time = utime.ticks_ms()
-        shuffle(self.scan_order)
+        # Scan order randomization is anti-Tempest hygiene, not a secret: it must
+        # never be able to take down the keypad. Since the RNG became fallible
+        # (it now reads the hardware TRNG and can raise OSError), a single glitch
+        # here would kill the scan task -- before login, so unrecoverable.
+        try:
+            shuffle(self.scan_order)
+        except Exception:
+            pass
 
         self._scan_count = 0
         self.waiting_for_any = False

--- a/shared/mempad.py
+++ b/shared/mempad.py
@@ -81,7 +81,14 @@ class MembraneNumpad(NumpadBase):
         # reset and re-start scanning keys
         self.waiting_for_any = False
         self.lp_time = utime.ticks_ms()
-        shuffle(self.scan_order)
+        # Scan order randomization is anti-Tempest hygiene, not a secret: it must
+        # never be able to take down the keypad. Since the RNG became fallible
+        # (it now reads the hardware TRNG and can raise OSError), a single glitch
+        # here would kill the scan task -- before login, so unrecoverable.
+        try:
+            shuffle(self.scan_order)
+        except Exception:
+            pass
 
         self._scan_count = 0
         self._history = bytearray(NUM_ROWS * NUM_COLS)

--- a/stm32/COLDCARD/rng.c
+++ b/stm32/COLDCARD/rng.c
@@ -31,6 +31,7 @@
  */
 
 #include <string.h>
+#include <stdbool.h>
 
 #include "py/obj.h"
 #include "py/runtime.h"
@@ -43,38 +44,95 @@
 
 void random_buffer(uint8_t *p, size_t count);
 
+#define RNG_TIMEOUT_MS      (10)
+#define RNG_MAX_ATTEMPTS    (3)
+
+// Bits we must be able to see and clear. Same names/positions on L4 and L4+.
+#ifndef RNG_SR_SEIS
+# define RNG_SR_SEIS    (1u << 6)
+#endif
+#ifndef RNG_SR_CEIS
+# define RNG_SR_CEIS    (1u << 5)
+#endif
+#ifndef RNG_SR_SECS
+# define RNG_SR_SECS    (1u << 2)
+#endif
+#ifndef RNG_SR_CECS
+# define RNG_SR_CECS    (1u << 1)
+#endif
+
+#define RNG_SR_ERRORS   (RNG_SR_SEIS | RNG_SR_CEIS | RNG_SR_SECS | RNG_SR_CECS)
+
+// rng_reset()
+//
+// Full re-init of the peripheral. Required after any seed or clock error:
+// per RM0432 (and RM0351) the SEIS flag must be cleared *and* RNGEN toggled
+// off->on, otherwise DRDY never asserts again and every later read times out
+// forever. Simply testing RNGEN (as the previous code did) is a no-op in that
+// state, which turned a transient glitch into a permanently dead device.
+static void rng_reset(void) {
+    __HAL_RCC_RNG_CLK_ENABLE();
+
+    RNG->CR &= ~RNG_CR_RNGEN;
+    RNG->SR &= ~(RNG_SR_SEIS | RNG_SR_CEIS);    // rc_w0: write 0 to clear
+    RNG->CR |= RNG_CR_RNGEN;
+
+    // RM: the first word produced after enabling may be invalid; discard it.
+    uint32_t start = HAL_GetTick();
+    while (!(RNG->SR & RNG_SR_DRDY)) {
+        if (HAL_GetTick() - start >= RNG_TIMEOUT_MS) return;
+    }
+    (void)RNG->DR;
+}
+
 static void rng_init(void) {
-    if (!(RNG->CR & RNG_CR_RNGEN)) {
-        __HAL_RCC_RNG_CLK_ENABLE();
-
-        RNG->CR |= RNG_CR_RNGEN;
-
-        // TODO: throw out some samples?
+    if (!(RNG->CR & RNG_CR_RNGEN) || (RNG->SR & RNG_SR_ERRORS)) {
+        rng_reset();
     }
 }
 
-
-#define RNG_TIMEOUT_MS (10)
-
 static uint32_t last_value;
 
-static uint32_t rng_get_or_fault(void)
+// rng_try_once()
+//
+// One attempt. Returns true and stores the word on success. Never throws.
+static bool rng_try_once(uint32_t *out)
 {
-    // Enable the RNG peripheral if it's not already enabled
-    rng_init();
-
-    // Wait for a new random number to be ready, takes on the order of 10us
     uint32_t start = HAL_GetTick();
 
     while (!(RNG->SR & RNG_SR_DRDY)) {
-        if (HAL_GetTick() - start >= RNG_TIMEOUT_MS) {
-            // hardware failure... do not return anything!
-            mp_raise_OSError(MP_EFAULT);
-        }
+        if (HAL_GetTick() - start >= RNG_TIMEOUT_MS) return false;
     }
 
-    // Get and return the new random number
-    last_value = RNG->DR;
+    // Data is only trustworthy if no error latched while we were waiting.
+    if (RNG->SR & RNG_SR_ERRORS) {
+        (void)RNG->DR;              // drain the suspect word
+        return false;
+    }
+
+    *out = RNG->DR;
+
+    return true;
+}
+
+static uint32_t rng_get_or_fault(void)
+{
+    uint32_t value = 0;
+
+    for (int attempt = 0; attempt < RNG_MAX_ATTEMPTS; attempt++) {
+        rng_init();
+
+        if (rng_try_once(&value)) {
+            last_value = value;
+            return last_value;
+        }
+
+        // Transient fault: recover the peripheral properly and try again.
+        rng_reset();
+    }
+
+    // Persistent hardware failure... do not return anything!
+    mp_raise_OSError(MP_EFAULT);
 
     return last_value;
 }

--- a/stm32/COLDCARD_MK4/rng.c
+++ b/stm32/COLDCARD_MK4/rng.c
@@ -31,6 +31,7 @@
  */
 
 #include <string.h>
+#include <stdbool.h>
 
 #include "py/obj.h"
 #include "py/runtime.h"
@@ -43,38 +44,95 @@
 
 void random_buffer(uint8_t *p, size_t count);
 
+#define RNG_TIMEOUT_MS      (10)
+#define RNG_MAX_ATTEMPTS    (3)
+
+// Bits we must be able to see and clear. Same names/positions on L4 and L4+.
+#ifndef RNG_SR_SEIS
+# define RNG_SR_SEIS    (1u << 6)
+#endif
+#ifndef RNG_SR_CEIS
+# define RNG_SR_CEIS    (1u << 5)
+#endif
+#ifndef RNG_SR_SECS
+# define RNG_SR_SECS    (1u << 2)
+#endif
+#ifndef RNG_SR_CECS
+# define RNG_SR_CECS    (1u << 1)
+#endif
+
+#define RNG_SR_ERRORS   (RNG_SR_SEIS | RNG_SR_CEIS | RNG_SR_SECS | RNG_SR_CECS)
+
+// rng_reset()
+//
+// Full re-init of the peripheral. Required after any seed or clock error:
+// per RM0432 (and RM0351) the SEIS flag must be cleared *and* RNGEN toggled
+// off->on, otherwise DRDY never asserts again and every later read times out
+// forever. Simply testing RNGEN (as the previous code did) is a no-op in that
+// state, which turned a transient glitch into a permanently dead device.
+static void rng_reset(void) {
+    __HAL_RCC_RNG_CLK_ENABLE();
+
+    RNG->CR &= ~RNG_CR_RNGEN;
+    RNG->SR &= ~(RNG_SR_SEIS | RNG_SR_CEIS);    // rc_w0: write 0 to clear
+    RNG->CR |= RNG_CR_RNGEN;
+
+    // RM: the first word produced after enabling may be invalid; discard it.
+    uint32_t start = HAL_GetTick();
+    while (!(RNG->SR & RNG_SR_DRDY)) {
+        if (HAL_GetTick() - start >= RNG_TIMEOUT_MS) return;
+    }
+    (void)RNG->DR;
+}
+
 static void rng_init(void) {
-    if (!(RNG->CR & RNG_CR_RNGEN)) {
-        __HAL_RCC_RNG_CLK_ENABLE();
-
-        RNG->CR |= RNG_CR_RNGEN;
-
-        // TODO: throw out some samples?
+    if (!(RNG->CR & RNG_CR_RNGEN) || (RNG->SR & RNG_SR_ERRORS)) {
+        rng_reset();
     }
 }
 
-
-#define RNG_TIMEOUT_MS (10)
-
 static uint32_t last_value;
 
-static uint32_t rng_get_or_fault(void)
+// rng_try_once()
+//
+// One attempt. Returns true and stores the word on success. Never throws.
+static bool rng_try_once(uint32_t *out)
 {
-    // Enable the RNG peripheral if it's not already enabled
-    rng_init();
-
-    // Wait for a new random number to be ready, takes on the order of 10us
     uint32_t start = HAL_GetTick();
 
     while (!(RNG->SR & RNG_SR_DRDY)) {
-        if (HAL_GetTick() - start >= RNG_TIMEOUT_MS) {
-            // hardware failure... do not return anything!
-            mp_raise_OSError(MP_EFAULT);
-        }
+        if (HAL_GetTick() - start >= RNG_TIMEOUT_MS) return false;
     }
 
-    // Get and return the new random number
-    last_value = RNG->DR;
+    // Data is only trustworthy if no error latched while we were waiting.
+    if (RNG->SR & RNG_SR_ERRORS) {
+        (void)RNG->DR;              // drain the suspect word
+        return false;
+    }
+
+    *out = RNG->DR;
+
+    return true;
+}
+
+static uint32_t rng_get_or_fault(void)
+{
+    uint32_t value = 0;
+
+    for (int attempt = 0; attempt < RNG_MAX_ATTEMPTS; attempt++) {
+        rng_init();
+
+        if (rng_try_once(&value)) {
+            last_value = value;
+            return last_value;
+        }
+
+        // Transient fault: recover the peripheral properly and try again.
+        rng_reset();
+    }
+
+    // Persistent hardware failure... do not return anything!
+    mp_raise_OSError(MP_EFAULT);
 
     return last_value;
 }


### PR DESCRIPTION
**Affects:** `stm32/COLDCARD_MK4/rng.c`, `stm32/COLDCARD/rng.c` (`COLDCARD_Q1/rng.c` is a symlink to the Mk4 file), as shipped in the 2026-07-31 hotfix (commit `ca724637`, "fixes rng").

**Summary:** the entropy fix is correct — `rng_get()` now resolves to the board TRNG accessor instead of MicroPython's software fallback. But `rng_get_or_fault()` has no recovery path for the STM32 RNG error flags, so a single seed error latches the peripheral into a state the code can never clear. Every subsequent call times out and raises `OSError(EFAULT)`, forever. Because `rng_get()` is now on the keypad scan path, which runs from an IRQ callback before login, that exception is not survivable by the user.

---

## 1. What changed

Before the hotfix, with `MICROPY_HW_ENABLE_RNG (0)`, `rng_get()` linked to the `#else` branch of `ports/stm32/rng.c` — a pure software Yasmarang PRNG. It touched no hardware and **could not fail**.

After the hotfix, `stm32/rng.o` is compiled from `/dev/null` and `rng_get()` resolves to:

```c
uint32_t rng_get(void) { return rng_get_or_fault(); }
```

which reads the hardware TRNG and calls `mp_raise_OSError(MP_EFAULT)` on a 10 ms timeout.

This is the right direction. The problem is what happens when the TRNG hiccups.

## 2. The peripheral is never recovered

```c
static void rng_init(void) {
    if (!(RNG->CR & RNG_CR_RNGEN)) {
        __HAL_RCC_RNG_CLK_ENABLE();
        RNG->CR |= RNG_CR_RNGEN;
        // TODO: throw out some samples?
    }
}
```

Per RM0432 §25.3.7 (and RM0351 for the Mk3's L4):

- On a seed error, `SECS` is set and `SEIS` latches. `DRDY` stops asserting.
- **`RNGEN` stays set.** Recovery requires clearing `SEIS` *and then* toggling `RNGEN` off→on.

`rng_init()` only tests `RNGEN`, so in the faulted state it is a no-op. `rng_get_or_fault()` then busy-waits 10 ms and throws — on every call, indefinitely, across reboots of the Python layer.

Two secondary issues in the same function:

- The reference manual says the first word after enabling may be invalid; the `// TODO: throw out some samples?` was never done.
- `RNG->DR` is read without checking whether `SEIS`/`CEIS` latched while waiting, so a suspect word can be returned as good.

## 3. Why this is not survivable

`rng_get()` is now reached from the keypad scan-order shuffle:

```
mempad.py / keyboard.py :: _start_scan()
  -> shuffle(self.scan_order)          # "We scan in random order, because Tempest."
  -> random.randbelow  ->  ngu.random.uniform
  -> _rand_below()  ->  CHIP_TRNG_32()  ->  rng_get()
```

`_start_scan()` is called from `anypress_irq`, a `Pin.irq` callback, at up to 60 Hz, and it runs **before login**. Three or more TRNG reads per keypress, each with a 10 ms worst case, in IRQ context.

An `OSError` there reaches `IMPT.handle_exc` → `die_with_debug` → `ux.show_fatal_error` + `callgate.show_logout(1)`. The user gets an error screen and cannot enter a PIN — so they cannot reach the upgrade menu either. That matches the "stuck on error screen / won't boot" reports following the hotfix.

Note that scan-order randomisation is anti-Tempest hygiene, not a secret. It does not need cryptographic quality and should never be able to take the device down.

## 4. Reproduction

`rng-testbench.c` (attached) mocks `RNG_CR` / `RNG_SR` / `RNG_DR` with the documented flag semantics (`SEIS`/`CEIS` sticky until software clears them; `SECS`/`CECS` read-only, cleared by hardware when the condition ends) and runs both the shipped and the patched `rng_get()`.

```
$ gcc -O1 -o rng-testbench rng-testbench.c && ./rng-testbench

== A. nominal hardware ==
  shipped                                  : ok (1000 calls)
  PATCHED                                  : ok (1000 calls)

== B. transient seed error, then back to normal ==
  shipped (during glitch)                  : RAISED OSError_EFAULT
  shipped (after glitch)                   : RAISED OSError_EFAULT
      RNGEN=1 SEIS=1
  PATCHED (during glitch)                  : RAISED OSError_EFAULT
  PATCHED (after glitch)                   : ok (50 calls)
      RNGEN=1 SEIS=0

== C. hard failure (48MHz PLLSAI1 clock absent) ==
  PATCHED (must still raise)               : RAISED OSError_EFAULT

== D. glitch 1-in-5, 5000 reads ==
  PATCHED : 1000 exceptions / 5000
  shipped : 5000 exceptions / 5000
```

Case B is the bug: the shipped code stays dead after the fault condition is gone. Case C confirms the patch does not trade robustness for degraded entropy — a genuine hardware failure still raises rather than silently falling back.

## 5. Proposed fix

`coldcard-rng-antibrick.patch` (attached, applies cleanly to `master`), 4 files:

**`stm32/COLDCARD_MK4/rng.c` and `stm32/COLDCARD/rng.c`**

- `rng_reset()`: enable clock, clear `RNGEN`, clear `SEIS`/`CEIS`, set `RNGEN`, discard the first word.
- `rng_init()`: trigger a reset when `RNGEN` is clear **or** any error flag is set.
- `rng_try_once()`: non-throwing single attempt; refuses the word if an error latched during the wait.
- `rng_get_or_fault()`: up to `RNG_MAX_ATTEMPTS` (3), resetting between attempts, then raise as before.

No change to the throw-on-persistent-failure contract, and no fallback to software entropy.

**`shared/mempad.py` and `shared/keyboard.py`**

Wrap `shuffle(self.scan_order)` in `try/except`. Defence in depth: an RNG fault should degrade the Tempest mitigation, not brick the device at the login screen.

## 6. Caveats

- Register behaviour was validated against a mock built from RM0432/RM0351, not against silicon. The `SEIS`-sticky recovery sequence is documented, but the patch should be confirmed on a real Mk4/Q before merging.
- This is preventive only. It does not recover devices that are already stuck.
- I have not been able to confirm the field reports independently; the causal chain above is derived from the source, not from a device I bricked.

---

## 7. Notes on this PR

Issues are disabled on this repo, so this is filed as a PR — but treat it as a
report first and a patch second. The diff is 4 files, +166/-36, and I have not
been able to test it on silicon, so please do not merge on my word alone.

Supporting material is kept off this branch so the change stays surgical:
**`rng-fault-analysis`** carries the writeup, the standalone testbench and the
diff under `docs/rng-fault-analysis/` —
https://github.com/Silexperience210/firmware/tree/rng-fault-analysis

If you would rather handle this privately given the timing, say so and I will
close this and resend to your security contact.
