### PR TITLE
bugfix: wipe in deltamode before listing saved passphrases

### DIFF
--- a/releases/Next-ChangeLog.md
+++ b/releases/Next-ChangeLog.md
@@ -7,6 +7,7 @@ This lists the new changes that have not yet been published in a normal release.
 - Bugfix: Detect RNG_SR_SEIS and RNG_SR_SECS, retry safely, and fail closed on persistent faults.
 - Bugfix: Prevent access to Seed Vault entries through Seed XOR restore in Delta Mode. Thanks to
   Rety for reporting this.
+- Bugfix: Wipe seed in Delta Mode when saved BIP-39 passphrases are listed, instead of revealing them.
 
 # Mk Specific Changes
 

--- a/shared/pwsave.py
+++ b/shared/pwsave.py
@@ -5,7 +5,7 @@
 import stash, ujson, ngu, pyb, os, version, aes256ctr
 from files import CardSlot, CardMissingError, needs_microsd
 from ux import ux_dramatic_pause, ux_confirm, ux_show_story, OK, X
-from utils import xfp2str, problem_file_line, B2A
+from utils import xfp2str, problem_file_line, B2A, wipe_if_deltamode
 from menu import MenuItem, MenuSystem
 from glob import settings
 
@@ -192,6 +192,9 @@ class PassphraseSaverMenu(MenuSystem):
         # We have a list of xfp+pw fields. Make a menu.
         # Read file, decrypt and make a menu to show; OR return None
         # if any error hit.
+        # - menu leaks passphrase text and XFP of each hidden wallet
+        wipe_if_deltamode()
+
         pw_saver = PassphraseSaver()
         with CardSlot() as card:
             pw_saver._calc_key(card)


### PR DESCRIPTION
`PassphraseSaverMenu.construct()` calls `_calc_key()`, which reads the real master secret via `SensitiveValues(bypass_tmp=True)` with no `enforce_delta`. In Delta Mode the secret is genuine, so the derived key decrypts the saved-passphrase file and the menu shows saved passphrases by partial text (full text when no prefix disambiguates), each wallet's XFP, and a Restore item.

Seed Vault guards the equivalent data with `wipe_if_deltamode()`; this does the same before the file is read.

Gate is on the menu, not `_calc_key()`, because `MicroSD2FA` inherits `_calc_key()` for the login-time 2FA check.

Tested on simulator: test_pwsave (11 passed). Delta Mode path itself not exercised - needs SE2 trick PIN setup.
