### PR TITLE
block SIGHASH_SINGLE by default

### DIFF
--- a/releases/Next-ChangeLog.md
+++ b/releases/Next-ChangeLog.md
@@ -11,6 +11,8 @@ This lists the new changes that have not yet been published in a normal release.
 - Bugfix: BIP-322 message signing now rejects non-ASCII and other unsupported
   message text before approval. Thanks to @KirillCherikov for reporting.
 - Bugfix: Prevent duplicate WIF Store entries after restarting
+- Change: Block `SIGHASH_SINGLE` and `SIGHASH_SINGLE|ANYONECANPAY` by default because they can leave later transaction outputs modifiable after signing. They remain available when Sighash Checks is set to Warn.
+  Thanks to [@instagibbs](https://github.com/instagibbs) for reporting this issue.
 
 # Mk Specific Changes
 

--- a/shared/psbt.py
+++ b/shared/psbt.py
@@ -1725,6 +1725,7 @@ class psbtObject(psbtProxy):
 
         sh_unusual = False
         none_sh = False
+        single_sh = False
 
         for input in self.inputs:
             # only if it is our input - one that will be eventually sign
@@ -1742,6 +1743,8 @@ class psbtObject(psbtProxy):
 
                     if input.sighash in (SIGHASH_NONE, SIGHASH_NONE|SIGHASH_ANYONECANPAY):
                         none_sh = True
+                    elif input.sighash in (SIGHASH_SINGLE, SIGHASH_SINGLE|SIGHASH_ANYONECANPAY):
+                        single_sh = True
 
         if sh_unusual and not settings.get("sighshchk"):
             if self.consolidation_tx:
@@ -1751,6 +1754,9 @@ class psbtObject(psbtProxy):
             if none_sh:
                 # sighash NONE or NONE|ANYONECANPAY is proposed: block
                 raise FatalPSBTIssue("Sighash NONE is not allowed as funds could be going anywhere.")
+
+            if single_sh:
+                raise FatalPSBTIssue("Sighash SINGLE is not allowed as some outputs could be changed.")
 
         if none_sh:
             self.warnings.append(

--- a/testing/test_sign.py
+++ b/testing/test_sign.py
@@ -2333,6 +2333,17 @@ def test_sighash_disallowed_NONE(sighash, _test_single_sig_sighash):
                              consolidation=False, sh_checks=True)
 
 
+@pytest.mark.parametrize("sighash", ["SINGLE", "SINGLE|ANYONECANPAY"])
+def test_sighash_disallowed_SINGLE(sighash, fake_txn, start_sign, end_sign,
+                                   settings_remove):
+    settings_remove("sighshchk")
+    psbt = fake_txn(1, 2, segwit_in=True, change_outputs=[1], sighashes=[sighash])
+    start_sign(psbt, False, stxn_flags=STXN_VISUALIZE)
+    with pytest.raises(Exception) as e:
+        end_sign(accept=None, expect_txn=False)
+    assert "Sighash SINGLE is not allowed as some outputs could be changed" in e.value.args[0]
+
+
 @pytest.mark.bitcoind
 def test_sighash_nonexistent(_test_single_sig_sighash):
     # invalid sighash value


### PR DESCRIPTION
just block it - if someone want to use it - then can disable sighash checks