### PR TITLE
bugfix: dice roll screen counted key-repeat events as dice rolls

### DIFF
--- a/shared/seed.py
+++ b/shared/seed.py
@@ -397,9 +397,8 @@ async def add_dice_rolls(count, seed, judge_them, nwords=None, enforce=False):
 
     counter = {}
     md = sha256(seed)
-    # no key-repeat on any key we act on: a held digit is one roll, not many
-    # - same idea as ux_mk4.ux_enter_number, which puts its digits in need_release
-    pr = PressRelease('123456' + KEY_ENTER + KEY_CANCEL + 'xy')
+    done_keys = (KEY_ENTER + KEY_CANCEL) if version.has_qwerty else 'yx'
+    pr = PressRelease('123456' + done_keys)
 
     # draws initial screen, and returns funct to update count and/or hash
     screen_updater = ux_dice_rolling()

--- a/shared/seed.py
+++ b/shared/seed.py
@@ -397,7 +397,9 @@ async def add_dice_rolls(count, seed, judge_them, nwords=None, enforce=False):
 
     counter = {}
     md = sha256(seed)
-    pr = PressRelease()
+    # no key-repeat on any key we act on: a held digit is one roll, not many
+    # - same idea as ux_mk4.ux_enter_number, which puts its digits in need_release
+    pr = PressRelease('123456' + KEY_ENTER + KEY_CANCEL + 'xy')
 
     # draws initial screen, and returns funct to update count and/or hash
     screen_updater = ux_dice_rolling()


### PR DESCRIPTION
`add_dice_rolls()` builds its key reader with no argument (`shared/seed.py:400`), so
`need_release` is the default `KEY_ENTER+KEY_CANCEL` on Q and `'xy'` on Mk. The digits
are in neither, so a held digit takes the key-repeat branch (`ux_q1.py:47-51`) and is
re-delivered about every 60ms for as long as it stays down. Each delivery hits
`count += 1` (`:417`) and `md.update(ch)` (`:424`).

Four presses held two seconds each produce over 99 counted rolls. Both gates pass,
the roll minimum at `:432` and the distribution check at `:452`, and the device offers
a 24-word seed built from 4 rolls, 10.3 bits, presented as 256-bit.

Fix: put the digits in `need_release`, so a roll arms on key-down and counts on key-up
(`ux_q1.py:70-74`, `ux_mk4.py:51-57`) and the repeat branch cannot reach the counter.
`ux_mk4.ux_enter_number:72` and `ux_input_digits:123` already do this for their digits.

A roll now registers on release, so if a second digit goes down while the first is
still held, `PressRelease` re-arms on the second and the first is dropped. That
under-counts, so the minimum-rolls gate asks for more rolls.

Worth noting for coverage: the existing tests drive keys through `numpad.inject()`
(`numpad.py:39-44`), which queues a press and a release together, so they cannot
express a held key.

---

Reported privately to security@coinkite.com and opened here as agreed.
