### PR TITLE
multisig: reject a cosigner key the device already holds

### DIFF
--- a/shared/multisig.py
+++ b/shared/multisig.py
@@ -864,7 +864,18 @@ class MultisigWallet(WalletABC):
 
         # serialize xpub w/ BIP-32 standard now.
         # - this has effect of stripping SLIP-132 confusion away
-        xpubs.append((xfp, deriv, chain.serialize_public(node, AF_P2SH)))
+        here = chain.serialize_public(node, AF_P2SH)
+
+        # reject a key we already have, even under a different fingerprint
+        # - dedup in __init__ is keyed on XFP, which is just text in the config file
+        # - compare pubkeys, not the serialization: depth, parent_fp and child_num
+        #   are unchecked at depth>1, so one key has many valid spellings
+        here_pk = node.pubkey()
+        for _, _, prev in xpubs:
+            prev_node = chain.deserialize_node(prev, AF_P2SH)
+            assert here_pk != prev_node.pubkey(), 'dup xpub'
+
+        xpubs.append((xfp, deriv, here))
 
         return (xfp == my_xfp)
 
@@ -1816,6 +1827,30 @@ async def ondevice_multisig_create(mode='p2wsh', addr_fmt=AF_P2WSH, is_qr=False,
             dis.fullscreen("Wait...")
             xpubs.append(add_own_xpub(chain, acct, addr_fmt))
             num_mine += 1
+
+    # dedup again, over the merged list
+    # - check_xpub saw slot A only; slot B and our own key arrive after it
+    # - the filters above are keyed on xfp, which the file gets to pick
+    seen = []
+    for _, _, xpub in xpubs:
+        pk = chain.deserialize_node(xpub, AF_P2SH).pubkey()
+        if pk in seen:
+            await ux_show_story("Same key offered twice, under two fingerprints.")
+            return
+        seen.append(pk)
+
+    # ...and no leg may be a key we already hold: xfp is just text from the file,
+    # so derive at the offered path and compare instead of trusting it
+    for sec in ([None, secret] if for_ccc else [None]):
+        with stash.SensitiveValues(secret=sec) as sv:
+            mine = sv.get_xfp()
+            for xfp, deriv, xpub in xpubs:
+                if xfp == mine: continue        # we put that one there ourselves
+                if sv.derive_path(deriv).pubkey() == \
+                        chain.deserialize_node(xpub, AF_P2SH).pubkey():
+                    await ux_show_story("Co-signer [%s] is a key this Coldcard has."
+                                        % xfp2str(xfp))
+                    return
 
     N = len(xpubs)
 


### PR DESCRIPTION
The only cosigner dedup is in `MultisigWallet.__init__` (`shared/multisig.py:145-149`)
and it is keyed on fingerprint:

```python
        for xfp, deriv, xpub in self.xpubs:
            self.xfp_paths[xfp] = str_to_keypath(xfp, deriv)

        assert len(self.xfp_paths) == self.N, 'dup XFP'
```

`xpub` is unpacked there and never used. Fingerprints are attacker-chosen text in the
config file, so one key under two labels passes that check and `make_redeem_script`
puts it in the script twice. Enrolled through `enrl`, the firmware's own
`yield_addresses()` gives `OP_2 <attacker> <attacker> <victim> OP_3`, two distinct
pubkeys of three. Ceiling is 14-of-15 by one key, 15-of-15 with Skip Checks. The
device refuses to co-sign it at spend time, so the loss is deposits into a wallet
with less redundancy than it displays.

Three changes:

1. `check_xpub` compares `node.pubkey()` against the legs already accepted. Not the
   serialized xpub: `depth`, `parent_fp` and `child_num` are unchecked at depth>1
   (`:822-829`, `:835-845`), libngu re-emits them verbatim, and `make_redeem_script`
   derives from chaincode and pubkey only (`:96-97`). A string compare falls to a
   four-byte edit of `parent_fp`.

2. The same comparison again over the merged list in `ondevice_multisig_create`.
   `check_xpub` only ever sees one accumulator: slot B is appended at `:1768`,
   `list(set(xpubs))` at `:1773` dedups exact tuples only, and both the CCC filter at
   `:1798` and the `add_own_xpub` insert at `:1817` are keyed on xfp.

3. A key the device already holds is refused whatever account it claims. The xfp in a
   `ccxp-*.json` is plain text (`:1540`), so anyone who has received an export can
   relabel it and offer the key back at a different account, where the pubkeys differ
   and no equality test sees it. The file supplies the derivation path, so the device
   derives at that path and compares.

On the CCC path this is worse: `M` is forced to 2, so a planted copy of key A gives
the master seed two of the legs and it meets the threshold alone, without the
spending policy binding.

`Multisig Wallets → Import` is not covered. The same key at a different account still
gets through there, because the cross-check in `check_xpub` (`:856-863`) only runs
when the xfp claims to be the device's own, and covering it means running the derive
on `from_psbt` during signing.

---

Reported privately to security@coinkite.com and opened here as agreed.
