### PR TITLE
Add SECURITY.md with a responsible-disclosure policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,29 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please report security vulnerabilities **privately**. Do not open a public issue
+or pull request describing a suspected vulnerability, as that can expose users
+before a fix is available.
+
+Preferred channels, in order:
+
+1. **GitHub private vulnerability reporting** for this repository
+   (the repository *Security* tab, "Report a vulnerability"). Enabling this gives
+   researchers a private, authenticated channel with no shared inbox.
+2. If that is not available, email the security contact below and, where possible,
+   encrypt the report with the project's PGP key.
+
+- Security contact: `<add address>`
+- PGP key / fingerprint: `<add link or fingerprint>`
+
+## What to include
+
+- A clear description and the steps or materials needed to reproduce the issue.
+- The affected hardware revision(s) and firmware version(s), where relevant.
+
+## Disclosure
+
+Please allow reasonable time for a fix to be prepared and released before any
+public disclosure. Coordinated disclosure is appreciated, and we are grateful to
+researchers who report responsibly.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,16 +6,9 @@ Please report security vulnerabilities **privately**. Do not open a public issue
 or pull request describing a suspected vulnerability, as that can expose users
 before a fix is available.
 
-Preferred channels, in order:
-
-1. **GitHub private vulnerability reporting** for this repository
-   (the repository *Security* tab, "Report a vulnerability"). Enabling this gives
-   researchers a private, authenticated channel with no shared inbox.
-2. If that is not available, email the security contact below and, where possible,
-   encrypt the report with the project's PGP key.
-
-- Security contact: `<add address>`
-- PGP key / fingerprint: `<add link or fingerprint>`
+Email security@coinkite.com, following the
+[responsible disclosure policy](https://coinkite.com/responsible-disclosure)
+(PGP: start with a cleartext message containing your public key).
 
 ## What to include
 


### PR DESCRIPTION
This repository does not currently define a security policy (GitHub shows "This project has not set up a SECURITY.md file yet"), so this adds a short SECURITY.md describing how to report vulnerabilities. I am also opening it for a practical reason: I have a security matter I would like to report responsibly, and I could not find a published disclosure channel. @doc-hex @scgbckbone could you point me to a secure contact, or enable GitHub's private vulnerability reporting on this repository? I will keep all specifics off this public thread and am glad to move to whatever private channel you prefer.