### PR TITLE
spending policy: gate USB restore on related keys

### DIFF
--- a/releases/Next-ChangeLog.md
+++ b/releases/Next-ChangeLog.md
@@ -68,6 +68,7 @@ This lists the new changes that have not yet been published in a normal release.
   Coldcard and asks for confirmation before installing it.
 - Bugfix: CCC velocity policies created by older firmware now enforce the
   current chain's minimum block height before co-signing.
+- Bugfix: USB backup restore now respects the Spending Policy's Related Keys setting.
 
 # Mk Specific Changes
 

--- a/shared/usb.py
+++ b/shared/usb.py
@@ -382,7 +382,7 @@ class USBHandler:
             if cmd in HOBBLED_CMDS:
                 raise SpendPolicyViolation
 
-            if cmd in {'pwok', 'pass'}:
+            if cmd in {'pwok', 'pass', 'rest'}:
                 from ccc import sssp_spending_policy
                 if not sssp_spending_policy('okeys'):
                     raise SpendPolicyViolation

--- a/testing/test_hobble.py
+++ b/testing/test_hobble.py
@@ -406,19 +406,25 @@ def test_h_tempseeds(mode, set_hobble, pick_menu_item, cap_menu, settings_set, i
 def test_h_usbcmds(en_okeys, set_hobble, dev):
     # test various usb commands are blocked during hobble
 
-    from ckcc_protocol.protocol import CCProtoError
+    from ckcc_protocol.protocol import CCProtoError, CCProtocolPacker
 
     set_hobble(True, {'okeys'} if en_okeys else {})
 
     block_list = [ 'back', 'enrl', 'bagi', 'hsms', 'user', 'nwur', 'rmur' ]
 
     if not en_okeys:
-        block_list.insert(0, 'pass')
+        block_list[0:0] = ['pass', 'rest']
 
     for cmd in block_list:
         with pytest.raises(CCProtoError) as ee:
             got = dev.send_recv(cmd)
         assert 'Spending policy in effect' in str(ee)
+
+    if en_okeys:
+        msg = CCProtocolPacker.restore_backup(1, bytes(32))
+        with pytest.raises(CCProtoError) as ee:
+            dev.send_recv(msg)
+        assert 'Checksum' in str(ee)
 
 
 @pytest.mark.parametrize('en_okeys', [ True, False])


### PR DESCRIPTION
## Summary

- require Related Keys before accepting USB backup restore while Spending Policy is active
- preserve temporary-seed restore when Related Keys is enabled