### PR TITLE
bugfix: WIF Store duplicate detection after restart

### DIFF
--- a/releases/Next-ChangeLog.md
+++ b/releases/Next-ChangeLog.md
@@ -10,6 +10,7 @@ This lists the new changes that have not yet been published in a normal release.
 - Bugfix: Wipe seed in Delta Mode when saved BIP-39 passphrases are listed, instead of revealing them.
 - Bugfix: BIP-322 message signing now rejects non-ASCII and other unsupported
   message text before approval. Thanks to @KirillCherikov for reporting.
+- Bugfix: Prevent duplicate WIF Store entries after restarting
 
 # Mk Specific Changes
 

--- a/shared/wif.py
+++ b/shared/wif.py
@@ -91,7 +91,7 @@ async def ux_visualize_wif(wif_str, kp, compressed, testnet):
     if ch == "1":
         title = "Success"
         try:
-            save_wif_store_items([(pk, sk)])
+            save_wif_store_items([[pk, sk]])
             msg = "Saved to WIF Store."
         except Exception as e:
             title = "Failure"
@@ -359,7 +359,7 @@ class WIFStoreMenu(MenuSystem):
                 sk = b2a_hex(kp.privkey()).decode()
                 pk = b2a_hex(kp.pubkey().to_bytes()).decode()
 
-                new_wifs.append((pk, sk))
+                new_wifs.append([pk, sk])
 
             save_wif_store_items(new_wifs)
 

--- a/testing/test_wif.py
+++ b/testing/test_wif.py
@@ -372,7 +372,7 @@ def test_visualize_wif_store_capacity(is_q1, goto_home, use_testnet, settings_re
 
 
 def test_wif_store_import_duplicate(settings_remove, import_wif_to_store, settings_get, cap_menu, cap_story,
-                                    goto_home):
+                                    goto_home, sim_exec):
     goto_home()
     settings_remove("wifs")
 
@@ -380,7 +380,13 @@ def test_wif_store_import_duplicate(settings_remove, import_wif_to_store, settin
 
     import_wif_to_store(wif_list)
     b4 = cap_menu()
-    assert len(settings_get("wifs")) == 4
+    sim_exec(
+        "import ujson\n"
+        "settings.set('wifs', ujson.loads(ujson.dumps(settings.get('wifs'))))"
+    )
+    saved = settings_get("wifs")
+    assert len(saved) == 4
+    assert all(isinstance(item, list) for item in saved)
 
     import_wif_to_store(wif_list, early_exit=True)
     assert len(settings_get("wifs")) == 4


### PR DESCRIPTION
WIF settings are persisted as JSON arrays. Previously, both import paths created `(pubkey, privkey)` tuples, while a settings reload restored those records as lists. The membership check therefore failed to recognize an already stored WIF after restart.

This creates JSON-native `[pubkey, privkey]` records from the start. The regression performs a device-side `ujson.dumps()`/`ujson.loads()` round-trip before reimporting the same WIFs and confirms that the store remains unchanged.

Also adds the bugfix to `releases/Next-ChangeLog.md`.

Tested:
- `test_wif_store_import_duplicate`