### PR TITLE
bugfix: block Delta Mode secret consumers

### DIFF
--- a/releases/Next-ChangeLog.md
+++ b/releases/Next-ChangeLog.md
@@ -30,6 +30,8 @@ This lists the new changes that have not yet been published in a normal release.
 - Bugfix: Prevent access to Seed Vault entries through Seed XOR restore in Delta Mode. Thanks to
   Rety for reporting this.
 - Bugfix: Wipe seed in Delta Mode when saved BIP-39 passphrases are listed, instead of revealing them.
+- Bugfix: Block Key Teleport’s secret picker and CCC key-C import from Seed
+  Vault in Delta Mode.
 - Bugfix: BIP-322 message signing now rejects non-ASCII and other unsupported
   message text before approval. Thanks to @KirillCherikov for reporting.
 - Bugfix: Prevent duplicate WIF Store entries after restarting

--- a/shared/ccc.py
+++ b/shared/ccc.py
@@ -858,15 +858,18 @@ async def gen_or_import():
     # returns 12 words, or None to abort
     from seed import WordNestMenu, generate_seed_with_user_entropy, approve_word_list
     from seed import SeedVaultChooserMenu, PURPOSE_CCC
+    from pincodes import pa
 
     msg = "Press %s to generate a new 12-word seed phrase to be used "\
           "as the Coldcard Co-Signing Secret (key C).\n\nOr press (1) to import existing "\
           "12-words or (2) for 24-words import." % OK
 
-    if settings.master_get("seedvault", False):
+    esc = "12"
+    if not pa.is_deltamode() and settings.master_get("seedvault", False):
+        esc += "6"
         msg += ' Press (6) to import from Seed Vault.'
 
-    ch = await ux_show_story(msg, escape='126', title="CCC Key C")
+    ch = await ux_show_story(msg, escape=esc, title="CCC Key C")
 
     if ch in '12':
         nwords = 24 if ch == '2' else 12

--- a/shared/teleport.py
+++ b/shared/teleport.py
@@ -4,7 +4,7 @@
 #               secure environment of two Q's.
 #
 import ngu, aes256ctr, bip39, json, ndef, chains, stash
-from utils import xfp2str, deserialize_secret
+from utils import xfp2str, deserialize_secret, wipe_if_deltamode
 from ubinascii import unhexlify as a2b_hex
 from ubinascii import hexlify as b2a_hex
 from glob import settings, dis
@@ -515,6 +515,8 @@ class SecretPickerMenu(MenuSystem):
         # this menu should be unreachable in hobbled mode.
         from pincodes import pa
         assert not pa.hobbled_mode
+
+        wipe_if_deltamode()  # shouldn't be here in delta mode
 
         from flow import word_based_seed, is_tmp, has_se_secrets
         has_notes = bool(NoteContentBase.count())

--- a/testing/test_ccc.py
+++ b/testing/test_ccc.py
@@ -1359,6 +1359,29 @@ def test_c_key_from_seed_vault(has_candidates, setup_ccc, build_test_seed_vault,
     press_select()
 
 
+def test_c_key_from_seed_vault_hidden_in_deltamode(
+        goto_home, goto_ccc_menu, settings_set, set_deltamode, press_select,
+        need_keypress, cap_story):
+    goto_home()
+    settings_set("ccc", None)
+    settings_set("seedvault", True)
+    set_deltamode(True)
+
+    goto_ccc_menu()
+    press_select()
+    time.sleep(.2)
+
+    title, story = cap_story()
+    assert title == "CCC Key C"
+    assert "import from Seed Vault" not in story
+
+    need_keypress("6")
+    time.sleep(.2)
+    new_title, new_story = cap_story()
+    assert new_title == title
+    assert new_story == story
+
+
 @pytest.mark.parametrize("way", ["sd", "qr"])
 @pytest.mark.parametrize("ftype", ["cc", "bsms"])
 @pytest.mark.parametrize("is_bbqr", [True, False])


### PR DESCRIPTION
## Summary

- hard-stop the Q Key Teleport secret picker in Delta Mode before it inspects notes or Seed Vault state
- hide and disable CCC key-C import from Seed Vault in Delta Mode