### PR TITLE
multisig: reject duplicate cosigner keys and keys the device already holds

### DIFF
--- a/releases/Next-ChangeLog.md
+++ b/releases/Next-ChangeLog.md
@@ -31,6 +31,8 @@ This lists the new changes that have not yet been published in a normal release.
   before signing, so the signature covered a different transaction than shown.
   Staged bytes are now re-verified before signing; any change aborts with
   "Transaction modified". Thanks to FreeZ Agent for the report and PoC.
+- Bugfix: Reject duplicate cosigner keys, and cosigner keys the device already holds,
+  during multisig wallet enrollment. Thanks to drk1wi for reporting this.
 
 # Mk Specific Changes
 

--- a/shared/multisig.py
+++ b/shared/multisig.py
@@ -787,6 +787,8 @@ class MultisigWallet(WalletABC):
         assert has_mine != 0, 'my key not included'
         assert has_mine == 1, 'my key included more than once'
 
+        cls.check_unique_cosigner_keys(xpubs)
+
         # done. have all the parts
         return cls(name, (M, N), xpubs, addr_fmt=addr_fmt,
                    chain_type=expect_chain, bip67=bip67)
@@ -867,6 +869,26 @@ class MultisigWallet(WalletABC):
         xpubs.append((xfp, deriv, chain.serialize_public(node, AF_P2SH)))
 
         return (xfp == my_xfp)
+
+    @classmethod
+    def check_unique_cosigner_keys(cls, xpubs):
+        # Final enrollment-time check over a complete cosigner list of (xfp, deriv, xpub):
+        # - no two legs may be the same key: XFP is attacker-chosen text in the config
+        #   file, and depth/parent_fp/child_num are unchecked at depth>1, so compare
+        #   pubkeys, not XFPs and not serialized xpubs (one key has many spellings)
+        # - no leg may be a key this device already holds, whatever XFP/account it
+        #   claims: derive at the offered path and compare. Legs claiming our XFP are
+        #   skipped here; check_xpub already derive-verified those against us.
+        chain = chains.current_chain()
+        pks = [chain.deserialize_node(xpub, AF_P2SH).pubkey() for _, _, xpub in xpubs]
+        assert len(set(pks)) == len(pks), 'same key under two XFPs'
+
+        with stash.SensitiveValues() as sv:
+            mine = sv.get_xfp()
+            for (xfp, deriv, _), pk in zip(xpubs, pks):
+                if xfp == mine: continue
+                assert sv.derive_path(deriv).pubkey() != pk, \
+                            '[%s] is our key' % xfp2str(xfp)
 
     def make_fname(self, prefix, suffix='txt'):
         rv = '%s-%s.%s' % (prefix, self.name, suffix)
@@ -1006,6 +1028,8 @@ class MultisigWallet(WalletABC):
                 has_mine += 1
 
         assert has_mine == 1         # 'my key not included'
+
+        cls.check_unique_cosigner_keys(xpubs)
 
         name = 'PSBT-%d-of-%d' % (M, N)
         # this will always create sortedmulti multisig (BIP-67)
@@ -1798,6 +1822,18 @@ async def ondevice_multisig_create(mode='p2wsh', addr_fmt=AF_P2WSH, is_qr=False,
         got_xfps = [a[0], c[0]]
         xpubs = [x for x in xpubs if x[0] not in got_xfps]
 
+        # key C is also ours: no offered leg may be that key, whatever XFP or
+        # account it claims - derive at the offered path and compare (legs
+        # claiming its XFP were filtered above; key A is covered by the
+        # check_unique_cosigner_keys call below)
+        with stash.SensitiveValues(secret=secret) as sv:
+            for xfp, deriv, xpub in xpubs:
+                if sv.derive_path(deriv).pubkey() == \
+                        chain.deserialize_node(xpub, AF_P2SH).pubkey():
+                    await ux_show_story("Co-signer [%s] is this device's key C."
+                                        % xfp2str(xfp))
+                    return
+
         if not xpubs:
             await ux_show_story("Need at least one other co-signer (key B).")
             return
@@ -1816,6 +1852,12 @@ async def ondevice_multisig_create(mode='p2wsh', addr_fmt=AF_P2WSH, is_qr=False,
             dis.fullscreen("Wait...")
             xpubs.append(add_own_xpub(chain, acct, addr_fmt))
             num_mine += 1
+
+    try:
+        MultisigWallet.check_unique_cosigner_keys(xpubs)
+    except AssertionError as exc:
+        await ux_show_story("Cosigner key rejected: %s." % exc)
+        return
 
     N = len(xpubs)
 

--- a/testing/test_multisig.py
+++ b/testing/test_multisig.py
@@ -1172,6 +1172,29 @@ def test_import_dup_xfp_fails(m_of_n, use_regtest, addr_fmt, clear_ms,
     #assert 'XFP' in str(ee)
     assert 'wrong pubkey' in str(ee)
 
+@pytest.mark.parametrize('case', ['dup_key_two_xfps', 'own_key_other_acct'])
+def test_import_dup_cosigner_key_fails(case, clear_ms, make_multisig, import_ms_wallet):
+    # cosigner dedup cannot be keyed on XFP: that is attacker-chosen text
+    M, N = 2, 3
+    keys = make_multisig(M, N, deriv="m/48h/1h/0h/2h")
+
+    if case == 'dup_key_two_xfps':
+        # same cosigner key offered twice, under two different fingerprints
+        keys[1] = (0x0badf00d, keys[0][1], keys[0][2])
+        derivs, msg = None, 'same key under two XFPs'
+    else:
+        # device's own key offered back under a fake XFP, at a different account
+        # - pubkeys differ from its real leg; only derive-and-compare catches it
+        dev_pk = BIP32Node.from_wallet_key(simulator_fixed_tprv)
+        keys[0] = (0x0badf00d, dev_pk, dev_pk.subkey_for_path("m/48h/1h/5h/2h"))
+        derivs = ["m/48h/1h/5h/2h"] + ["m/48h/1h/0h/2h"] * (N-1)
+        msg = 'is our key'
+
+    with pytest.raises(Exception) as ee:
+        import_ms_wallet(M, N, 'p2wsh', accept=1, keys=keys,
+                         common=None if derivs else "m/48h/1h/0h/2h", derivs=derivs)
+    assert msg in str(ee)
+
 @pytest.mark.parametrize('addr_fmt', [AF_P2SH, AF_P2WSH, AF_P2WSH_P2SH])
 @pytest.mark.parametrize('desc', ["multi", "sortedmulti"])
 def test_ms_cli(dev, addr_fmt, clear_ms, import_ms_wallet, addr_vs_path, desc):


### PR DESCRIPTION
Cosigner dedup was keyed on XFP, which is just text in the config file — so one key could enroll twice under two fingerprints, and our own key could be offered back under a fake one. On the CCC path (M=2) that's enough for the device to meet the threshold alone.

One classmethod, `MultisigWallet.check_unique_cosigner_keys()`, called from `from_file`, `import_from_psbt` and `ondevice_multisig_create`: no two legs may share a pubkey, and no leg may be a key we hold (derive at the claimed path and compare — works whatever XFP/account the file claims). Key C gets the same check inline in the CCC block.


