### PR TITLE
Confirm cloned seed fingerprint

### DIFF
--- a/releases/Next-ChangeLog.md
+++ b/releases/Next-ChangeLog.md
@@ -57,6 +57,8 @@ This lists the new changes that have not yet been published in a normal release.
   during multisig wallet enrollment. Thanks to drk1wi for reporting this.
 - Bugfix: Separate the SE1 check nonce from the PIN digest. Thanks to
   [@instagibbs](https://github.com/instagibbs) for reporting this issue.
+- Enhancement: Clone Coldcard now shows the restored seed's master fingerprint on the receiving
+  Coldcard and asks for confirmation before installing it.
 
 # Mk Specific Changes
 

--- a/shared/backups.py
+++ b/shared/backups.py
@@ -792,9 +792,7 @@ back and press %s to complete clone process.''' % OK)
         uos.remove(fname)       # ccbk-start.json
 
     # this will reset in successful case, no return (but delme is called)
-    # no need to ask for UX confirmation during clone - as user can see what is loaded on source CC
-    prob = await restore_complete_doit(incoming, words, file_cleanup=delme,
-                                       ux_confirm=False)
+    prob = await restore_complete_doit(incoming, words, file_cleanup=delme)
     if prob:
         await ux_show_story(prob, title='FAILED')
 

--- a/testing/clone_tests.py
+++ b/testing/clone_tests.py
@@ -91,8 +91,8 @@ def _clone(source, target):
     #     _need_keypress(device, KEY_ENTER if target_is_Q else "y", timeout=1000)
     # except: pass
 
-    for _ in range(3):
-        # need 3 ENTERS - 1. start the process; 2.FTUX; 3. Success story
+    for _ in range(4):
+        # need 4 ENTERS - 1. start; 2. accept XFP; 3. FTUX; 4. Success story
         try:
             # somehow it works even if it timeouts
             # remember that we have only one .socket (fpath is compiled in pyb.py)


### PR DESCRIPTION
Show the restored seed fingerprint for confirmation before Clone Coldcard completes.

This uses the existing backup-restore confirmation and leaves the clone file format and source-device flow unchanged, including compatibility with older source firmware.