### PR TITLE
bugfix: detect RNG_SR_SEIS and RNG_SR_SECS, retry safely, and fail cl…

### DIFF
--- a/releases/Next-ChangeLog.md
+++ b/releases/Next-ChangeLog.md
@@ -4,7 +4,7 @@ This lists the new changes that have not yet been published in a normal release.
 
 # Shared Improvements - Both Mk and Q
 
-- tbd
+- Bugfix: Detect RNG_SR_SEIS and RNG_SR_SECS, retry safely, and fail closed on persistent faults.
 
 # Mk Specific Changes
 

--- a/shared/keyboard.py
+++ b/shared/keyboard.py
@@ -97,7 +97,12 @@ class FullKeyboard(NumpadBase):
     def _start_scan(self):
         # reset and re-start scanning keys
         self.lp_time = utime.ticks_ms()
-        shuffle(self.scan_order)
+        try:
+            shuffle(self.scan_order)
+        except OSError:
+            # An RNG fault may reduce scan-order randomization, but must not
+            # prevent the keyboard from accepting input before login.
+            pass
 
         self._scan_count = 0
         self.waiting_for_any = False

--- a/shared/mempad.py
+++ b/shared/mempad.py
@@ -81,7 +81,12 @@ class MembraneNumpad(NumpadBase):
         # reset and re-start scanning keys
         self.waiting_for_any = False
         self.lp_time = utime.ticks_ms()
-        shuffle(self.scan_order)
+        try:
+            shuffle(self.scan_order)
+        except OSError:
+            # An RNG fault may reduce scan-order randomization, but must not
+            # leave the keypad disabled before the user can log in.
+            pass
 
         self._scan_count = 0
         self._history = bytearray(NUM_ROWS * NUM_COLS)

--- a/stm32/COLDCARD_MK4/rng.c
+++ b/stm32/COLDCARD_MK4/rng.c
@@ -31,6 +31,7 @@
  */
 
 #include <string.h>
+#include <stdbool.h>
 
 #include "py/obj.h"
 #include "py/runtime.h"
@@ -46,36 +47,81 @@ void random_buffer(uint8_t *p, size_t count);
 static void rng_init(void) {
     if (!(RNG->CR & RNG_CR_RNGEN)) {
         __HAL_RCC_RNG_CLK_ENABLE();
-
         RNG->CR |= RNG_CR_RNGEN;
-
-        // TODO: throw out some samples?
     }
 }
 
-
-#define RNG_TIMEOUT_MS (10)
+#define RNG_TIMEOUT_MS      (10)
+#define RNG_MAX_ATTEMPTS    (3)
+#define RNG_SEED_ERROR_MASK (RNG_SR_SEIS | RNG_SR_SECS)
 
 static uint32_t last_value;
 
-static uint32_t rng_get_or_fault(void)
+// Recover from a seed error.
+static void rng_recover(void)
 {
-    // Enable the RNG peripheral if it's not already enabled
-    rng_init();
+    // Ensure the peripheral is clocked before touching its registers.
+    __HAL_RCC_RNG_CLK_ENABLE();
 
-    // Wait for a new random number to be ready, takes on the order of 10us
+    // Clear sticky SEIS, then cycle RNGEN per the STM32L4 recovery sequence.
+    RNG->SR &= ~RNG_SR_SEIS;
+    RNG->CR &= ~RNG_CR_RNGEN;
+    RNG->CR |= RNG_CR_RNGEN;
+}
+
+// Make one bounded attempt to obtain a trustworthy, non-zero word.
+static bool rng_try_once(uint32_t *value)
+{
     uint32_t start = HAL_GetTick();
 
-    while (!(RNG->SR & RNG_SR_DRDY)) {
+    // Seed errors can suppress DRDY, so check for them while polling.
+    while (1) {
+        uint32_t sr = RNG->SR;
+
+        if (sr & RNG_SEED_ERROR_MASK) {
+            return false;
+        }
+
+        if (sr & RNG_SR_DRDY) {
+            break;
+        }
+
         if (HAL_GetTick() - start >= RNG_TIMEOUT_MS) {
-            // hardware failure... do not return anything!
-            mp_raise_OSError(MP_EFAULT);
+            return false;
         }
     }
 
-    // Get and return the new random number
-    last_value = RNG->DR;
+    uint32_t sample = RNG->DR;
 
+    // Recheck after reading DR to close the polling race; zero is also suspect.
+    if (!sample || (RNG->SR & RNG_SEED_ERROR_MASK)) {
+        return false;
+    }
+
+    *value = sample;
+    return true;
+}
+
+static uint32_t rng_get_or_fault(void)
+{
+    rng_init();
+
+    // Retry transient failures, recovering only between attempts.
+    for (int attempt = 0; attempt < RNG_MAX_ATTEMPTS; attempt++) {
+        uint32_t value;
+
+        if (rng_try_once(&value)) {
+            last_value = value;
+            return last_value;
+        }
+
+        if (attempt + 1 < RNG_MAX_ATTEMPTS) {
+            rng_recover();
+        }
+    }
+
+    // Persistent hardware failure: never return suspect randomness.
+    mp_raise_OSError(MP_EFAULT);
     return last_value;
 }
 

--- a/stm32/COLDCARD_MK4/rng.c
+++ b/stm32/COLDCARD_MK4/rng.c
@@ -53,6 +53,13 @@ static void rng_init(void) {
 
 #define RNG_TIMEOUT_MS      (10)
 #define RNG_MAX_ATTEMPTS    (3)
+
+// Clock-error flags (CEIS/CECS) are intentionally ignored: per RM0432
+// section 32.3.7, "the clock error has no impact on generated random
+// numbers", and ST's errata (ES0250/ES0335) confirm a clock error neither
+// stops generation nor invalidates RNG_DR when DRDY is set. A dead clock
+// still fails closed via the DRDY timeout below. CEIS is left set on
+// purpose: clearing it is a no-op while RNG interrupts stay disabled.
 #define RNG_SEED_ERROR_MASK (RNG_SR_SEIS | RNG_SR_SECS)
 
 static uint32_t last_value;

--- a/stm32/COLDCARD_MK4/rng.c
+++ b/stm32/COLDCARD_MK4/rng.c
@@ -70,10 +70,29 @@ static void rng_recover(void)
     // Ensure the peripheral is clocked before touching its registers.
     __HAL_RCC_RNG_CLK_ENABLE();
 
-    // Clear sticky SEIS, then cycle RNGEN per the STM32L4 recovery sequence.
+    // Clear sticky SEIS and cycle RNGEN (ST HAL recommendation).
     RNG->SR &= ~RNG_SR_SEIS;
     RNG->CR &= ~RNG_CR_RNGEN;
     RNG->CR |= RNG_CR_RNGEN;
+
+    // RM0432 32.3.7: after clearing SEIS, read out 12 words from RNG_DR and
+    // discard each of them to clean the pipeline of pre-error residue.
+    // Bounded: if the error recurs or DRDY stops arriving, bail out and let
+    // the next attempt's flag checks and DRDY timeout handle it.
+    for (int i = 0; i < 12; i++) {
+        uint32_t start = HAL_GetTick();
+
+        while (!(RNG->SR & RNG_SR_DRDY)) {
+            if (RNG->SR & RNG_SEED_ERROR_MASK) {
+                return;
+            }
+            if (HAL_GetTick() - start >= RNG_TIMEOUT_MS) {
+                return;
+            }
+        }
+
+        (void)RNG->DR;
+    }
 }
 
 // Make one bounded attempt to obtain a trustworthy, non-zero word.

--- a/stm32/mk4-bootloader/rng.c
+++ b/stm32/mk4-bootloader/rng.c
@@ -6,7 +6,21 @@
 #include "basics.h"
 #include "stm32l4xx_hal.h"
 
+#define RNG_MAX_ATTEMPTS (3)
+#define RNG_SEED_ERROR_MASK (RNG_SR_SEIS | RNG_SR_SECS)
 
+// Recover from a seed error.
+static void
+rng_recover(void)
+{
+    // Ensure the peripheral is clocked before touching its registers.
+    __HAL_RCC_RNG_CLK_ENABLE();
+
+    // Clear sticky SEIS, then cycle RNGEN per the STM32L4 recovery sequence.
+    RNG->SR &= ~RNG_SR_SEIS;
+    RNG->CR &= ~RNG_CR_RNGEN;
+    RNG->CR |= RNG_CR_RNGEN;
+}
 
 // rng_setup()
 //
@@ -47,25 +61,43 @@ rng_sample(void)
 {
     static uint32_t last_rng_result;
 
-    while(1) {
-        // Check if data register contains valid random data
-        while(!(RNG->SR & RNG_FLAG_DRDY)) {
-            // busy wait; okay to get stuck here... better than failing.
+    // Attempts bound seed-error recovery; DRDY polling remains intentionally unbounded.
+    for(int attempt = 0; attempt < RNG_MAX_ATTEMPTS; attempt++) {
+        while(1) {
+            uint32_t sr = RNG->SR;
+
+            if(sr & RNG_SEED_ERROR_MASK) {
+                break;
+            }
+
+            if(!(sr & RNG_FLAG_DRDY)) {
+                // Missing clocks are a hard failure. Preserve the existing
+                // fail-closed behaviour and wait rather than use bad data.
+                continue;
+            }
+
+            uint32_t rv = RNG->DR;
+
+            // Recheck after reading DR to close the documented polling race.
+            if(RNG->SR & RNG_SEED_ERROR_MASK) {
+                break;
+            }
+
+            if(rv != last_rng_result && rv) {
+                last_rng_result = rv;
+
+                return rv;
+            }
+
+            // Zero or repeat: poll for another word without consuming an attempt.
         }
 
-        // Get the new number
-        uint32_t rv = RNG->DR;
-
-        if(rv != last_rng_result && rv) {
-            last_rng_result = rv;
-
-            return rv;
+        if(attempt + 1 < RNG_MAX_ATTEMPTS) {
+            rng_recover();
         }
-
-        // keep trying if not a new number
     }
 
-    // NOT-REACHED
+    fatal_error("rng");
 }
 
 // rng_buffer()

--- a/stm32/mk4-bootloader/rng.c
+++ b/stm32/mk4-bootloader/rng.c
@@ -24,10 +24,22 @@ rng_recover(void)
     // Ensure the peripheral is clocked before touching its registers.
     __HAL_RCC_RNG_CLK_ENABLE();
 
-    // Clear sticky SEIS, then cycle RNGEN per the STM32L4 recovery sequence.
+    // Clear sticky SEIS and cycle RNGEN (ST HAL recommendation).
     RNG->SR &= ~RNG_SR_SEIS;
     RNG->CR &= ~RNG_CR_RNGEN;
     RNG->CR |= RNG_CR_RNGEN;
+
+    // RM0432 32.3.7: discard 12 words to clean the pipeline. The DRDY wait
+    // stays unbounded like rng_sample(): a dead clock remains a hard
+    // fail-closed wait; a recurring seed error bails to the next attempt.
+    for(int i = 0; i < 12; i++) {
+        while(!(RNG->SR & RNG_FLAG_DRDY)) {
+            if(RNG->SR & RNG_SEED_ERROR_MASK) {
+                return;
+            }
+        }
+        (void)RNG->DR;
+    }
 }
 
 // rng_setup()

--- a/stm32/mk4-bootloader/rng.c
+++ b/stm32/mk4-bootloader/rng.c
@@ -7,6 +7,14 @@
 #include "stm32l4xx_hal.h"
 
 #define RNG_MAX_ATTEMPTS (3)
+
+// Clock-error flags (CEIS/CECS) are intentionally ignored: per RM0432
+// section 32.3.7, "the clock error has no impact on generated random
+// numbers", and ST's errata (ES0250/ES0335) confirm a clock error neither
+// stops generation nor invalidates RNG_DR when DRDY is set. A dead clock
+// still fails closed via the intentionally unbounded DRDY wait below.
+// CEIS is left set on purpose: clearing it is a no-op while RNG interrupts
+// stay disabled.
 #define RNG_SEED_ERROR_MASK (RNG_SR_SEIS | RNG_SR_SECS)
 
 // Recover from a seed error.


### PR DESCRIPTION
Compared with #692, this branch is a safer. It follows the documented STM32L4 recovery sequence, validates RNG status both before and after reading data, rejects suspect zero samples, uses bounded retries, catches only the expected keypad OSError, and applies the same protection to the shared Mk4/Q1 bootloader. 

Mk3 support is intentionally deferred to a separate PR.