### PR TITLE
bugfix: separate SE1 check nonce

### DIFF
--- a/releases/Next-ChangeLog.md
+++ b/releases/Next-ChangeLog.md
@@ -55,6 +55,8 @@ This lists the new changes that have not yet been published in a normal release.
   "Transaction modified". Thanks to FreeZ Agent for the report and PoC.
 - Bugfix: Reject duplicate cosigner keys, and cosigner keys the device already holds,
   during multisig wallet enrollment. Thanks to drk1wi for reporting this.
+- Bugfix: Separate the SE1 check nonce from the PIN digest. Thanks to
+  [@instagibbs](https://github.com/instagibbs) for reporting this issue.
 
 # Mk Specific Changes
 

--- a/stm32/mk4-bootloader/se2.c
+++ b/stm32/mk4-bootloader/se2.c
@@ -1195,6 +1195,7 @@ se2_encrypt_secret(const uint8_t secret[], int secret_len, int offset,
 
     if(check_value) {
         // encrypt the check value: 32 zeros
+        nonce[15] = 0x80;       // separate counter range from encrypted secrets
         aes_init(&ctx);
         ctx.num_pending = 32;
         aes_done(&ctx, check_value, 32, aes_key, nonce);
@@ -1239,6 +1240,7 @@ se2_decrypt_secret(uint8_t secret[], int secret_len, int offset,
 
     if(check_value) {
         // decrypt the check value
+        nonce[15] = 0x80;       // separate counter range from encrypted secrets
         aes_init(&ctx);
         aes_add(&ctx, check_value, 32);
         uint8_t got[32];
@@ -1254,6 +1256,7 @@ se2_decrypt_secret(uint8_t secret[], int secret_len, int offset,
     }
 
     // decrypt the real data
+    nonce[15] = offset / AES_BLOCK_SIZE;
     aes_init(&ctx);
     aes_add(&ctx, main_slot, secret_len);
     aes_done(&ctx, secret, secret_len, aes_key, nonce);


### PR DESCRIPTION
needs physical access after you insert PIN 