### PR TITLE
Fix nested passphrase wallet display and backups

### DIFF
--- a/docs/backup-files.md
+++ b/docs/backup-files.md
@@ -41,13 +41,14 @@ called `ckcc-backup.txt`, but the filename is now picked randomly.
 ## BIP39 Passphrase
 
 If BIP39 passphrase is active, the passphrase wallet itself is backed-up,
-as extended private key created from seed words plus passphrase. Neither
-the seed words nor the passphrase are part of such backup.
+as an extended private key (ie. a XPRV) created from seed words plus
+passphrase. Neither the seed words nor the passphrase are part of such backup.
 
-Older versions defaulted to backing-up main wallet, and offered a choice
-between the two. That option is gone, because passphrase can be applied
-on top of another temporary seed, in which case main wallet is not the
-wallet the passphrase was applied to.
+Before versions 5.6.1 (Mk4/Mk5) and 1.5.1Q (Q1), backups defaulted to the
+main wallet. Versions supporting passphrase-wallet backups offered a choice
+between the two. That option is gone, because passphrase can be applied on
+top of another temporary seed, in which case main wallet is not the wallet
+the passphrase was applied to.
 
 ## Ephemeral Seeds
 
@@ -229,4 +230,3 @@ setting.terms_ok = 1
 As you can see, it is a simple text file and if you needed to access your funds
 without the help of a Coldcard, it would be a simple matter to import either the `xprv`
 (BIP32 master) or the mnemonic (BIP39) into another wallet system.
-

--- a/docs/backup-files.md
+++ b/docs/backup-files.md
@@ -40,14 +40,23 @@ called `ckcc-backup.txt`, but the filename is now picked randomly.
 
 ## BIP39 Passphrase
 
-If BIP39 passphrase is active the default behavior is to back-up
-main wallet - not BIP39 passphrase wallet. From version `5.2.0`
-users can choose to back-up also BIP39 passphrase wallet.
+If BIP39 passphrase is active, the passphrase wallet itself is backed-up,
+as extended private key created from seed words plus passphrase. Neither
+the seed words nor the passphrase are part of such backup.
+
+Older versions defaulted to backing-up main wallet, and offered a choice
+between the two. That option is gone, because passphrase can be applied
+on top of another temporary seed, in which case main wallet is not the
+wallet the passphrase was applied to.
 
 ## Ephemeral Seeds
 
 If ephemeral seed is active the default behavior is to always 
 back-up ephemeral wallet instead of the main wallet.
+
+This applies to every path that captures the whole device: `Backup System`,
+`Clone Coldcard` and Key Teleport's `Full COLDCARD Backup`. All of them
+capture the seed in effect, and warn about it beforehand.
 
 ## Limitations
 

--- a/releases/Next-ChangeLog.md
+++ b/releases/Next-ChangeLog.md
@@ -25,6 +25,7 @@ This lists the new changes that have not yet been published in a normal release.
   Thanks to [@drk1wi](https://github.com/drk1wi).
 - Change: When a BIP-39 passphrase is active, View Seed Words now shows only the effective extended private key instead of the underlying seed words.
 - Change: Backup System, Clone Coldcard, and Key Teleport’s Full COLDCARD Backup now capture the wallet secret currently in effect, including temporary seeds and BIP-39 passphrase wallets, and warn before export.
+- Bugfix: View Seed Words and backup workflows incorrectly treated the master seed as the parent of every BIP-39 passphrase wallet. When a passphrase was applied to a temporary seed, they could not access that immediate parent seed.
 
 # Mk Specific Changes
 

--- a/releases/Next-ChangeLog.md
+++ b/releases/Next-ChangeLog.md
@@ -23,6 +23,7 @@ This lists the new changes that have not yet been published in a normal release.
   download (signed txn, visualization, backup), require an encrypted session,
   and are invalidated by any upload, newly staged transaction, or new session.
   Thanks to [@drk1wi](https://github.com/drk1wi).
+- Change: When a BIP-39 passphrase is active, View Seed Words now shows only the effective extended private key instead of the underlying seed words.
 
 # Mk Specific Changes
 

--- a/releases/Next-ChangeLog.md
+++ b/releases/Next-ChangeLog.md
@@ -24,6 +24,7 @@ This lists the new changes that have not yet been published in a normal release.
   and are invalidated by any upload, newly staged transaction, or new session.
   Thanks to [@drk1wi](https://github.com/drk1wi).
 - Change: When a BIP-39 passphrase is active, View Seed Words now shows only the effective extended private key instead of the underlying seed words.
+- Change: Backup System, Clone Coldcard, and Key Teleport’s Full COLDCARD Backup now capture the wallet secret currently in effect, including temporary seeds and BIP-39 passphrase wallets, and warn before export.
 
 # Mk Specific Changes
 

--- a/shared/actions.py
+++ b/shared/actions.py
@@ -543,9 +543,10 @@ async def convert_ephemeral_to_master(*a):
     from stash import bip39_passphrase
 
     words = settings.get("words", True)
-    _type = 'BIP-39 passphrase' if bip39_passphrase else 'temporary seed'
+    master_words = settings.master_get("words", True)
+    _type = 'BIP-39 passphrase wallet' if bip39_passphrase else 'temporary seed'
     msg = 'Convert currently used %s to master seed. Old master seed' % _type
-    if words or bip39_passphrase:
+    if master_words:
         msg += ' words themselves are erased forever, '
     else:
         msg += ' is erased forever, '
@@ -712,7 +713,7 @@ async def export_seedqr(*a):
 
     # Note: cannot reach this menu item if no words. If they are tmp, that's cool.
 
-    with stash.SensitiveValues(bypass_tmp=False, enforce_delta=True) as sv:
+    with stash.SensitiveValues(enforce_delta=True) as sv:
         if sv.mode != 'words':
             raise ValueError(sv.mode)
 

--- a/shared/actions.py
+++ b/shared/actions.py
@@ -613,7 +613,7 @@ new wallet.''', 'AGAIN...', confirm_key='4'):
 
 def render_master_secrets(mode, raw, node):
     # Render list of words, or XPRV / master secret to text.
-    import stash, chains
+    import chains
 
     c = chains.current_chain()
     qr_alnum = False
@@ -635,12 +635,6 @@ def render_master_secrets(mode, raw, node):
 
         msg += ux_render_words(words)
 
-        if stash.bip39_passphrase:
-            msg += '\n\nBIP-39 Passphrase:\n    *****'
-            if node:
-                msg += '\n\nSeed+Passphrase:\n%s' % c.serialize_private(node)
-
-
     elif mode == 'xprv':
         title = "Extended Private Key" if version.has_qwerty else None
         msg = c.serialize_private(node)
@@ -657,9 +651,9 @@ def render_master_secrets(mode, raw, node):
     return title, msg, qr, qr_alnum
 
 async def view_seed_words(*a):
-    if not await ux_confirm('The next screen will show the seed words'
-                            ' (and if defined, your BIP-39 passphrase).'
-                            '\n\nAnyone with knowledge of those words '
+    if not await ux_confirm('The next screen will show the secret seed words'
+                            ' (or extended private key).'
+                            '\n\nAnyone with knowledge of the secret '
                             'can control all funds in this wallet.'):
         return
 
@@ -667,26 +661,19 @@ async def view_seed_words(*a):
     from glob import dis, NFC
 
     dis.fullscreen("Wait...")
-    dis.busy_bar(True)
 
-    # preserve old UI where we show words + passphrase
-    # instead of just calculated seed + passphrase = extended privkey
-    # new: calculated xprv is now also shown for BIP39 passphrase wallet
-    raw = mode = None
-    if stash.bip39_passphrase:
-        # get main secret - bypass tmp
-        with stash.SensitiveValues(bypass_tmp=True, enforce_delta=True) as sv:
-            assert sv.mode == "words"
-            raw = sv.raw[:]
-            mode = sv.mode
+    # CHANGED: old UI where we show words + passphrase
+    # instead just calculated seed + passphrase = extended privkey for all BIP39 passphrase wallets
 
-        stash.SensitiveValues.clear_cache()
+    with stash.SensitiveValues(enforce_delta=True) as sv:
+        msg = ""
+        if stash.bip39_passphrase:
+            # on the top of the page - so visible on Mk4/5
+            msg += "BIP-39 Passphrase in effect\n\n"
 
-    with stash.SensitiveValues(bypass_tmp=False, enforce_delta=True) as sv:
-        dis.busy_bar(False)
-        title, msg, qr, qr_alnum = render_master_secrets(mode or sv.mode,
-                                                         raw or sv.raw,
-                                                         sv.node)
+        title, sub_msg, qr, qr_alnum = render_master_secrets(sv.mode, sv.raw, sv.node)
+        msg += sub_msg
+
         esc = "1"
         if not version.has_qwerty:
             msg += '\n\nPress (1) to view as QR Code'
@@ -709,7 +696,6 @@ async def view_seed_words(*a):
 
     stash.blank_object(qr)
     stash.blank_object(msg)
-    stash.blank_object(raw)
 
 async def export_seedqr(*a):
     # see standard: <https://github.com/SeedSigner/seedsigner/blob/dev/docs/seed_qr/README.md>

--- a/shared/backups.py
+++ b/shared/backups.py
@@ -22,12 +22,11 @@ bkpw_min_len = const(32)
 # - limited by size of LFS area of flash, since all settings are held there
 MAX_BACKUP_FILE_SIZE = const(128*1024)     # bytes
 
-def render_backup_contents(bypass_tmp=False):
+def render_backup_contents():
     # simple text format: 
     #   key = value
     # or #comments
     # but value is JSON
-    current_tmp = None
     rv = StringIO()
 
     def COMMENT(val=None):
@@ -45,7 +44,7 @@ def render_backup_contents(bypass_tmp=False):
 
     COMMENT('Private key details: ' + chain.name)
 
-    with stash.SensitiveValues(bypass_tmp=bypass_tmp, enforce_delta=True) as sv:
+    with stash.SensitiveValues(enforce_delta=True) as sv:
         if sv.mode == 'words':
             ADD('mnemonic', bip39.b2a_words(sv.raw))
 
@@ -72,20 +71,6 @@ def render_backup_contents(bypass_tmp=False):
             for k,v in pairs:
                 ADD(k, v)
 
-        if bypass_tmp and pa.tmp_value:
-            current_tmp = pa.tmp_value[:]
-            pa.tmp_value = None
-            # we also need correct settings from main seed
-            if sv.mode == 'words':
-                nv = stash.SecretStash.encode(seed_phrase=sv.raw)
-            else:
-                assert sv.mode == "xprv"
-                nv = stash.SecretStash.encode(xprv=sv.node)
-
-            settings.set_key(nv)
-            settings.load()
-            stash.blank_object(nv)
-    
     COMMENT('Firmware version (informational)')
     date, vers, timestamp = version.get_mpy_version()[0:3]
     ADD('fw_date', date)
@@ -118,13 +103,6 @@ def render_backup_contents(bypass_tmp=False):
             ADD('hsm_policy', hsm.capture_backup())
 
     rv.write('\n# EOF\n')
-
-    if bypass_tmp and current_tmp:
-        # go back to tmp secret and its settings
-        stash.SensitiveValues.clear_cache()
-        pa.tmp_value = current_tmp
-        settings.set_key()
-        settings.load()
 
     return rv.getvalue()
 
@@ -404,27 +382,21 @@ def encrypt_7z_data(password, body, ext="txt"):
     return zz, hdr, footer
 
 
+async def confirm_tmp_in_effect(what):
+    # We always capture the seed in effect, never the master seed underneath it.
+    # Passphrase can be applied on top of another temporary seed, so we cannot
+    # offer master seed as an alternative - be clear about whose secret leaves.
+    if not pa.tmp_value:
+        return True
+
+    name = "BIP-39 passphrase" if stash.bip39_passphrase else "temporary seed"
+    return await ux_confirm("A %s is in effect, so %s will be of that seed." % (name, what))
+
 async def make_complete_backup(fname_pattern='backup.7z', write_sflash=False):
-    from stash import bip39_passphrase
-
     pwd = None
-    bypass_tmp = False
 
-    if bip39_passphrase and pa.tmp_value:
-        # this is a BIP39 password ephemeral wallet
-        msg = ("BIP39 passphrase is in effect. Backup ignores passphrases "
-               "and produces backup of main seed. Press %s to back-up main wallet,"
-               " press (2) to back-up BIP39 passphrase wallet "
-               "(extended private key created via seed + pass)" % OK)
-        ch = await ux_show_story(msg, escape="2")
-        if ch == "x": return
-        if ch == "y":
-            bypass_tmp = True
-
-    elif pa.tmp_value:
-        if not await ux_confirm("A temporary seed is in effect, "
-                                "so backup will be of that seed."):
-            return
+    if not await confirm_tmp_in_effect("backup"):
+        return
 
     # first check if bkpw already defined on tmp seed settings
     stored_pwd, skip_quiz = await bkpw_workflow()
@@ -450,18 +422,17 @@ async def make_complete_backup(fname_pattern='backup.7z', write_sflash=False):
             settings.set('bkpw', pwd)  # if on tmp save to tmp, do not update master
             settings.save()
 
-    return await write_complete_backup(pwd, fname_pattern, write_sflash=write_sflash,
-                                       bypass_tmp=bypass_tmp)
+    return await write_complete_backup(pwd, fname_pattern, write_sflash=write_sflash)
 
 async def write_complete_backup(pwd, fname_pattern, write_sflash=False,
-                                allow_copies=True, bypass_tmp=False):
+                                allow_copies=True):
     # Just do the writing
     from glob import dis
     from files import CardSlot
 
     # Show progress:
     dis.fullscreen('Encrypting...' if pwd else 'Generating...')
-    body = render_backup_contents(bypass_tmp=bypass_tmp).encode()
+    body = render_backup_contents().encode()
 
     gc.collect()
 
@@ -858,6 +829,9 @@ async def clone_write_data(*a):
         await ux_show_story("Start this process on the other Coldcard, which will write a file onto MicroSD card as the first step.\n\nInsert that card and try again here.")
         return
 
+    if not await confirm_tmp_in_effect("clone"):
+        return
+
     # pick our own temp keys for this encryption
     pair = ngu.secp256k1.keypair()
     my_pubkey = pair.pubkey().to_bytes(False)
@@ -865,7 +839,7 @@ async def clone_write_data(*a):
 
     fname = b2a_hex(my_pubkey).decode() + '-ccbk.7z'
 
-    await write_complete_backup(b2a_hex(session_key).decode(), fname, allow_copies=False, bypass_tmp=True)
+    await write_complete_backup(b2a_hex(session_key).decode(), fname, allow_copies=False)
 
     await ux_show_story("Done.\n\nTake this MicroSD card back to other Coldcard and continue from there.")
 

--- a/shared/pincodes.py
+++ b/shared/pincodes.py
@@ -405,7 +405,6 @@ class PinAttempt:
         from glob import settings, dis
         stash.SensitiveValues.clear_cache()
 
-        bypass_tmp = False
         stash.bip39_passphrase = bool(bip39pw)
 
         # capture values we have already
@@ -416,7 +415,6 @@ class PinAttempt:
 
         if raw_secret is None:
             assert pa.tmp_value
-            bypass_tmp = True
             pa.tmp_value = None
             if blank:
                 # wipe current ephemeral secret settings slot
@@ -434,7 +432,7 @@ class PinAttempt:
 
         # Recalculate xfp/xpub values (depends both on secret and chain)
         try:
-            with stash.SensitiveValues(raw_secret, bypass_tmp=bypass_tmp) as sv:
+            with stash.SensitiveValues(raw_secret) as sv:
                 if chain is not None:
                     sv.chain = chain
 

--- a/shared/pwsave.py
+++ b/shared/pwsave.py
@@ -112,7 +112,7 @@ class PassphraseSaverMenu(MenuSystem):
         from seed import set_bip39_passphrase
         from pincodes import pa
 
-        bypass_tmp = True
+        bypass_tmp = bool(pa.tmp_value)
         pw, expect_xfp = item.arg
         if pa.tmp_value and settings.get("words", True):
             xfp = settings.get("xfp", 0)

--- a/shared/teleport.py
+++ b/shared/teleport.py
@@ -3,7 +3,7 @@
 # teleport.py - Magically transport extremely sensitive data between the
 #               secure environment of two Q's.
 #
-import ngu, aes256ctr, bip39, json, ndef, chains
+import ngu, aes256ctr, bip39, json, ndef, chains, stash
 from utils import xfp2str, deserialize_secret
 from ubinascii import unhexlify as a2b_hex
 from ubinascii import hexlify as b2a_hex
@@ -16,7 +16,7 @@ from menu import MenuItem, MenuSystem
 from notes import NoteContentBase
 from sffile import SFFile
 from multisig import MultisigWallet
-from stash import SensitiveValues, SecretStash, blank_object, bip39_passphrase
+from stash import SensitiveValues, SecretStash, blank_object
 
 # One page github-hosted static website that shows QR based on URL contents pushed by NFC
 KT_DOMAIN = 'keyteleport.com'
@@ -538,7 +538,7 @@ class SecretPickerMenu(MenuSystem):
             # tmp seed, or maybe bip39 is in effect 
             # - share the current master secret, not the real master
             msg = 'Temp Secret (words)' if word_based_seed() else (
-                        'XPRV from Words+Passphrase' if bip39_passphrase else 'Temp XPRV Secret')
+                        'XPRV from Seed+Passphrase' if stash.bip39_passphrase else 'Temp XPRV Secret')
         elif has_se_secrets():
             # sharing real master secret
             msg = 'Master Seed Words' if word_based_seed() else 'Master XPRV'
@@ -590,12 +590,21 @@ class SecretPickerMenu(MenuSystem):
 
     async def share_full_backup(self, *a):
         # context, and warn them
-        ch = await ux_show_story("Sending complete backup, including master secret, "
-            "seed vault (if any), multisig wallets, notes/passwords, and all settings! "
-            "The receiving "
-            "COLDCARD must already have the master seed wiped to be able to install "
-            "everything, otherwise only master secret and multisig are saved into a tmp seed. "
-            "OK to proceed?")
+        from pincodes import pa
+
+        if pa.tmp_value:
+            if stash.bip39_passphrase:
+                what = "BIP-39 Passphrase wallet"
+            else:
+                what = "current active temporary secret"
+        else:
+            what = "master secret, seed vault (if any)"
+
+        ch = await ux_show_story("Sending complete backup, including %s, multisig wallets,"
+                                 " notes/passwords, and all settings! The receiving COLDCARD"
+                                 " must already have the master seed wiped to be able to install"
+                                 " everything, otherwise only the transferred secret and multisig"
+                                 " wallets are saved into a temporary seed. OK to proceed?" % what)
         if ch != 'y': return
 
         from backups import render_backup_contents
@@ -603,7 +612,7 @@ class SecretPickerMenu(MenuSystem):
         dis.fullscreen("Buiding Backup...")
 
         # renders a text file, with rather a lot of comments; strip them
-        bkup = render_backup_contents(bypass_tmp=True)
+        bkup = render_backup_contents()
         out = []
         for ln in bkup.split('\n'):
             if not ln: continue
@@ -618,7 +627,7 @@ class SecretPickerMenu(MenuSystem):
 
         dis.fullscreen("Wait...")
 
-        with SensitiveValues(bypass_tmp=False, enforce_delta=True) as sv:
+        with SensitiveValues(enforce_delta=True) as sv:
             raw = bytearray(sv.secret)
             xfp = xfp2str(sv.get_xfp())
 

--- a/testing/test_backup.py
+++ b/testing/test_backup.py
@@ -108,13 +108,9 @@ def backup_system(settings_set, settings_remove, goto_home, pick_menu_item,
 
         title, body = cap_story()
         if st:
-            if st == "b39pass":
-                assert "BIP39 passphrase is in effect" in body
-                assert "ignores passphrases and produces backup of main seed" in body
-                assert "(2) to back-up BIP39 passphrase wallet" in body
-            if st == "eph":
-                assert "A temporary seed is in effect" in body
-                assert "so backup will be of that seed" in body
+            name = "BIP-39 passphrase" if st == "b39pass" else "temporary seed"
+            assert f"A {name} is in effect" in body
+            assert "so backup will be of that seed" in body
 
             press_select()
             time.sleep(.1)
@@ -267,10 +263,8 @@ def test_make_backup(multisig, goto_home, pick_menu_item, cap_story, need_keypre
     title, body = cap_story()
 
     if st == "b39pass" and multisig:
-        # correct settings switch back?
         # multisig is only in main wallet
         # must not be copied from main to b39pass
-        # must not be available after backup done
         assert not get_setting('multisig', None)
 
     if notes:
@@ -308,7 +302,7 @@ def test_make_backup(multisig, goto_home, pick_menu_item, cap_story, need_keypre
     verify_backup_file(fn)
     decrypted = check_and_decrypt_backup(fn, words)
     avail_settings = []
-    if seedvault and (st in [None, "b39pass"]):
+    if seedvault and (st is None):
         assert "seedvault" in decrypted
         assert "seeds" in decrypted
         avail_settings.append("seeds")
@@ -322,7 +316,8 @@ def test_make_backup(multisig, goto_home, pick_menu_item, cap_story, need_keypre
         time.sleep(.01)
 
     # test verify on device (CRC check)
-    if multisig:
+    if multisig and (st != "b39pass"):
+        # multisig is in main wallet only, but backup is of the b39pass wallet
         avail_settings.append("multisig")
 
     restore_backup_cs(files[0], words, avail_settings=avail_settings,
@@ -413,7 +408,7 @@ def test_backup_ephemeral_wallet(stype, pick_menu_item, press_select, goto_home,
 
 @pytest.mark.parametrize('seedvault', [False, True])
 @pytest.mark.parametrize("passphrase", ["@coinkite rulez!!", "!@#!@", "AAAAAAAAAAA"])
-def test_backup_bip39_wallet(passphrase, set_bip39_pw, pick_menu_item, need_keypress,
+def test_backup_bip39_wallet(passphrase, set_bip39_pw, pick_menu_item, press_select,
                              goto_home, cap_story, pass_word_quiz, get_setting,
                              verify_backup_file, microsd_path, check_and_decrypt_backup,
                              sim_execfile, unit_test, word_menu_entry, cap_menu,
@@ -431,10 +426,9 @@ def test_backup_bip39_wallet(passphrase, set_bip39_pw, pick_menu_item, need_keyp
     pick_menu_item("Backup System")
     time.sleep(.1)
     title, story = cap_story()
-    assert "BIP39 passphrase is in effect" in story
-    assert "ignores passphrases and produces backup of main seed" in story
-    assert "(2) to back-up BIP39 passphrase wallet" in story
-    need_keypress("2")
+    assert "A BIP-39 passphrase is in effect" in story
+    assert "so backup will be of that seed" in story
+    press_select()
     time.sleep(.1)
     title, story = cap_story()
     if "Use same backup file password as last time?" in story:
@@ -465,7 +459,7 @@ def test_backup_bip39_wallet(passphrase, set_bip39_pw, pick_menu_item, need_keyp
     assert "seeds" not in contents
     assert simulator_fixed_words not in contents
     assert simulator_fixed_tprv not in contents
-    assert target == contents
+    assert sorted(target.splitlines()) == sorted(contents.splitlines())
     seed = Mnemonic.to_seed(simulator_fixed_words, passphrase=passphrase)
     expect = BIP32Node.from_master_secret(seed, netcode="XTN")
     esk = expect.hwif(as_private=True)
@@ -592,6 +586,57 @@ def test_clone_start(reset_seed_words, pick_menu_item, cap_story, goto_home, src
     os.remove(f"{sd_dir}/{fname}")
 
     # TODO check file made is a good backup, with correct password
+
+
+@pytest.mark.parametrize("b39pass", [False, True])
+def test_clone_start_tmp_seed(b39pass, reset_seed_words, pick_menu_item, cap_story, goto_home,
+                              src_root_dir, sim_root_dir, generate_ephemeral_words, set_bip39_pw,
+                              press_cancel, press_select, settings_set):
+    # clone is of the seed in effect, and says so before writing anything
+    sd_dir = f"{sim_root_dir}/MicroSD"
+    fname = "ccbk-start.json"
+    reset_seed_words()
+    settings_set("seedvault", 0)
+    sec = generate_ephemeral_words(24, from_main=True, seed_vault=False)
+    if b39pass:
+        # passphrase on top of the temporary seed - master seed is not its parent
+        set_bip39_pw("coinkite", reset=False, on_tmp=True)
+
+    goto_home()
+    shutil.copy(f"{src_root_dir}/testing/data/{fname}", sd_dir)
+    before = {i for i in os.listdir(sd_dir) if i.endswith(".7z")}
+    pick_menu_item("Advanced/Tools")
+    pick_menu_item("Backup")
+    pick_menu_item("Clone Coldcard")
+    time.sleep(.2)
+    title, story = cap_story()
+    name = "BIP-39 passphrase" if b39pass else "temporary seed"
+    assert f"A {name} is in effect" in story
+    assert "so clone will be of that seed" in story
+    assert "main seed" not in story
+
+    press_cancel()
+    time.sleep(.2)
+    # nothing written when refused (stale clone files are purged before this point)
+    after = {i for i in os.listdir(sd_dir) if i.endswith(".7z")}
+    assert not (after - before)
+
+    # accept, and the file is written from the seed in effect
+    pick_menu_item("Clone Coldcard")
+    time.sleep(.2)
+    press_select()
+    time.sleep(1)
+    title, story = cap_story()
+    assert "Done" in story
+    assert "Take this MicroSD card back to other Coldcard" in story
+    after = {i for i in os.listdir(sd_dir) if i.endswith(".7z")}
+    assert len(after - before) == 1
+
+    goto_home()
+    for fn in (after - before):
+        os.remove(f"{sd_dir}/{fn}")
+    os.remove(f"{sd_dir}/{fname}")
+    reset_seed_words()
 
 
 def test_bkpw_override(reset_seed_words, override_bkpw, goto_home, pick_menu_item,

--- a/testing/test_bip39pw.py
+++ b/testing/test_bip39pw.py
@@ -363,7 +363,7 @@ def test_bip39pass_on_ephemeral_seed(generate_ephemeral_words, import_ephemeral_
     enter_complex(passphrase, apply=True)
 
     tmp_seed = Mnemonic.to_seed(" ".join(sec), passphrase=passphrase)
-    tmp_node = BIP32Node.from_master_secret(tmp_seed)
+    tmp_node = BIP32Node.from_master_secret(tmp_seed, netcode="XTN")
     tmp_fp = tmp_node.fingerprint().hex().upper()
 
     time.sleep(.2)
@@ -390,6 +390,24 @@ def test_bip39pass_on_ephemeral_seed(generate_ephemeral_words, import_ephemeral_
             press_select()
         else:
             press_select()  # do not store
+
+    goto_home()
+    pick_menu_item("Advanced/Tools")
+    pick_menu_item("Danger Zone")
+    pick_menu_item("Seed Functions")
+    pick_menu_item("View Seed Words")
+    time.sleep(.1)
+    _, story = cap_story()
+    assert "secret seed words" in story
+    press_select()
+    time.sleep(.1)
+    _, story = cap_story()
+    assert tmp_node.hwif(as_private=True) in story
+    assert story.startswith("BIP-39 Passphrase in effect\n\n")
+    assert passphrase not in story
+    assert "Seed words" not in story
+    press_select()
+    goto_home()
 
     if seed_vault:
         # check correct meta in seed vault

--- a/testing/test_bip39pw.py
+++ b/testing/test_bip39pw.py
@@ -315,7 +315,7 @@ def test_lockdown_ux(stype, pick_menu_item, set_bip39_pw, goto_home, is_q1,
     assert 'Make sure all duress wallets associated with previous seed are deleted' in story
     assert 'carried forward without being properly generated from new master seed.' in story
     if stype == "bip39pw":
-        assert "Convert currently used BIP-39 passphrase to master seed" in story
+        assert "Convert currently used BIP-39 passphrase wallet to master seed" in story
         assert "but the passphrase itself is erased" in story
 
     assert "Press (4) to prove you read to the end of this message and accept all consequences" in story
@@ -334,7 +334,7 @@ def test_bip39pass_on_ephemeral_seed(generate_ephemeral_words, import_ephemeral_
                                      reset_seed_words, goto_eph_seed_menu, stype,
                                      enter_complex, cap_story, cap_menu,
                                      settings_set, seed_vault, press_select,
-                                     go_to_passphrase):
+                                     go_to_passphrase, press_cancel):
     passphrase = "@coinkite rulez!!"
     reset_seed_words()
     settings_set("seedvault", 1)
@@ -407,6 +407,18 @@ def test_bip39pass_on_ephemeral_seed(generate_ephemeral_words, import_ephemeral_
     assert passphrase not in story
     assert "Seed words" not in story
     press_select()
+    goto_home()
+
+    # backup must be of the wallet in effect, no offer to back-up main seed
+    pick_menu_item("Advanced/Tools")
+    pick_menu_item("Backup")
+    pick_menu_item("Backup System")
+    time.sleep(.1)
+    _, story = cap_story()
+    assert "A BIP-39 passphrase is in effect" in story
+    assert "so backup will be of that seed" in story
+    assert "main seed" not in story
+    press_cancel()
     goto_home()
 
     if seed_vault:

--- a/testing/test_ccc.py
+++ b/testing/test_ccc.py
@@ -1417,7 +1417,7 @@ def test_ccc_challenge_qr_bad_checksum_crash(setup_ccc, goto_ccc_menu, cap_story
     scan_a_qr(bad_seed_qr)
     time.sleep(.5)
     press_select()
-
+    time.sleep(.1)
     title, story = cap_story()
     assert 'Sorry, those words are incorrect' in story
 

--- a/testing/test_drv_entro.py
+++ b/testing/test_drv_entro.py
@@ -43,7 +43,8 @@ def derive_bip85_secret(goto_home, press_select, pick_menu_item, cap_story, ente
         press_select()
         time.sleep(0.1)
         title, story = cap_story()
-        if "You have a temporary seed active - deriving from temporary" in story:
+        if (("You have a temporary seed active - deriving from temporary" in story)
+                or ("it will be wrapped into the new secret" in story)):
             press_select()
 
         time.sleep(0.1)
@@ -119,6 +120,24 @@ def derive_bip85_secret(goto_home, press_select, pick_menu_item, cap_story, ente
         return can_import, story
 
     return doit
+
+
+def test_bip39_passphrase_warning(set_bip39_pw, goto_home, pick_menu_item, cap_story,
+                                  press_select, press_cancel, reset_seed_words, is_q1):
+    set_bip39_pw("bip85-test")
+
+    goto_home()
+    pick_menu_item('Advanced/Tools')
+    pick_menu_item('Derive Seed B85' if not is_q1 else 'Derive Seeds (BIP-85)')
+    press_select()
+    time.sleep(.1)
+
+    _, story = cap_story()
+    assert "You have a BIP-39 passphrase set right now" in story
+    assert "it will be wrapped into the new secret" in story
+
+    press_cancel()
+    reset_seed_words()
 
 
 @pytest.fixture

--- a/testing/test_teleport.py
+++ b/testing/test_teleport.py
@@ -764,7 +764,10 @@ def test_send_backup(testcase, rx_start, tx_start, cap_menu, enter_complex, pick
 
     title, body = cap_story()
 
-    assert 'Sending complete backup' in body
+    assert ('Sending complete backup, including master secret, seed vault (if any), '
+            'multisig wallets' in body)
+    assert 'otherwise only the transferred secret and multisig' in body
+    assert ',,' not in body
 
     press_select()
 
@@ -803,6 +806,28 @@ def test_send_backup(testcase, rx_start, tx_start, cap_menu, enter_complex, pick
         restore_backup_unpacked()
         assert settings_get('notes') == notes
         settings_set('notes', [])
+
+
+def test_send_backup_tmp_story(rx_start, tx_start, pick_menu_item, cap_story, press_cancel,
+                               generate_ephemeral_words, set_bip39_pw, restore_main_seed):
+    def check_story(expected):
+        code, rx_pubkey = rx_start()
+        tx_start(rx_pubkey, code)
+        pick_menu_item('Full COLDCARD Backup')
+
+        _, body = cap_story()
+        assert ('Sending complete backup, including %s, multisig wallets' % expected) in body
+        assert 'otherwise only the transferred secret and multisig' in body
+        assert ',,' not in body
+        press_cancel()
+
+    generate_ephemeral_words(num_words=12, from_main=True, seed_vault=False)
+    check_story('current active temporary secret')
+    restore_main_seed()
+
+    set_bip39_pw('teleport-test')
+    check_story('BIP-39 Passphrase wallet')
+    restore_main_seed()
 
 
 def test_teleport_backup_invalid_raw_secret(grab_payload, rx_complete, goto_home,

--- a/testing/test_ux.py
+++ b/testing/test_ux.py
@@ -493,7 +493,12 @@ def test_show_seed(mode, b39_word, goto_home, pick_menu_item, cap_story, need_ke
     reset_seed_words()
     if mode == 'words':
         set_bip39_pw(b39_word, reset=False)
-        words = simulator_fixed_words.split(" ")
+        if b39_word:
+            seed = Mnemonic.to_seed(simulator_fixed_words, passphrase=b39_word)
+            node = BIP32Node.from_master_secret(seed, netcode="XTN")
+            expect = node.hwif(as_private=True)
+        else:
+            words = simulator_fixed_words.split(" ")
 
     else:
         if b39_word: return
@@ -519,6 +524,8 @@ def test_show_seed(mode, b39_word, goto_home, pick_menu_item, cap_story, need_ke
     title, body = cap_story()
     where = title if is_q1 else body
     assert 'Are you SURE' in where
+    assert 'secret seed words' in body
+    assert 'or extended private key' in body
     assert 'can control all funds' in body
     press_select()      # skip warning
     time.sleep(0.01)
@@ -527,7 +534,7 @@ def test_show_seed(mode, b39_word, goto_home, pick_menu_item, cap_story, need_ke
     if not is_q1:
         assert title == 'NO-TITLE'
 
-    if mode == 'words':
+    if mode == 'words' and not b39_word:
         assert '24' in (title if is_q1 else body)
 
         lines = body.split('\n')
@@ -536,30 +543,18 @@ def test_show_seed(mode, b39_word, goto_home, pick_menu_item, cap_story, need_ke
         else:
             assert lines[1:25] == ['%2d: %s' % (n+1, w) for n,w in enumerate(words)]
 
-        if b39_word:
-            if is_q1:
-                assert lines[9] == 'BIP-39 Passphrase:'
-                assert "*" in lines[10]
-                assert "Seed+Passphrase" in lines[12]
-                ek = lines[13]
-            else:
-                assert lines[26] == 'BIP-39 Passphrase:'
-                assert "*" in lines[27]
-                assert "Seed+Passphrase" in lines[29]
-                ek = lines[30]
-
-            seed = Mnemonic.to_seed(simulator_fixed_words, passphrase=b39_word)
-            expect = BIP32Node.from_master_secret(seed, netcode="XTN")
-            esk = expect.hwif(as_private=True)
-            assert esk == ek
-        else:
-            assert "BIP-39 Passphrase" not in body
-
+        assert "BIP-39 Passphrase" not in body
         qr_expect = ' '.join(w[0:4].upper() for w in words)
 
     else:
         assert expect in body
         qr_expect = expect
+        if b39_word:
+            assert body.startswith("BIP-39 Passphrase in effect\n\n")
+            assert b39_word not in body
+            assert "Seed words" not in body
+        else:
+            assert "BIP-39 Passphrase" not in body
 
     if not is_q1:
         assert '(1) to view as QR Code' in body


### PR DESCRIPTION
## Summary

BIP-39 passphrase wallets are represented internally as temporary extended private keys. Because a passphrase can be applied to a word-based temporary seed, the persistent master seed is not necessarily the passphrase wallet’s parent.

Update secret display and backup workflows to consistently use the wallet currently in effect:

- Show the effective XPRV in View Seed Words when a BIP-39 passphrase is active, without displaying the parent seed words or passphrase.
- Make Backup System, Clone Coldcard, and Key Teleport’s Full COLDCARD Backup capture the active temporary or passphrase wallet.
- Warn before exporting when a temporary seed or passphrase wallet is active.
- Remove the choice between master and passphrase-wallet backups, since that choice cannot correctly represent passphrases applied to temporary seeds.
- Simplify related temporary-secret bypass and settings-switching logic.
- Correct related passphrase restoration and temporary-to-master messaging.

The backup file format is unchanged. Passphrase-wallet backups contain the effective XPRV, not the parent seed words or passphrase.