### PR TITLE
bugfix: simulator crashed, then hung, on Destroy Seed

### DIFF
--- a/testing/test_sim_pyb.py
+++ b/testing/test_sim_pyb.py
@@ -1,0 +1,88 @@
+# Regression tests for the simulator's `pyb` stand-in module.
+#
+# unix/variant/pyb.py fakes the pyb module for the unix simulator. Anything the
+# shared firmware reaches for on `pyb` has to exist there, or the simulator dies
+# with AttributeError at the moment that code path runs - which is typically deep
+# in a menu action, long after boot.
+#
+import ast, os, pytest
+
+HERE = os.path.dirname(__file__)
+PYB = os.path.join(HERE, '..', 'unix', 'variant', 'pyb.py')
+SHARED = os.path.join(HERE, '..', 'shared')
+
+# used only on the real device: shared/usb.py guards it with `if is_simulator()`
+GUARDED = {'hid_keyboard'}
+
+def pyb_tree():
+    with open(PYB, 'rt') as fd:
+        return ast.parse(fd.read(), filename='pyb.py')
+
+def sim_pyb_names():
+    # top-level names the simulator's pyb module provides
+    names = set()
+    for node in pyb_tree().body:
+        if isinstance(node, (ast.FunctionDef, ast.ClassDef)):
+            names.add(node.name)
+        elif isinstance(node, ast.Assign):
+            for t in node.targets:
+                if isinstance(t, ast.Name):
+                    names.add(t.id)
+    return names
+
+def pyb_attrs_used():
+    # every pyb.<attr> the shared firmware references
+    used = {}
+    for fn in sorted(os.listdir(SHARED)):
+        if not fn.endswith('.py'):
+            continue
+        try:
+            with open(os.path.join(SHARED, fn), 'rt') as fd:
+                src = fd.read()
+        except OSError:
+            continue        # symlink into an uninitialized submodule
+        tree = ast.parse(src, filename=fn)
+        for node in ast.walk(tree):
+            if (isinstance(node, ast.Attribute)
+                    and isinstance(node.value, ast.Name)
+                    and node.value.id == 'pyb'):
+                used.setdefault(node.attr, []).append('%s:%d' % (fn, node.lineno))
+    return used
+
+def load_flash_class():
+    # compile just the Flash class - pyb.py as a whole imports utime/usocket,
+    # which don't exist off-device
+    for node in pyb_tree().body:
+        if isinstance(node, ast.ClassDef) and node.name == 'Flash':
+            mod = ast.Module(body=[node], type_ignores=[])
+            ast.fix_missing_locations(mod)
+            ns = {}
+            exec(compile(mod, 'pyb.py', 'exec'), ns)
+            return ns['Flash']
+    return None
+
+@pytest.mark.parametrize('attr', sorted(a for a in pyb_attrs_used() if a not in GUARDED))
+def test_pyb_attr_exists_in_simulator(attr):
+    # every pyb.<attr> the firmware uses must exist in the simulator's stand-in
+    where = ', '.join(pyb_attrs_used()[attr])
+    assert attr in sim_pyb_names(), \
+        "shared/ uses pyb.%s (%s) but unix/variant/pyb.py does not define it" % (attr, where)
+
+def test_flash_is_a_block_device():
+    # files.py wipe_flash_filesystem() drives it as a block device
+    Flash = load_flash_class()
+    assert Flash is not None, "unix/variant/pyb.py defines no Flash class"
+
+    fl = Flash(start=0)         # files.py:59 - "start=0 does magic things"
+
+    BP_IOCTL_SEC_COUNT, BP_IOCTL_SEC_SIZE = 4, 5
+    bsize = fl.ioctl(BP_IOCTL_SEC_SIZE, 0)
+    assert bsize == 512, "files.py asserts bsize == 512, got %r" % (bsize,)
+
+    bcount = fl.ioctl(BP_IOCTL_SEC_COUNT, 0)
+    assert isinstance(bcount, int) and bcount > 0, \
+        "sector count must be a positive int, got %r" % (bcount,)
+
+    # the wipe writes a full block of random bytes to every sector
+    fl.writeblocks(0, bytearray(bsize))
+    fl.writeblocks(bcount - 1, bytearray(bsize))

--- a/unix/variant/ckcc.py
+++ b/unix/variant/ckcc.py
@@ -187,13 +187,26 @@ def gate(method, buf_io, arg2):
 
     return ENOENT
 
+# what the bootloader does for each one-way callgate; all of them end firmware execution
+ONEWAY_WHAT = {
+    2: 'enter DFU',
+    3: 'wipe memory, logout & reboot',
+    23: 'wipe seed & reboot',
+    24: 'brick & reboot',
+}
+
 def oneway(method, arg2):
 
     # TODO: capture method/arg2 into an object so unit tests can read it back while we are dead
 
     print("\n\nNOTE: One-way callgate into bootloader: method=%d arg2=%d\n\n" % (method, arg2))
-    while 1:
-        utime.sleep(60)
+
+    # Real device: bootloader takes over here and this firmware never runs again. We
+    # can't reboot, and spinning forever just leaves the last frame on screen, which
+    # looks exactly like a crash - so stop, and say why.
+    print("Simulator: would %s. Exiting.\n" % ONEWAY_WHAT.get(method, 'halt'))
+
+    raise SystemExit
 
 def is_simulator():
     return True

--- a/unix/variant/pyb.py
+++ b/unix/variant/pyb.py
@@ -134,6 +134,34 @@ class SDCard:
         pass
 
 
+class Flash:
+    # Internal flash filesystem as a block device. Real mk4 has 512-byte
+    # sectors, and files.py asserts that. No real flash here, so - like
+    # SDCard above - this just pretends.
+    SEC_SIZE = 512
+    SEC_COUNT = 256         # nominal: only paces the wipe's progress bar here
+
+    def __init__(self, start=0, **kws):
+        # files.py/mk4.py pass start=0, which "does magic things" on-device
+        return
+
+    def ioctl(self, op, arg):
+        # opcodes from extmod/vfs.h
+        if op == 4:                 # BP_IOCTL_SEC_COUNT
+            return self.SEC_COUNT
+        if op == 5:                 # BP_IOCTL_SEC_SIZE
+            return self.SEC_SIZE
+        return 0
+
+    def readblocks(self, n, buf, off=0):
+        for i in range(len(buf)):
+            buf[i] = 0xff           # erased flash reads as ones
+
+    # so wipe_flash_filesystem() can pretend to work
+    def writeblocks(self, n, buf, off=0):
+        pass
+
+
 class ExtInt:
     def __init__(self, *a, **kw):
         return


### PR DESCRIPTION
Destroy Seed could not complete in the unix simulator. Two separate problems, one behind the other.

### 1. `pyb.Flash` was missing (crash)

`wipe_flash_filesystem()` drives internal flash as a block device via `pyb.Flash(start=0)` (`shared/files.py:59`), but `unix/variant/pyb.py` never defined `Flash`:

```
File "shared/actions.py", line 609, in clear_seed
File "shared/files.py", line 59, in wipe_flash_filesystem
AttributeError: 'module' object has no attribute 'Flash'
```

This fails *after* both confirmations and after trick PINs are cleared, so the wallet is left half-wiped.

Adds a `Flash` block-device stub alongside the existing `SDCard` one, using the same "pretend to work" approach: 512-byte sectors, as `files.py:61` asserts, and writes that go nowhere. Also adds `testing/test_sim_pyb.py`, which holds the simulator's `pyb` to the attributes `shared/` actually references — that is what would have caught this before it reached a menu action.

### 2. The callgate then hung the simulator

With the crash fixed, Destroy Seed ran to completion and sat on "Clearing..." forever. `ckcc.oneway()` printed a NOTE and then looped on `utime.sleep(60)`, so the last drawn frame stayed on screen — a finished wipe and a crash look identical.

It now raises `SystemExit` and names what the bootloader would have done. All four one-way methods end firmware execution on real hardware (DFU, logout, wipe, brick), so all four stop rather than spin. `machine.py` already does exactly this for `bootloader()`/`soft_reset()`/`reset()`, and the simulator runs with `-i`, so this lands at the REPL the same way a simulated reset always has.

`machine.py`'s `_flush_data()` is deliberately *not* called here: it does `settings.save()`, and `clear_seed()` blanks settings on the line before `fast_wipe()`, so flushing would write back what was just erased.

### Testing

- `testing/test_sim_pyb.py` — 7/7 pass
- Destroy Seed run end to end in the simulator, which now finishes and stops cleanly:

```
NOTE: One-way callgate into bootloader: method=23 arg2=48879
Simulator: would wipe seed & reboot. Exiting.
```

- Nothing under `testing/` references `oneway`, `fast_wipe`, `show_logout`, or `enter_dfu`
- `bare_metal.py` installs its own `my_oneway`, so bare-metal mode is unaffected

Simulator-only — no changes to `shared/` or any on-device code path.

<img width="512" height="156" alt="Screenshot 2026-08-14 at 7 20 23 PM" src="https://github.com/user-attachments/assets/59aac170-c1f7-47df-8676-0b6dca03c3f1" />

