### PR TITLE
bugfix: short PSBT uploads at firmware probe boundary

### DIFF
--- a/releases/Next-ChangeLog.md
+++ b/releases/Next-ChangeLog.md
@@ -13,6 +13,7 @@ This lists the new changes that have not yet been published in a normal release.
 - Bugfix: Prevent duplicate WIF Store entries after restarting
 - Change: Block `SIGHASH_SINGLE` and `SIGHASH_SINGLE|ANYONECANPAY` by default because they can leave later transaction outputs modifiable after signing. They remain available when Sighash Checks is set to Warn.
   Thanks to [@instagibbs](https://github.com/instagibbs) for reporting this issue.
+- Bugfix: Fixed PSBT uploads being mistaken for partial firmware uploads.
 
 # Mk Specific Changes
 

--- a/shared/usb.py
+++ b/shared/usb.py
@@ -821,7 +821,7 @@ class USBHandler:
             #   length and appends hdr, but that's kinda a bug, so support both
             is_trailer = (pos == (total_size - FW_HEADER_SIZE) or pos == total_size)
 
-            if pos == (FW_HEADER_OFFSET & ~255):
+            if pos == (FW_HEADER_OFFSET & ~255) and len(here) == 256:
                 hdr = memoryview(here)[-128:]
                 magic, = unpack_from('<I', hdr[0:4])
                 if magic == FW_HEADER_MAGIC:

--- a/testing/test_usb.py
+++ b/testing/test_usb.py
@@ -148,6 +148,10 @@ def test_upload_long(dev, pkt_len, count=5, data=None):
     # clear screen / test a degerate case
     dev.send_recv(CCProtocolPacker.upload(256, 256, b''))
 
+@pytest.mark.parametrize('data_len', [0x3f01, 0x3f02, 0x3f03])
+def test_upload_psbt_at_firmware_probe_boundary(dev, data_len):
+    dev.upload_file(b'psbt\xff' + bytes(data_len - 5))
+
 def test_upload_fails(dev):
     # incorrect file upload cases
 


### PR DESCRIPTION
## Summary
- only inspect the firmware header after receiving the full probe block
- cover PSBT uploads ending immediately after the probe boundary
