### PR TITLE
bugfix: reject malformed BBQr part geometry

### DIFF
--- a/releases/Next-ChangeLog.md
+++ b/releases/Next-ChangeLog.md
@@ -20,4 +20,5 @@ This lists the new changes that have not yet been published in a normal release.
 
 ## 1.4.xQ - 2065-09-xx
 
-- tbd
+- Bugfix: Reject malformed multipart BBQrs that could include stale PSRAM bytes in decoded
+  results. Thanks to Piotr Duszynski for reporting this.

--- a/shared/bbqr.py
+++ b/shared/bbqr.py
@@ -11,6 +11,11 @@ from version import MAX_TXN_LEN
 b32encode = ngu.codecs.b32_encode
 b32decode = ngu.codecs.b32_decode
 
+
+class BBQrInvalidPart(QRDecodeExplained):
+    pass
+
+
 TYPE_LABELS = dict(P='PSBT File', T='Transaction', J='JSON', C='CBOR', U='Unicode Text',
                         X='Executable', B='Binary', 
                         R='KT Rx', S='KT Tx', E='KT PSBT')
@@ -227,17 +232,32 @@ class BBQrState:
             else:
                 # based on (required) assumption that all parts are equal, we know
                 # where to put this data, so do that.
-                self.parts.add(hdr.which)
-
                 if self.blksize is None:
                     self.blksize = len(raw)
 
-                self.storage.save_packet(self.blksize, hdr, hdr.which, raw)
+                try:
+                    self.storage.save_packet(self.blksize, hdr, hdr.which, raw)
+                except BBQrInvalidPart:
+                    # A successfully decoded QR can still violate BBQr's part-size
+                    # rules. Discard the series and keep scanning, just as for a
+                    # corrupt body, instead of escaping into the caller's UX task.
+                    dis.draw_bbqr_progress(hdr, self.parts, corrupt=True)
+                    self.reset()
+                    self.storage.reset()
+                    return True
+
+                self.parts.add(hdr.which)
 
         # seeing any other packet is enough to decide where to put the runt
         if self.runt and self.blksize:
             wh, raw = self.runt
-            self.storage.save_packet(self.blksize, hdr, wh, raw)
+            try:
+                self.storage.save_packet(self.blksize, hdr, wh, raw)
+            except BBQrInvalidPart:
+                dis.draw_bbqr_progress(hdr, self.parts, corrupt=True)
+                self.reset()
+                self.storage.reset()
+                return True
             self.runt = None
 
         # provide UX -- even if we didn't use it
@@ -257,21 +277,25 @@ class BBQrStorage:
         self.hdr = None                 # could be any header in series
         self.runt_size = None
         self.final_size = None
+        self.parts = set()              # which parts have been written into buf
 
     def save_packet(self, blksize, hdr, which, data):
         # Record bytes (after deserialization, Base32/Hex decoding)
         # - might be zlib compressed still, but certainly binary
-        assert blksize
+        if not blksize:
+            raise BBQrInvalidPart("Empty BBQr part")
+
+        if self.hdr:
+            assert self.hdr.is_compat(hdr)
+
+        # All decoded parts must be the same size, except the final part which
+        # may be shorter. Otherwise final_size can include bytes never written.
+        if len(data) > blksize or \
+                (which != hdr.num_parts-1 and len(data) != blksize):
+            raise BBQrInvalidPart("Invalid BBQr part size")
 
         if not self.hdr:
             self.hdr = hdr
-        else:
-            assert self.hdr.is_compat(hdr)
-
-        if which == hdr.num_parts-1:
-            # size of runt determines final complete size
-            self.runt_size = len(data)
-            self.final_size = (blksize * (hdr.num_parts-1)) + self.runt_size
 
         if not self.buf:
             # memory alloc now
@@ -280,6 +304,13 @@ class BBQrStorage:
 
         offset = which * blksize
         self.write_pkt(offset, data)
+
+        if which == hdr.num_parts-1:
+            # size of runt determines final complete size
+            self.runt_size = len(data)
+            self.final_size = (blksize * (hdr.num_parts-1)) + self.runt_size
+
+        self.parts.add(which)
 
     def alloc_buf(self, upper_bound):
         # set aside space needed for whole thing
@@ -305,12 +336,18 @@ class BBQrStorage:
     def _finalize(self):
         pass
 
+    def _check_complete(self):
+        # Never return bytes from a slot that save_packet() did not write.
+        if not self.hdr or len(self.parts) != self.hdr.num_parts:
+            raise QRDecodeExplained("Missing BBQr part")
+
     def get_buffer(self):
         return self.buf
 
     def finalize(self):
         # Got all the parts, so maybe decompress. Return details of what we got
         # - return: file type, exact final size
+        self._check_complete()
         self._finalize()
 
         if self.hdr.encoding == 'Z':
@@ -322,8 +359,8 @@ class BBQrStorage:
 class BBQrPsramStorage(BBQrStorage):
     # specialized verison for use on funky PSRAM chip of Q
 
-    def __init__(self):
-        super().__init__()
+    def reset(self):
+        super().reset()
         self.frags = dict()
         self.psr_offset = 0
 
@@ -440,6 +477,7 @@ class BBQrPsramStorage(BBQrStorage):
         return PSRAM.read_at(0, self.final_size)
 
     def finalize(self):
+        self._check_complete()
         self._finalize()
 
         if self.hdr.encoding == 'Z':

--- a/testing/test_bbqr.py
+++ b/testing/test_bbqr.py
@@ -355,6 +355,102 @@ def test_split_unit(test_size, encoding, sim_exec, sim_eval):
                 assert target_ver == 40
 
 
+def test_reject_bad_part_sizes_unit(sim_exec):
+    setup = "import bbqr, ngu\nE = ngu.codecs.b32_encode\n" \
+            "st = bbqr.BBQrPsramStorage(); ss = bbqr.BBQrState(st)\n"
+
+    cases = [
+        # A non-final part shorter than the established block size.
+        "ss.collect('B$2U0300' + E(b'A'*15))\n" \
+        "more = ss.collect('B$2U0301' + E(b'B'))",
+
+        # The final part may be shorter, but never longer.
+        "ss.collect('B$2U0300' + E(b'A'*15))\n" \
+        "more = ss.collect('B$2U0302' + E(b'C'*99))",
+
+        # Apply the same rule when the final part arrives first as a runt.
+        "ss.collect('B$2U0302' + E(b'C'*99))\n" \
+        "more = ss.collect('B$2U0300' + E(b'A'*15))",
+
+        # A short first part cannot redefine the geometry of later parts.
+        "ss.collect('B$2U0300' + E(b'A'))\n" \
+        "more = ss.collect('B$2U0301' + E(b'B'*15))",
+    ]
+
+    for body in cases:
+        cmd = setup + body + "\nRV.write(repr((more, ss.hdr is None, " \
+                            "len(ss.parts), st.hdr is None, len(st.parts), " \
+                            "len(st.frags))))"
+        print(f"CMD: {cmd}")
+        resp = sim_exec(cmd)
+        print(f"RESP: {resp}")
+
+        # Invalid geometry is a recoverable corrupt scan: no exception escapes,
+        # and neither collector nor storage retains attacker-controlled state.
+        assert resp == '(True, True, 0, True, 0, 0)'
+
+
+def test_bbqr_storage_guards_unit(sim_exec):
+    setup = "import bbqr, ngu\nE = ngu.codecs.b32_encode\n"
+
+    # Storage enforces the sizing rule even when used without BBQrState.
+    resp = sim_exec(setup +
+        "st = bbqr.BBQrPsramStorage()\n"
+        "h0 = bbqr.BBQrHeader('B$2U0300')\n"
+        "h1 = bbqr.BBQrHeader('B$2U0301')\n"
+        "st.save_packet(15, h0, 0, b'A'*15)\n"
+        "try:\n"
+        "    st.save_packet(15, h1, 1, b'B')\n"
+        "except bbqr.BBQrInvalidPart as exc:\n"
+        "    RV.write(str(exc))")
+    assert resp == 'Invalid BBQr part size'
+
+    # Flushing alignment fragments is valid before completion, but public
+    # finalization must reject a missing part instead of returning PSRAM bytes.
+    resp = sim_exec(setup +
+        "st = bbqr.BBQrPsramStorage()\n"
+        "h0 = bbqr.BBQrHeader('B$2U0300')\n"
+        "h2 = bbqr.BBQrHeader('B$2U0302')\n"
+        "st.save_packet(15, h0, 0, b'A'*15)\n"
+        "st.save_packet(15, h2, 2, b'C'*4)\n"
+        "st._finalize()\n"
+        "try:\n"
+        "    st.finalize()\n"
+        "except bbqr.QRDecodeExplained as exc:\n"
+        "    RV.write(str(exc))")
+    assert resp == 'Missing BBQr part'
+
+    # Preserve valid out-of-order input, repeated frames and a short final part.
+    resp = sim_exec(setup +
+        "st = bbqr.BBQrPsramStorage(); ss = bbqr.BBQrState(st)\n"
+        "ss.collect('B$2U0302' + E(b'C'*4))\n"
+        "ss.collect('B$2U0301' + E(b'B'*15))\n"
+        "ss.collect('B$2U0301' + E(b'B'*15))\n"
+        "ss.collect('B$2U0300' + E(b'A'*15))\n"
+        "ty, sz, buf = st.finalize()\n"
+        "RV.write(b'%r %d %r' % (ty, sz, bytes(buf)[0:sz]))")
+    assert resp == "'U' 34 %r" % (b'A'*15 + b'B'*15 + b'C'*4)
+
+
+def test_bbqr_psram_reset_unit(sim_exec):
+    # An abandoned unaligned series must not leave fragments that are flushed
+    # into the next, otherwise valid, series.
+    cmd = "import bbqr, ngu\nE = ngu.codecs.b32_encode\n" \
+          "st = bbqr.BBQrPsramStorage(); ss = bbqr.BBQrState(st)\n" \
+          "ss.collect('B$2U0200' + E(b'A'*5))\n" \
+          "had_frags = bool(st.frags)\n" \
+          "ss.collect('B$2J0200' + E(b'B'*8))\n" \
+          "frags_after_reset = len(st.frags)\n" \
+          "ss.collect('B$2J0201' + E(b'C'*4))\n" \
+          "ty, sz, buf = st.finalize()\n" \
+          "RV.write(repr((had_frags, frags_after_reset, ty, sz, " \
+                         "bytes(buf)[0:sz])))"
+    print(f"CMD: {cmd}")
+    resp = sim_exec(cmd)
+    print(f"RESP: {resp}")
+    assert resp == repr((True, 0, 'J', 12, b'BBBBBBBBCCCC'))
+
+
 @pytest.mark.bitcoind
 @pytest.mark.parametrize("file", [
     "data/sim_conso.psbt",


### PR DESCRIPTION
Supersedes #718 with the additional state, UX and integration hardening found during review. Thanks to @drk1wi for the original report and patch.

## Summary

- require every decoded multipart BBQr block to match the established block size, except for a shorter final block
- track successfully written parts and refuse to finalize incomplete storage
- treat invalid geometry as a recoverable corrupt scan instead of escaping an AssertionError into callers
- clear pending PSRAM alignment fragments and offsets when a QR series resets
- keep partial fragment flushing separate from completeness checks, so repeated-frame comparison can safely inspect an incomplete series
- add Q release notes and regression coverage

This prevents calculated result lengths from including PSRAM bytes that were never written by the current QR series.
