### PR TITLE
fix: feed full SE hash into ngu.random.reseed

### DIFF
--- a/shared/mk4.py
+++ b/shared/mk4.py
@@ -38,15 +38,15 @@ COLDCARD Virtual Disk
 
 def rng_seeding():
     # seed our RNG with entropy from secure elements
-    import callgate, ngu, ustruct
+    import callgate, ngu
 
     a = callgate.read_rng(1)        # SE1
     b = callgate.read_rng(2)        # SE2
 
-    n = ngu.hash.sha256d(a+b)
-    n, = ustruct.unpack('I', n[0:4])
-
-    ngu.random.reseed(n)
+    # Pass full sha256d digest. Truncating to 32 bits left most SE entropy
+    # on the floor and libngu reseed(int) only overwrote one yasmarang word.
+    # Requires libngu reseed(bytes) support (switck/libngu#65).
+    ngu.random.reseed(ngu.hash.sha256d(a+b))
         
 
 def init0():


### PR DESCRIPTION
## Summary
`rng_seeding()` hashed SE1+SE2 with `sha256d`, then kept only the first 4 bytes for `ngu.random.reseed(int)`. That discarded most SE entropy, and libngu’s integer reseed only overwrote `yasmarang_pad`.

This change passes the full 32-byte digest to `reseed`.

## Dependency
Requires [switck/libngu#65](https://github.com/switck/libngu/pull/65) (`reseed(bytes)` absorbs into full yasmarang state). Integer `reseed` remains for compatibility.

## Test plan
- [ ] Build with updated libngu submodule / vendored tree
- [ ] Boot MK4 / Q1 / simulator — `init0` → `rng_seeding` no exception
- [ ] Confirm `uniform` / seed paths still function

Elacity CodeRED Amber review (portal #52). Related: libngu TRNG retry + Linux getrandom in the same libngu PR (#51/#53).