### PR TITLE
bugfix: harden callgate buffer bounds

### DIFF
--- a/releases/Next-ChangeLog.md
+++ b/releases/Next-ChangeLog.md
@@ -15,6 +15,8 @@ This lists the new changes that have not yet been published in a normal release.
   Thanks to [@instagibbs](https://github.com/instagibbs) for reporting this issue.
 - Bugfix: Fixed PSBT uploads being mistaken for partial firmware uploads.
 - Bugfix: Prevent valid message signatures when using a Delta Mode PIN.
+- Bugfix: Harden callgate buffer validation against integer overflow and out-of-range access,
+  following a finding in the [Karma-X security review](https://karma-x.io/blog/post/75/).
 
 # Mk Specific Changes
 

--- a/stm32/mk4-bootloader/dispatch.c
+++ b/stm32/mk4-bootloader/dispatch.c
@@ -33,6 +33,19 @@
 #include "stm32l4xx_hal.h"
 
 
+// range_is_inside()
+//
+    static bool
+range_is_inside(uint32_t addr, uint32_t len, uint32_t base, uint32_t size)
+{
+    if(addr < base) return false;
+
+    uint32_t offset = addr - base;
+
+    // Subtraction-based bounds checks avoid overflow in addr + len.
+    return (offset < size) && (len <= (size - offset));
+}
+
 // good_addr()
 //
     static int
@@ -40,12 +53,10 @@ good_addr(const uint8_t *b, int minlen, int len, bool readonly)
 {
     uint32_t x = (uint32_t)b;
 
-    if(minlen) {
-        if(!b) return EFAULT;               // gave no buffer
-        if(len < minlen) return ERANGE;     // too small
-    }
-        
-    if((x >= SRAM1_BASE) && ((x+len) <= BL_SRAM_BASE)) {
+    if(!b) return EFAULT;                   // gave no buffer
+    if(len < minlen) return ERANGE;         // too small (also rejects negative lengths)
+
+    if(range_is_inside(x, (uint32_t)len, SRAM1_BASE, BL_SRAM_BASE - SRAM1_BASE)) {
         // ok: it's inside the SRAM areas, up to where we start
         return 0;
     }
@@ -54,7 +65,7 @@ good_addr(const uint8_t *b, int minlen, int len, bool readonly)
         return EPERM;
     }
 
-    if((x >= FIRMWARE_START) && (x - FIRMWARE_START) < FW_MAX_LENGTH_MK4) {
+    if(range_is_inside(x, (uint32_t)len, FIRMWARE_START, FW_MAX_LENGTH_MK4)) {
         // inside flash of main firmware (happens for QSTR's)
         return 0;
     }
@@ -111,7 +122,7 @@ firewall_dispatch(int method_num, uint8_t *buf_io, int len_in,
     // - mpy may provide a pointer to flash if we give it a qstr or small value, and if
     //   we're reading only, that's fine.
 
-    if(len_in > 1024) {     // arbitrary max, increase as needed
+    if((len_in < 0) || (len_in > 1024)) {     // arbitrary max, increase as needed
         rv = ERANGE;
         goto fail;
     }
@@ -565,7 +576,7 @@ firewall_dispatch(int method_num, uint8_t *buf_io, int len_in,
 
         case 25: {
             // mk4: usage of mcu key slots
-            REQUIRE_OUT(8);
+            REQUIRE_OUT(3 * sizeof(uint32_t));
 
             int *avail = (int *)(buf_io+0);
             int *consumed = (int *)(buf_io+4);


### PR DESCRIPTION
## Summary

- validate the complete caller-provided buffer span in the Mk4/Q bootloader callgate
- use subtraction-based bounds checks so address-plus-length arithmetic cannot wrap
- reject negative callgate lengths explicitly
- require the full 12-byte output buffer used by the MCU-key usage method
- document the bugfix in releases/Next-ChangeLog.md

## Security impact

The Mk4/Q SRAM check previously calculated the end address as x + len, which could wrap. Its read-only firmware check validated only the starting address.

The replacement checks first establish a non-negative offset inside the permitted region and then compare the requested length with the remaining region size. No unchecked end-address addition is performed.

This hardening follows the callgate bounds observation discussed in the Karma-X review: https://karma-x.io/blog/post/75/
