### PR TITLE
bootloader: reject DFU images longer than signed firmware_length

### DIFF
--- a/stm32/mk4-bootloader/psram.c
+++ b/stm32/mk4-bootloader/psram.c
@@ -308,6 +308,7 @@ psram_recover_firmware(void)
 psram_do_upgrade(const uint8_t *start, uint32_t size)
 {
     ASSERT(size >= FW_MIN_LENGTH);
+    ASSERT(size <= FW_MAX_LENGTH_MK4);
 
     // In case of reset/crash, we can recover, so save
     // what we need for that -- yes, we will re-verify signatures

--- a/stm32/mk4-bootloader/verify.c
+++ b/stm32/mk4-bootloader/verify.c
@@ -253,6 +253,10 @@ verify_firmware_in_ram(const uint8_t *start, uint32_t len, uint8_t world_check[3
     // check basics like verison, hw compat, etc
     if(!verify_header(hdr)) goto fail;
 
+    // Length of data to be flashed must equal the signed length exactly:
+    // anything more is unsigned, attacker-controlled bytes (fail closed).
+    if(len != hdr->firmware_length) goto fail;
+
     if(check_is_downgrade(hdr->timestamp, (const char *)hdr->version_string)) {
         puts("downgrade");
         goto fail;


### PR DESCRIPTION
verify_firmware_in_ram() authenticated only hdr->firmware_length bytes, but the untrusted DFU element length was passed unchecked to psram_do_upgrade(), which flashed that many bytes. Anything appended past the signed length (up to FW_MAX_LENGTH_MK4, which reaches the top of flash and covers the whole internal /flash filesystem) was written to flash without possessing the signing key, e.g. via recovery-mode SD upgrade of the currently-installed signed image.

- verify_firmware_in_ram(): require len == hdr->firmware_length, fail closed on any mismatch
- psram_do_upgrade(): assert size <= FW_MAX_LENGTH_MK4 (defense in depth)

