### PR TITLE
bbqr: reject part sizes that would return unwritten bytes

### DIFF
--- a/shared/bbqr.py
+++ b/shared/bbqr.py
@@ -257,6 +257,7 @@ class BBQrStorage:
         self.hdr = None                 # could be any header in series
         self.runt_size = None
         self.final_size = None
+        self.parts = set()              # which parts we've written into buf
 
     def save_packet(self, blksize, hdr, which, data):
         # Record bytes (after deserialization, Base32/Hex decoding)
@@ -267,6 +268,14 @@ class BBQrStorage:
             self.hdr = hdr
         else:
             assert self.hdr.is_compat(hdr)
+
+        # Standard requires all parts to be equal size, except the final one which
+        # may be short. Enforce that, else final_size would count bytes we never
+        # write, and get_buffer() would hand those (uninitialized) bytes to caller.
+        assert len(data) <= blksize, 'part too big'
+        assert len(data) == blksize or which == hdr.num_parts-1, 'part too short'
+
+        self.parts.add(which)
 
         if which == hdr.num_parts-1:
             # size of runt determines final complete size
@@ -303,7 +312,8 @@ class BBQrStorage:
         self.final_size = len(self.buf)
 
     def _finalize(self):
-        pass
+        # every part must have arrived, or else buf holds bytes we never wrote
+        assert len(self.parts) == self.hdr.num_parts, 'missing part'
 
     def get_buffer(self):
         return self.buf
@@ -377,6 +387,8 @@ class BBQrPsramStorage(BBQrStorage):
     def _finalize(self):
         # flush out fragments to where they actually belong
         from glob import PSRAM
+
+        super()._finalize()
 
         while self.frags:
             off, data = self.frags.popitem()

--- a/testing/test_bbqr.py
+++ b/testing/test_bbqr.py
@@ -355,6 +355,49 @@ def test_split_unit(test_size, encoding, sim_exec, sim_eval):
                 assert target_ver == 40
 
 
+def test_part_sizes_unit(sim_exec):
+    # unit test for: bbqr.BBQrStorage.save_packet() part sizing rules
+    # - all parts must be blksize, except the final part which may be shorter
+    # - otherwise final_size counts bytes that were never written, and
+    #   get_buffer() hands that (uninitialized) PSRAM back as decoded data
+
+    setup = "import bbqr, ngu\nE = ngu.codecs.b32_encode\n" \
+            "st = bbqr.BBQrPsramStorage(); ss = bbqr.BBQrState(st)\n"
+
+    def attempt(body):
+        cmd = setup + "try:\n" + body + "\n    RV.write(b'accepted')\n" \
+                        "except AssertionError as exc:\n    RV.write(b'rejected: %s' % exc)"
+        print(f"CMD: {cmd}")
+        resp = sim_exec(cmd)
+        print(f"RESP: {resp}")
+        return resp
+
+    # middle part shorter than blksize
+    resp = attempt("    ss.collect('B$2U0300' + E(b'A'*15))\n"
+                   "    ss.collect('B$2U0301' + E(b'B'))")
+    assert resp.startswith('rejected'), resp
+
+    # final part longer than blksize
+    resp = attempt("    ss.collect('B$2U0300' + E(b'A'*15))\n"
+                   "    ss.collect('B$2U0302' + E(b'C'*99))")
+    assert resp.startswith('rejected'), resp
+
+    # a part never arrives: nothing may come back out
+    resp = attempt("    ss.collect('B$2U0300' + E(b'A'*15))\n"
+                   "    ss.collect('B$2U0302' + E(b'C'*4))\n"
+                   "    st.finalize()")
+    assert resp.startswith('rejected'), resp
+
+    # well formed: equal parts, short final part, arriving out of order
+    resp = sim_exec(setup + "ss.collect('B$2U0302' + E(b'C'*4))\n"
+                            "ss.collect('B$2U0301' + E(b'B'*15))\n"
+                            "ss.collect('B$2U0300' + E(b'A'*15))\n"
+                            "ty, sz, buf = st.finalize()\n"
+                            "RV.write(b'%r %d %r' % (ty, sz, bytes(buf)[0:sz]))")
+    print(f"RESP: {resp}")
+    assert resp.strip() == "'U' 34 %r" % (b'A'*15 + b'B'*15 + b'C'*4)
+
+
 @pytest.mark.bitcoind
 @pytest.mark.parametrize("file", [
     "data/sim_conso.psbt",


### PR DESCRIPTION
`BBQrStorage.save_packet()` (`shared/bbqr.py:271-282`) sizes the decoded result from
the geometry the QR series declares:

```python
        if which == hdr.num_parts-1:
            # size of runt determines final complete size
            self.runt_size = len(data)
            self.final_size = (blksize * (hdr.num_parts-1)) + self.runt_size
```

but `write_pkt()` only ever writes `len(data)` bytes. Nothing requires a non-final
part to be `blksize` long, nor `runt_size` to be `<= blksize`, and `blksize` is
whatever the first part to arrive happens to carry (`:232-233`). Any shortfall is
counted into `final_size` and never written.

`BBQrPsramStorage.get_buffer()` (`:437-440`) then returns
`PSRAM.read_at(0, self.final_size)`, and `psram.py:16-18` has no initialisation
check. PSRAM[0..2MB) is the PSBT staging area and is not wiped at boot, so the
uncounted bytes are whatever the previous scan or export left there. A 16-part series
carrying 43 attacker bytes came back as 239, and `decode_qr_result` classified the
result as text and routed it onward.

Fix: enforce in `save_packet()` what `collect()` (`:228`) already documents as a
required assumption, that every part is `blksize` except the final one which may be
short, and refuse in `_finalize()` to complete a series with a part missing.

Two things in the same file are deliberately left alone. `BBQrStorage.get_buffer()`
returns the whole buffer rather than `buf[:final_size]`, which nothing in tree reaches
because `scanner.py:251` uses the PSRAM subclass and that overrides `get_buffer()`
with a bounded read. `BBQrPsramStorage` does not override `reset()`, so a `frags` entry
from an abandoned series survives a header change and gets flushed into the next
series by `_finalize()`. That one is reachable and is a separate defect.

The new checks raise `AssertionError` out of `collect()`. `ux_q1.py:666`,
`actions.py:1451` and `tapsigner.py:54` do not catch it, where the neighbouring idiom
for this kind of rejection is `raise QRDecodeExplained` (`bbqr.py:198`).

---

Reported privately to security@coinkite.com and opened here as agreed.
