### PR TITLE
cleanup: drop unused fetch() params

### DIFF
--- a/shared/pincodes.py
+++ b/shared/pincodes.py
@@ -361,20 +361,12 @@ class PinAttempt:
         # - call new_main_secret() when main secret changes!
         # - is_secret_blank and is_successful may be wrong now, re-login to get again
 
-    def fetch(self, duress_pin=None, spare_num=0, bypass_tmp=False):
+    def fetch(self, bypass_tmp=False):
         if self.tmp_value and not bypass_tmp:
             # must make a copy here, and must be mutable instance so not reused
-            if spare_num:
-                return bytearray(AE_SECRET_LEN)
             return bytearray(self.tmp_value)
 
-        if duress_pin is None:
-            secret = self.roundtrip(4, spare_num=spare_num)
-        else:
-            # mk3 and earlier
-            secret = self.roundtrip(4, old_pin=duress_pin, get_duress_secret=True)
-
-        return secret
+        return self.roundtrip(4)
 
     def ls_fetch(self):
         # get the "long secret"

--- a/testing/test_pincodes.py
+++ b/testing/test_pincodes.py
@@ -116,22 +116,6 @@ def test_greenlight(repl, setup_repl, is_mark4):
 
     repl.exec("dis.clear(); dis.text(0,0, 'done'); dis.show()")
 
-def test_duress(repl, setup_repl, only_mk3):
-    ss = repl.eval("pa.setup(b'')")
-    assert ss&0xf == 3
-
-    assert repl.eval('pa.private_state == 0') == False
-    assert repl.eval('pa.has_duress_pin()') == False
-    assert repl.eval('pa.is_successful()') == True
-    assert repl.eval("pa.change(is_duress=True, new_pin=b'34-34', old_pin=b'')") == None
-    assert repl.eval("pa.change(is_duress=True, new_secret=b'a'*72, old_pin=b'34-34')") == None
-    assert repl.eval("pa.fetch(duress_pin=b'34-34')") == b'a'*72
-    assert repl.eval("pa.change(is_duress=True, new_secret=bytes(72), old_pin=b'34-34', new_pin=b'')") == None
-    assert repl.eval('pa.has_duress_pin()') == False
-
-    # cleanup
-    repl.eval("pa.setup(b'')")
-
 MAX_ATT = 13
 
 @pytest.mark.parametrize('nfails', [MAX_ATT-1, 1, 3, 5])


### PR DESCRIPTION
`PinAttempt.fetch()` had `duress_pin` and `spare_num` parameters that no caller passes.

- `duress_pin` is the mk3-and-earlier duress path
- `spare_num` branch returning a zeroed buffer while a temporary seed is active was unreachable

`roundtrip(4)` is equivalent to the old `roundtrip(4, spare_num=0)`: `spare_num=None` skips the block, and `0 << 8` was a no-op on `change_flags`.

Tested on simulator: test_pwsave (11 passed), test_bip39pw (88 passed).
