### PR TITLE
macOS fixes pip install and unix simulator build on current toolchains

### DIFF
--- a/macos-mpy.patch
+++ b/macos-mpy.patch
@@ -2,13 +2,14 @@ diff --git a/mpy-cross/Makefile b/mpy-cross/Makefile
 index 971f2f81a..0c25a11e0 100644
 --- a/mpy-cross/Makefile
 +++ b/mpy-cross/Makefile
-@@ -17,7 +17,8 @@ INC += -I$(BUILD)
+@@ -17,7 +17,9 @@ INC += -I$(BUILD)
  INC += -I$(TOP)
- 
+
  # compiler settings
 -CWARN = -Wall -Werror
 +CWARN = -Wall -Werror -Wno-error=unused-but-set-variable -Wno-error=array-bounds
 +CWARN += -Wno-error=unknown-warning-option
++CWARN += -Wno-error=unterminated-string-initialization -Wno-error=gnu-folding-constant
  CWARN += -Wextra -Wno-unused-parameter -Wpointer-arith
  CFLAGS = $(INC) $(CWARN) -std=gnu99 $(CFLAGS_MOD) $(COPT) $(CFLAGS_EXTRA)
  CFLAGS += -fdata-sections -ffunction-sections -fno-asynchronous-unwind-tables
@@ -16,13 +17,14 @@ diff --git a/ports/unix/Makefile b/ports/unix/Makefile
 index 6a936a242..43e6bf02a 100644
 --- a/ports/unix/Makefile
 +++ b/ports/unix/Makefile
-@@ -38,7 +38,8 @@ INC +=  -I$(TOP)
+@@ -38,7 +38,9 @@ INC +=  -I$(TOP)
  INC += -I$(BUILD)
- 
+
  # compiler settings
 -CWARN = -Wall -Werror
 +CWARN = -Wall -Werror -Wno-error=unused-but-set-variable -Wno-error=array-bounds
 +CWARN += -Wno-error=unknown-warning-option -Wno-error=deprecated-non-prototype -Wno-error=bitwise-instead-of-logical
++CWARN += -Wno-error=unterminated-string-initialization -Wno-error=gnu-folding-constant
  CWARN += -Wextra -Wno-unused-parameter -Wpointer-arith -Wdouble-promotion -Wfloat-conversion
  CFLAGS += $(INC) $(CWARN) -std=gnu99 -DUNIX $(CFLAGS_MOD) $(COPT) -I$(VARIANT_DIR) $(CFLAGS_EXTRA)
- 
+

--- a/macos-mpy.patch
+++ b/macos-mpy.patch
@@ -1,30 +1,30 @@
 diff --git a/mpy-cross/Makefile b/mpy-cross/Makefile
-index 971f2f81a..0c25a11e0 100644
+index 971f2f81a..beb0434d9 100644
 --- a/mpy-cross/Makefile
 +++ b/mpy-cross/Makefile
-@@ -17,7 +17,9 @@ INC += -I$(BUILD)
- INC += -I$(TOP)
-
+@@ -19,6 +19,10 @@ INC += -I$(TOP)
  # compiler settings
--CWARN = -Wall -Werror
-+CWARN = -Wall -Werror -Wno-error=unused-but-set-variable -Wno-error=array-bounds
-+CWARN += -Wno-error=unknown-warning-option
-+CWARN += -Wno-error=unterminated-string-initialization -Wno-error=gnu-folding-constant
+ CWARN = -Wall -Werror
  CWARN += -Wextra -Wno-unused-parameter -Wpointer-arith
++# suppressions must follow -Wall/-Wextra, which would otherwise re-enable them
++CWARN += -Wno-unused-but-set-variable -Wno-array-bounds
++CWARN += -Wno-error=unknown-warning-option
++CWARN += -Wno-unterminated-string-initialization -Wno-gnu-folding-constant
  CFLAGS = $(INC) $(CWARN) -std=gnu99 $(CFLAGS_MOD) $(COPT) $(CFLAGS_EXTRA)
  CFLAGS += -fdata-sections -ffunction-sections -fno-asynchronous-unwind-tables
+
 diff --git a/ports/unix/Makefile b/ports/unix/Makefile
-index 6a936a242..43e6bf02a 100644
+index 6a936a242..477eb512c 100644
 --- a/ports/unix/Makefile
 +++ b/ports/unix/Makefile
-@@ -38,7 +38,9 @@ INC +=  -I$(TOP)
- INC += -I$(BUILD)
-
+@@ -40,6 +40,10 @@ INC += -I$(BUILD)
  # compiler settings
--CWARN = -Wall -Werror
-+CWARN = -Wall -Werror -Wno-error=unused-but-set-variable -Wno-error=array-bounds
-+CWARN += -Wno-error=unknown-warning-option -Wno-error=deprecated-non-prototype -Wno-error=bitwise-instead-of-logical
-+CWARN += -Wno-error=unterminated-string-initialization -Wno-error=gnu-folding-constant
+ CWARN = -Wall -Werror
  CWARN += -Wextra -Wno-unused-parameter -Wpointer-arith -Wdouble-promotion -Wfloat-conversion
++# suppressions must follow -Wall/-Wextra, which would otherwise re-enable them
++CWARN += -Wno-unused-but-set-variable -Wno-array-bounds
++CWARN += -Wno-error=unknown-warning-option -Wno-error=deprecated-non-prototype -Wno-error=bitwise-instead-of-logical
++CWARN += -Wno-unterminated-string-initialization -Wno-gnu-folding-constant
  CFLAGS += $(INC) $(CWARN) -std=gnu99 -DUNIX $(CFLAGS_MOD) $(COPT) -I$(VARIANT_DIR) $(CFLAGS_EXTRA)
 
+ # Debugging/Optimization

--- a/testing/requirements.txt
+++ b/testing/requirements.txt
@@ -15,7 +15,8 @@ zbar-py==1.0.4
 nfcpy==1.0.3
 
 # optional, and only helpful if you have a desktop NFC-V capable reader
-pyscard==2.0.2
+# 2.0.2 fails to compile against swig 4.3+ (undeclared identifier '$function')
+pyscard==2.3.1
 
 # BSMS library
 git+https://github.com/coinkite/bsms-bitcoin-secure-multisig-setup.git@master#egg=bsms-bitcoin-secure-multisig-setup

--- a/unix/Makefile
+++ b/unix/Makefile
@@ -25,7 +25,10 @@ tags:
 
 # Make a vanilla copy of micropython (unix) for use with upip and comparsion purposes
 tools:
-	cd $(PORT_TOP) && $(MAKE) clean deplibs all
+	# axtls, not deplibs: deplibs also builds the bundled libffi, which is
+	# unused here (MICROPY_STANDALONE=0 links the system libffi via pkg-config)
+	# and whose aarch64 sysv.S no longer assembles under recent clang.
+	cd $(PORT_TOP) && $(MAKE) clean axtls all
 	cp $(PORT_TOP)/micropython ./micropython
 	cd $(PORT_TOP) && $(MAKE) clean
 

--- a/unix/simulator.py
+++ b/unix/simulator.py
@@ -969,7 +969,16 @@ Q1 specials:
 
         xterm_args.extend(['-l', '-lf', logfile])
 
-    xterm = subprocess.Popen(xterm_args + ['-e'] + cc_cmd,
+    # xterm only hosts the REPL console; the simulated screen is drawn with SDL
+    # and needs no X11. Without a display (ie. macOS without XQuartz) xterm exits
+    # immediately and takes the firmware down with it, so run the child directly.
+    if os.environ.get('DISPLAY') and shutil.which('xterm'):
+        console_cmd = xterm_args + ['-e'] + cc_cmd
+    else:
+        print("No X11 DISPLAY: running without the REPL console window.")
+        console_cmd = cc_cmd
+
+    xterm = subprocess.Popen(console_cmd,
                                 env=env,
                                 stdin=subprocess.DEVNULL, stdout=subprocess.DEVNULL,
                                 pass_fds=pass_fds, shell=False)


### PR DESCRIPTION
Thanks for contributing to COLDCARD source code, please be as descriptive as possible.

- If you haven't yet, please check out our docs https://coldcardwallet.com/docs/
- Have you tested your work yet? You can do it with the simulator https://github.com/Coldcard/firmware/blob/master/unix/simulator.py

*By submitting this work you agree to the [Individual Contributor License Agreement (CLA)](https://raw.githubusercontent.com/Coldcard/firmware/master/CONTRIBUTING.md)*

---

## Summary

On a current macOS toolchain, `pip install -r requirements.txt` fails outright and
`cd unix && make setup && make ngu-setup && make && ./simulator.py` cannot be completed.
This PR fixes each blocker so both work from a clean checkout, and leaves the unix build
free of compiler warnings.

Nothing here changes firmware behaviour on device. The changes are confined to the
desktop build/test tooling and the simulator.

**Environment where this was reproduced and fixed**

| | |
|---|---|
| OS | macOS 26 (Darwin 25.5.0), Apple Silicon |
| Compiler | Apple clang 21.0.0 |
| SWIG | 4.5.0 |
| Python | 3.13.5 |

## 1. `testing/requirements.txt` — pyscard 2.0.2 → 2.3.1

`pip install -r requirements.txt` aborted for everyone on this toolchain. `pyscard==2.0.2`
ships pre-generated SWIG sources that no longer compile against SWIG >= 4.3; the build died
with 19 errors of the form:

```
smartcard/scard/scard_wrap.c:5032:5: error: use of undeclared identifier '$function'
```

Because pip aborts the whole transaction on a failed wheel build, this one pin blocked
*every* dependency, including the ones needed just to run the simulator.

2.3.1 publishes a cp313 wheel, so it installs without invoking SWIG at all. Everything else
in the requirements tree resolved unchanged.

## 2. `macos-mpy.patch` — Apple clang 21

Two warnings are newly fatal under the existing `-Werror`, both on constructs that are
deliberate upstream:

- `extmod/moductypes.c` — `static const char type2char[16] = "BbHhIiQq------fd";` is exactly
  16 chars and intentionally carries no NUL, which now trips
  `-Wunterminated-string-initialization`.
- `py/emitnative.c` — `MP_STATIC_ASSERT` expands to `sizeof(char[1 - 2 * !(cond)])`, which
  `-Wgnu-folding-constant` rejects as a folded VLA.

Both are demoted, in the same spirit as the clang-version drift this patch already handles.

The patch additionally silences four warning classes so the unix build is clean. All 35
warnings were benign-by-design in upstream/third-party code:

| Class | Count | Origin |
|---|---|---|
| `-Wunused-but-set-variable` | 25 | `MP_BC_PRELUDE_*_DECODE` declares every prelude field; callers read only some |
| `-Warray-bounds` | 4 | `py/vm.c` indexes negatively off the VM stack pointer, eg `sp[-N + 1]` |
| `-Wgnu-folding-constant` | 3 | libngu `uint8_t d[H_SIZE]` — const-folded, not a real VLA |
| `-Wunterminated-string-initialization` | 3 | `moductypes.c` and secp256k1 — fixed-size arrays that intentionally omit the NUL |

One ordering detail is worth flagging for review, because it is easy to reintroduce:
`-Wextra` *enables* `-Wunterminated-string-initialization`, so a `-Wno-` placed before the
`-Wextra` line is silently undone. (The pre-existing `-Wno-error=` entries survived that only
because they change error status rather than enablement.) The suppressions are therefore
grouped after `-Wall`/`-Wextra`, with a comment saying why.

**If you would rather keep `-Warray-bounds` visible** in Coldcard's own C code, changing that
one entry back to `-Wno-error=array-bounds` restores 4 warnings from `py/vm.c` and nothing else.

## 3. `unix/Makefile` — `tools` should depend on `axtls`, not `deplibs`

`deplibs` is `libffi axtls`, but only axtls is used: `mpconfigport.mk` sets
`MICROPY_STANDALONE = 0`, so the ffi module links the *system* libffi found via pkg-config
and `$(BUILD)/lib/libffi` is never referenced.

Building it is not merely wasted time — on macOS it fails outright:

```
clang: error: unsupported option '-print-multi-os-directory'
src/aarch64/sysv.S: error: invalid CFI advance_loc expression
make[4]: *** [src/aarch64/sysv.lo] Error 1
```

The failure has been invisible because that recipe chains its steps with `;` rather than `&&`,
so the errors scroll past and `make setup` still exits 0.

Depending on axtls directly removes the failure and shortens setup noticeably. The resulting
vanilla micropython is unchanged — `import ffi` and `import ussl` both still work.

Root cause for the curious: micropython pins `lib/libffi` at a 2018 commit that predates
support for modern clang on arm64-Darwin. Bumping that submodule would be the alternative
fix, but is unnecessary while the bundled copy goes unused.

## 4. `unix/simulator.py` — survive having no X11 display

`simulator.py` spawns `xterm -e <coldcard-mpy ...>` purely to host the firmware's REPL console;
the Coldcard screen itself is drawn with SDL and needs no X11. On macOS without XQuartz, xterm
exits immediately (`DISPLAY is not set`), the main loop sees `xterm.poll() != None`, breaks, and
the simulator dies during startup:

```
xterm: Xt error: Can't open display:
Coldcard Simulator: Commands (over simulated window):
  ...
<xterm stopped: 1>
```

Since the firmware runs *inside* that xterm, losing it means the simulator cannot start at all —
so a fresh macOS checkout cannot reach the simulator without first installing XQuartz.

This runs the child directly when `DISPLAY` (or xterm) is missing. The simulated screen, the
`/tmp/ckcc-simulator.sock` link and `ckcc -x` all keep working; only the separate console window
is lost, and it is unusable in that situation anyway. **Behaviour with a working X11 display is
unchanged.**

This is the one commit here that changes runtime behaviour, so it is the one most worth a close
look. If you would prefer the simulator to keep failing loudly rather than degrade, it is easy
to drop this commit and keep the other three.

## Testing

From a clean checkout on the environment above:

- `pip install -r requirements.txt` completes; `pip check` reports no broken requirements.
- `cd unix && make setup && make ngu-setup && make && ./simulator.py` completes end to end.
- The running simulator answers over its socket:
  - `ckcc -x version` → `5.x.x` / `mk5`
  - `ckcc -x eval "7*6"` → `42`
- `./simulator.py --mk3` reports `hw_label='mk3'`, `(mk_num, has_se2, has_nfc, supports_hsm) == (3, False, False, False)`.
- `make setup`, `make`, and `mpy-cross` each rebuild from clean with **0 compiler warnings**
  (the only remaining line is a linker warning about the CommandLineTools SDK's
  `libSystem.tbd` stub, which is environmental).
- `macos-mpy.patch` was verified by reverse-applying it against the built tree, confirming it
  reproduces exactly the state that builds.

## Notes

- `testing/` was not run as a suite: `python-secp256k1` needs a locally compiled native
  `libsecp256k1` (per `testing/README.md`), which was out of scope here.
- No firmware/device code is touched; `stm32/` is untouched.
