### PR TITLE
bugfix: Mk3 Detect RNG_SR_SEIS and RNG_SR_SECS, retry safely, and fail closed on persistent faults.

### DIFF
--- a/releases/ChangeLog.md
+++ b/releases/ChangeLog.md
@@ -1,3 +1,24 @@
+## 4.2.1 - TBD
+
+- Bugfix: Detect RNG_SR_SEIS and RNG_SR_SECS, retry safely, and fail closed on persistent faults.
+
+## 4.2.0 - Jul 31, 2026
+
+**Urgent hotfix to correct a limited entropy bug**
+
+Please regenerate seeds only with this new version of the firmware and any
+later updates from today onwards.
+
+**Mk3 users must regenerate any seeds** made on earlier versions
+as their entropy is critically low at just ~40 bits.
+
+On **Mk4, Mk5 and Q entropy** may be as low as ~72 bits. This is
+well below our target of 128 bits.
+
+Follow the steps listed in
+[our blog announcement](https://blog.coinkite.com/coldcard-mk3-seed-generation-warning/)
+to be safe, and please be careful not to cut corners or rush this process.
+
 ## 4.1.9 - Jun 26, 2023
 
 - Bugfix: QR codes could not be rendered in 4.1.8 release due to a regression.

--- a/shared/mempad.py
+++ b/shared/mempad.py
@@ -77,7 +77,12 @@ class MembraneNumpad(NumpadBase):
         # reset and re-start scanning keys
         self.waiting_for_any = False
         self.lp_time = utime.ticks_ms()
-        shuffle(self.scan_order)
+        try:
+            shuffle(self.scan_order)
+        except OSError:
+            # An RNG fault may reduce scan-order randomization, but must not
+            # leave the keypad disabled before the user can log in.
+            pass
 
         self._scan_count = 0
         self._history = bytearray(NUM_ROWS * NUM_COLS)

--- a/stm32/COLDCARD/rng.c
+++ b/stm32/COLDCARD/rng.c
@@ -31,6 +31,7 @@
  */
 
 #include <string.h>
+#include <stdbool.h>
 
 #include "py/obj.h"
 #include "py/runtime.h"
@@ -46,36 +47,81 @@ void random_buffer(uint8_t *p, size_t count);
 static void rng_init(void) {
     if (!(RNG->CR & RNG_CR_RNGEN)) {
         __HAL_RCC_RNG_CLK_ENABLE();
-
         RNG->CR |= RNG_CR_RNGEN;
-
-        // TODO: throw out some samples?
     }
 }
 
-
-#define RNG_TIMEOUT_MS (10)
+#define RNG_TIMEOUT_MS      (10)
+#define RNG_MAX_ATTEMPTS    (3)
+#define RNG_SEED_ERROR_MASK (RNG_SR_SEIS | RNG_SR_SECS)
 
 static uint32_t last_value;
 
-static uint32_t rng_get_or_fault(void)
+// Recover from a seed error.
+static void rng_recover(void)
 {
-    // Enable the RNG peripheral if it's not already enabled
-    rng_init();
+    // Ensure the peripheral is clocked before touching its registers.
+    __HAL_RCC_RNG_CLK_ENABLE();
 
-    // Wait for a new random number to be ready, takes on the order of 10us
+    // Clear sticky SEIS, then cycle RNGEN per the STM32L4 recovery sequence.
+    RNG->SR &= ~RNG_SR_SEIS;
+    RNG->CR &= ~RNG_CR_RNGEN;
+    RNG->CR |= RNG_CR_RNGEN;
+}
+
+// Make one bounded attempt to obtain a trustworthy, non-zero word.
+static bool rng_try_once(uint32_t *value)
+{
     uint32_t start = HAL_GetTick();
 
-    while (!(RNG->SR & RNG_SR_DRDY)) {
+    // Seed errors can suppress DRDY, so check for them while polling.
+    while (1) {
+        uint32_t sr = RNG->SR;
+
+        if (sr & RNG_SEED_ERROR_MASK) {
+            return false;
+        }
+
+        if (sr & RNG_SR_DRDY) {
+            break;
+        }
+
         if (HAL_GetTick() - start >= RNG_TIMEOUT_MS) {
-            // hardware failure... do not return anything!
-            mp_raise_OSError(MP_EFAULT);
+            return false;
         }
     }
 
-    // Get and return the new random number
-    last_value = RNG->DR;
+    uint32_t sample = RNG->DR;
 
+    // Recheck after reading DR to close the polling race; zero is also suspect.
+    if (!sample || (RNG->SR & RNG_SEED_ERROR_MASK)) {
+        return false;
+    }
+
+    *value = sample;
+    return true;
+}
+
+static uint32_t rng_get_or_fault(void)
+{
+    rng_init();
+
+    // Retry transient failures, recovering only between attempts.
+    for (int attempt = 0; attempt < RNG_MAX_ATTEMPTS; attempt++) {
+        uint32_t value;
+
+        if (rng_try_once(&value)) {
+            last_value = value;
+            return last_value;
+        }
+
+        if (attempt + 1 < RNG_MAX_ATTEMPTS) {
+            rng_recover();
+        }
+    }
+
+    // Persistent hardware failure: never return suspect randomness.
+    mp_raise_OSError(MP_EFAULT);
     return last_value;
 }
 

--- a/stm32/COLDCARD/rng.c
+++ b/stm32/COLDCARD/rng.c
@@ -53,6 +53,13 @@ static void rng_init(void) {
 
 #define RNG_TIMEOUT_MS      (10)
 #define RNG_MAX_ATTEMPTS    (3)
+
+// Clock-error flags (CEIS/CECS) are intentionally ignored: per RM0351
+// section 27.3.7, "the clock error has no impact on generated random
+// numbers", and ST's L476 errata (ES0250) confirm a clock error neither
+// stops generation nor invalidates RNG_DR when DRDY is set. A dead clock
+// still fails closed via the DRDY timeout below. CEIS is left set on
+// purpose: clearing it is a no-op while RNG interrupts stay disabled.
 #define RNG_SEED_ERROR_MASK (RNG_SR_SEIS | RNG_SR_SECS)
 
 static uint32_t last_value;

--- a/stm32/COLDCARD/rng.c
+++ b/stm32/COLDCARD/rng.c
@@ -70,7 +70,9 @@ static void rng_recover(void)
     // Ensure the peripheral is clocked before touching its registers.
     __HAL_RCC_RNG_CLK_ENABLE();
 
-    // Clear sticky SEIS, then cycle RNGEN per the STM32L4 recovery sequence.
+    // RM0351 27.3.7 recovery in full: clear sticky SEIS, then cycle RNGEN to
+    // reinitialize and restart the RNG. Unlike RM0432 (L4R/S), no pipeline
+    // flush is prescribed here.
     RNG->SR &= ~RNG_SR_SEIS;
     RNG->CR &= ~RNG_CR_RNGEN;
     RNG->CR |= RNG_CR_RNGEN;

--- a/stm32/bootloader/rng.c
+++ b/stm32/bootloader/rng.c
@@ -6,6 +6,22 @@
 #include "basics.h"
 #include "stm32l4xx_hal.h"
 
+#define RNG_MAX_ATTEMPTS (3)
+#define RNG_SEED_ERROR_MASK (RNG_SR_SEIS | RNG_SR_SECS)
+
+// Recover from a seed error.
+static void
+rng_recover(void)
+{
+    // Ensure the peripheral is clocked before touching its registers.
+    __HAL_RCC_RNG_CLK_ENABLE();
+
+    // Clear sticky SEIS, then cycle RNGEN per the STM32L4 recovery sequence.
+    RNG->SR &= ~RNG_SR_SEIS;
+    RNG->CR &= ~RNG_CR_RNGEN;
+    RNG->CR |= RNG_CR_RNGEN;
+}
+
 // rng_setup()
 //
     void
@@ -45,25 +61,43 @@ rng_sample(void)
 {
     static uint32_t last_rng_result;
 
-    while(1) {
-        // Check if data register contains valid random data
-        while(!(RNG->SR & RNG_FLAG_DRDY)) {
-            // busy wait; okay to get stuck here... better than failing.
+    // Attempts bound seed-error recovery; DRDY polling remains intentionally unbounded.
+    for(int attempt = 0; attempt < RNG_MAX_ATTEMPTS; attempt++) {
+        while(1) {
+            uint32_t sr = RNG->SR;
+
+            if(sr & RNG_SEED_ERROR_MASK) {
+                break;
+            }
+
+            if(!(sr & RNG_FLAG_DRDY)) {
+                // Missing clocks are a hard failure. Preserve the existing
+                // fail-closed behaviour and wait rather than use bad data.
+                continue;
+            }
+
+            uint32_t rv = RNG->DR;
+
+            // Recheck after reading DR to close the documented polling race.
+            if(RNG->SR & RNG_SEED_ERROR_MASK) {
+                break;
+            }
+
+            if(rv != last_rng_result && rv) {
+                last_rng_result = rv;
+
+                return rv;
+            }
+
+            // Zero or repeat: poll for another word without consuming an attempt.
         }
 
-        // Get the new number
-        uint32_t rv = RNG->DR;
-
-        if(rv != last_rng_result && rv) {
-            last_rng_result = rv;
-
-            return rv;
+        if(attempt + 1 < RNG_MAX_ATTEMPTS) {
+            rng_recover();
         }
-
-        // keep trying if not a new number
     }
 
-    // NOT-REACHED
+    fatal_error("rng");
 }
 
 // rng_buffer()


### PR DESCRIPTION
* added forgotten changelog