### PR TITLE
Mk3: RNG self-test proving rng_get() enter the hardware read path

### DIFF
--- a/releases/ChangeLog.md
+++ b/releases/ChangeLog.md
@@ -1,6 +1,7 @@
 ## 4.2.1 - TBD
 
 - Bugfix: Detect RNG_SR_SEIS and RNG_SR_SECS, retry safely, and fail closed on persistent faults.
+- Enhancement: RNG self-test proving rng_get() enter the hardware read path. Brick device otherwise.
 
 ## 4.2.0 - Jul 31, 2026
 

--- a/shared/main.py
+++ b/shared/main.py
@@ -26,6 +26,12 @@ if 0:
 
 print("---\nColdcard Wallet from Coinkite Inc. (c) 2018-2021.\n")
 
+# boot-time RNG linkage self-test passed (device hard-faults otherwise);
+# printed here because the serial console has no sink earlier in boot
+import ckcc
+if hasattr(ckcc, 'rng_ok') and ckcc.rng_ok():
+    print("RNG selftest: PASS")
+
 # Setup OLED and get something onto it.
 from display import Display
 dis = Display()

--- a/stm32/COLDCARD/modckcc.c
+++ b/stm32/COLDCARD/modckcc.c
@@ -186,6 +186,14 @@ STATIC mp_obj_t is_stm32l496(void)
 }
 MP_DEFINE_CONST_FUN_OBJ_0(is_stm32l496_obj, is_stm32l496);
 
+/// \function rng_ok()
+/// True if the boot-time RNG linkage self-test ran and passed.
+STATIC mp_obj_t rng_ok(void)
+{
+    return mp_obj_new_bool(rng_boot_selftest_ok);
+}
+MP_DEFINE_CONST_FUN_OBJ_0(rng_ok_obj, rng_ok);
+
 
 
 STATIC mp_obj_t vcp_enabled(mp_obj_t new_val)
@@ -262,6 +270,7 @@ STATIC const mp_rom_map_elem_t ckcc_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_oneway),              MP_ROM_PTR(&sec_oneway_gate_obj) },
     { MP_ROM_QSTR(MP_QSTR_is_simulator),        MP_ROM_PTR(&is_simulator_obj) },
     { MP_ROM_QSTR(MP_QSTR_is_stm32l496),        MP_ROM_PTR(&is_stm32l496_obj) },
+    { MP_ROM_QSTR(MP_QSTR_rng_ok),              MP_ROM_PTR(&rng_ok_obj) },
     { MP_ROM_QSTR(MP_QSTR_vcp_enabled),         MP_ROM_PTR(&vcp_enabled_obj) },
     { MP_ROM_QSTR(MP_QSTR_wipe_fs),             MP_ROM_PTR(&wipe_fs_obj) },
     { MP_ROM_QSTR(MP_QSTR_presume_green),       MP_ROM_PTR(&presume_green_obj) },
@@ -282,6 +291,10 @@ MP_REGISTER_MODULE(MP_QSTR_ckcc, ckcc_module, 1);
 void ckcc_early_init(void)
 {
     // Add system-wide init code here.
+
+    // Prove rng_get() is wired to the hardware TRNG before anything can
+    // consume entropy; hard-faults (no boot) otherwise.
+    rng_selftest();
 
     // Disable ^C to interrupt code.
     // cannot find where this might be set by other code to ^C.

--- a/stm32/COLDCARD/modckcc.c
+++ b/stm32/COLDCARD/modckcc.c
@@ -270,7 +270,7 @@ STATIC const mp_rom_map_elem_t ckcc_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_oneway),              MP_ROM_PTR(&sec_oneway_gate_obj) },
     { MP_ROM_QSTR(MP_QSTR_is_simulator),        MP_ROM_PTR(&is_simulator_obj) },
     { MP_ROM_QSTR(MP_QSTR_is_stm32l496),        MP_ROM_PTR(&is_stm32l496_obj) },
-    { MP_ROM_QSTR(MP_QSTR_rng_ok),              MP_ROM_PTR(&rng_ok_obj) },
+    { MP_ROM_QSTR(MP_QSTR_rng_ok),               MP_ROM_PTR(&rng_ok_obj) },
     { MP_ROM_QSTR(MP_QSTR_vcp_enabled),         MP_ROM_PTR(&vcp_enabled_obj) },
     { MP_ROM_QSTR(MP_QSTR_wipe_fs),             MP_ROM_PTR(&wipe_fs_obj) },
     { MP_ROM_QSTR(MP_QSTR_presume_green),       MP_ROM_PTR(&presume_green_obj) },

--- a/stm32/COLDCARD/rng.c
+++ b/stm32/COLDCARD/rng.c
@@ -175,6 +175,7 @@ void rng_selftest(void)
         }
     }
 
+    rng_count = 0;
     rng_count_active = true;
 
     // discard these warm-up words; not exposed anywhere

--- a/stm32/COLDCARD/rng.c
+++ b/stm32/COLDCARD/rng.c
@@ -48,6 +48,8 @@ static void rng_init(void) {
     if (!(RNG->CR & RNG_CR_RNGEN)) {
         __HAL_RCC_RNG_CLK_ENABLE();
         RNG->CR |= RNG_CR_RNGEN;
+
+        // first samples after enable are discarded by rng_selftest() at boot
     }
 }
 
@@ -63,6 +65,14 @@ static void rng_init(void) {
 #define RNG_SEED_ERROR_MASK (RNG_SR_SEIS | RNG_SR_SECS)
 
 static uint32_t last_value;
+
+// Counting is armed only by rng_selftest() for a few words at boot, then
+// disabled permanently. Not exposed anywhere (no Python, no USB).
+static bool rng_count_active;
+static uint32_t rng_count;
+
+// Set when rng_selftest() passes; read-only proof the check ran.
+bool rng_boot_selftest_ok;
 
 // Recover from a seed error.
 static void rng_recover(void)
@@ -121,6 +131,7 @@ static uint32_t rng_get_or_fault(void)
 
         if (rng_try_once(&value)) {
             last_value = value;
+            if (rng_count_active) rng_count++;
             return last_value;
         }
 
@@ -137,6 +148,53 @@ static uint32_t rng_get_or_fault(void)
 uint32_t rng_get(void)
 {
     return rng_get_or_fault();
+}
+
+// rng_selftest()
+//
+// Boot-time proof that rng_get() -- the exact symbol libngu's
+// CHIP_TRNG_32() and the rest of the firmware's entropy consumers link
+// against -- enters the hardware read path above. Peripheral health
+// itself is enforced per-call by rng_get_or_fault(); here we only check
+// linkage. Runs before the Python VM exists, so failure is fatal.
+//
+extern void __fatal_error(const char *msg);     // NORETURN, ports/stm32/main.c
+
+void rng_selftest(void)
+{
+    rng_init();
+
+    // Wait at register level for the first word: proves entropy is flowing,
+    // and guarantees the rng_get() calls below find DRDY set and can never
+    // reach their mp_raise() timeout path (no VM/nlr handler installed
+    // yet, so an exception here would be an uncontrolled crash).
+    uint32_t start = HAL_GetTick();
+    while(!(RNG->SR & RNG_SR_DRDY)) {
+        if(HAL_GetTick() - start >= RNG_TIMEOUT_MS) {
+            __fatal_error("rng: no entropy");
+        }
+    }
+
+    rng_count_active = true;
+
+    // discard these warm-up words; not exposed anywhere
+    for(int i = 0; i < 8; i++) {
+        (void)rng_get();
+    }
+
+    rng_count_active = false;
+
+    if(rng_count != 8) {
+        // rng_get() did not pass through the hardware read path: it must
+        // have resolved to a non-hardware implementation
+        __fatal_error("rng: bad linkage");
+    }
+
+    // Reaching Python at all proves this passed (failures above are fatal),
+    // but record it so main.py can print "RNG selftest: PASS" once the
+    // console exists (mp_hal_stdout_tx_strn has no attached sink this
+    // early in boot).
+    rng_boot_selftest_ok = true;
 }
 
 /// \function pyb_rng_get()

--- a/stm32/COLDCARD/rng.h
+++ b/stm32/COLDCARD/rng.h
@@ -3,6 +3,9 @@
  */
 #pragma once
 
+#include <stdbool.h>
+#include <stdint.h>
+
 uint32_t rng_get(void);
 
 // Boot-time self-test: hard-faults unless rng_get() verifiably passes

--- a/stm32/COLDCARD/rng.h
+++ b/stm32/COLDCARD/rng.h
@@ -5,5 +5,12 @@
 
 uint32_t rng_get(void);
 
+// Boot-time self-test: hard-faults unless rng_get() verifiably passes
+// through the hardware read path.
+void rng_selftest(void);
+
+// Set when rng_selftest() passes at boot.
+extern bool rng_boot_selftest_ok;
+
 MP_DECLARE_CONST_FUN_OBJ_0(pyb_rng_get_obj);
 MP_DECLARE_CONST_FUN_OBJ_1(pyb_rng_get_bytes_obj);


### PR DESCRIPTION
* same as https://github.com/Coldcard/firmware/pull/694 just for Mk3
* requires https://github.com/Coldcard/firmware/pull/695