### PR TITLE
bugfix: dwld served PSRAM that the current USB session never staged

### DIFF
--- a/shared/usb.py
+++ b/shared/usb.py
@@ -135,6 +135,11 @@ class USBHandler:
         self.file_checksum = sha256()
         self.is_fw_upgrade = False
 
+        # How much of each of the two PSRAM files this session has staged.
+        # - 'dwld' serves nothing past this, so a session cannot read back
+        #   what some other session left in PSRAM
+        self.readable = [0, 0]
+
         # handle simulator
         self.blockable = getattr(self.dev, 'pipe', self.dev)
 
@@ -544,7 +549,7 @@ class USBHandler:
         if cmd == 'stok' or cmd == 'bkok' or cmd == 'smok' or cmd == 'pwok':
             # Have we finished (whatever) the transaction,
             # which needed user approval? If so, provide result.
-            from auth import UserAuthorizedAction
+            from auth import UserAuthorizedAction, RemoteBackup
 
             req = UserAuthorizedAction.active_request
             if not req:
@@ -577,6 +582,12 @@ class USBHandler:
                 # generic file response
                 resp_len, sha = req.result
                 UserAuthorizedAction.cleanup()
+
+                # allow it to be downloaded: backups are written to file zero,
+                # signing (and visualization) results to file one. Key off the
+                # request, since 'stok' and 'bkok' both reach here.
+                self.readable[0 if isinstance(req, RemoteBackup) else 1] = resp_len
+
                 return pack('<4sI32s', 'strx', resp_len, sha)
 
         if cmd == 'pass':
@@ -711,6 +722,9 @@ class USBHandler:
         if version == 0x2:
             self.bound = True
 
+        # new session: it has staged nothing yet, so it can download nothing
+        self.readable = [0, 0]
+
         # pick a random key pair, just for this session
         pair = ngu.secp256k1.keypair()
         my_pubkey = pair.pubkey().to_bytes(True)        # un-compressed
@@ -766,6 +780,11 @@ class USBHandler:
         assert offset + length <= MAX_TXN_LEN, "bad offset"
         assert 1 <= length, 'len'
 
+        # can only read back what this session staged, and only over the
+        # session that staged it (a new 'ncry' clears self.readable)
+        assert self.encrypted_req, 'must encrypt'
+        assert offset + length <= self.readable[file_number], 'not staged'
+
         # maintain a running SHA256 over what's sent
         if offset == 0:
             self.file_checksum = sha256()
@@ -793,6 +812,7 @@ class USBHandler:
         if offset == 0:
             self.file_checksum = sha256()
             self.is_fw_upgrade = False
+            self.readable[0] = 0
             dis.fullscreen("Receiving...", 0)
         else:
             dis.progress_sofar(offset, total_size)
@@ -846,6 +866,9 @@ class USBHandler:
 
             # write to PSRAM
             PSRAM.write(pos, here)
+
+        # they can read back what we just stored, but nothing beyond it
+        self.readable[0] = max(self.readable[0], offset + len(data))
 
         if offset+len(data) >= total_size and not hsm_active:
             # probably done

--- a/testing/test_usb.py
+++ b/testing/test_usb.py
@@ -262,6 +262,27 @@ def test_dwld_oob_psram_read(file_no, dev, mk_num):
         dev.send_recv(msg, encrypt=False)
     assert 'bad offset' in str(e.value)
 
+def test_dwld_needs_encryption(dev):
+    body = b'a' * 256
+    ll, sha = dev.upload_file(body)
+    msg = struct.pack('<4sIII', b'dwld', 0, ll, 0)
+    with pytest.raises(CCProtoError) as e:
+        dev.send_recv(msg, encrypt=False)
+    assert 'must encrypt' in str(e.value)
+
+    # ... but the session that uploaded it can have it back
+    assert dev.download_file(ll, sha, file_number=0) == body
+
+@pytest.mark.parametrize("file_no", [0, 1])
+def test_dwld_other_session(file_no, dev):
+    # nothing staged by an earlier session is readable after a new 'ncry'
+    ll, _ = dev.upload_file(b'a' * 256)
+    dev.start_encryption()
+    msg = struct.pack('<4sIII', b'dwld', 0, ll, file_no)
+    with pytest.raises(CCProtoError) as e:
+        dev.send_recv(msg)
+    assert 'not staged' in str(e.value)
+
 def test_p2sh_truncated_xfp_paths(dev):
     AF_P2SH = 0x08
     header = struct.pack('<IBBH', AF_P2SH, 1, 2, 30)


### PR DESCRIPTION
`handle_download` (`shared/usb.py:757-784`) bounds the read by the size of the window
and never by what this session actually put there:

```python
        assert 0 <= offset < MAX_TXN_LEN, "bad offset"
        assert offset + length <= MAX_TXN_LEN, "bad offset"
        ...
        pos = (MAX_TXN_LEN * file_number) + offset
        PSRAM.read(pos, buf)
```

Between them the two file numbers cover the whole 4MB window (`psram.py:10-11`), and
the lower half is never cleared: `psram_wipe_and_setup` (`psramdisk.c:527`) memsets
`PSRAM_TOP_BASE`, the upper half. So a later connection reads back what an earlier one
left, which for the lower window is the staged PSBT (`usb.py:848`) and the signed
result (`auth.py:779`). A plaintext link that never sends `ncry` swept all 4,194,304
bytes over 2,048 requests, and a separate session with its own `ncry` read another
session's PSBT and signed result with checksums matching the receipts the device had
handed out.

Fix: track how much of each of the two files this session staged and serve only that.
`self.readable = [0, 0]` clears at offset zero of an `upld` and rises after the write,
and is set from the length the device itself reports in the `stok`/`bkok` branch.
`handle_crypto_setup` clears both, and `dwld` now requires the encrypted session so a
peer that never sends `ncry` cannot inherit the previous session's extents.
`USBHandler` is a singleton built once per power-up (`usb.py:80-107`), so `ncry` is the
only point at which per-session state can be reset.

The file number comes from `isinstance(req, RemoteBackup)` rather than the command
name, because `stok` and `bkok` both reach that branch against whatever request is
pending (`:544`), so the host would otherwise choose which extent gets opened. This
matches how `:392-396` already keys on `isinstance(req, FirmwareUpgradeRequest)`.

Not covered: `MAX_UPLOAD_LEN` is 4MB and `upld` writes at absolute `pos` (checked at
`:801`), so an upload running past 2MB lands in file one's window while only file
zero's extent rises. The only upload I found that goes that large is the firmware
upgrade, which is checked with `sha2` rather than read back, so I left it rather than
guess at the right accounting.

---

Reported privately to security@coinkite.com and opened here as agreed.
