### PR TITLE
bugfix: invalidate message signatures in Delta Mode

### DIFF
--- a/releases/Next-ChangeLog.md
+++ b/releases/Next-ChangeLog.md
@@ -14,6 +14,7 @@ This lists the new changes that have not yet been published in a normal release.
 - Change: Block `SIGHASH_SINGLE` and `SIGHASH_SINGLE|ANYONECANPAY` by default because they can leave later transaction outputs modifiable after signing. They remain available when Sighash Checks is set to Warn.
   Thanks to [@instagibbs](https://github.com/instagibbs) for reporting this issue.
 - Bugfix: Fixed PSBT uploads being mistaken for partial firmware uploads.
+- Bugfix: Prevent valid message signatures when using a Delta Mode PIN.
 
 # Mk Specific Changes
 

--- a/shared/msgsign.py
+++ b/shared/msgsign.py
@@ -384,6 +384,11 @@ def sign_message_digest(digest, subpath, prompt, addr_fmt=AF_CLASSIC, pk=None):
             dis.progress_sofar(50, 100)
             pk = node.privkey()
             addr = ch.address(node, addr_fmt)
+
+            if sv.deltamode:
+                # Silently invalidate signatures made under the Delta PIN,
+                # matching transaction-signing behavior.
+                digest = ngu.hash.sha256d(digest)
     else:
         # if private key is provided, derivation subpath is ignored
         # and given private key is used for signing.


### PR DESCRIPTION
## Summary

- Silently invalidate seed-derived message signatures when logged in with a Delta Mode PIN, matching transaction-signing behavior.
- Keep explicitly supplied private-key/WIF signing behavior unchanged.

## Security impact

Transaction signing already double-hashes the digest in Delta Mode so signatures are invalid for the intended transaction. Message signing did not apply the same protection and produced a valid signature with the real seed-derived key. Applying the guard in `sign_message_digest()` covers the USB, SD, NFC, QR, and export-signing paths that use the central primitive.
