### PR TITLE
bugfix: block BIP-85 derivation in Delta Mode

### DIFF
--- a/releases/Next-ChangeLog.md
+++ b/releases/Next-ChangeLog.md
@@ -34,6 +34,7 @@ This lists the new changes that have not yet been published in a normal release.
 - Bugfix: Wipe seed in Delta Mode when saved BIP-39 passphrases are listed, instead of revealing them.
 - Bugfix: Block Key Teleport’s secret picker and CCC key-C import from Seed
   Vault in Delta Mode.
+- Bugfix: Wipe seed before BIP-85 derivation in Delta Mode.
 - Bugfix: BIP-322 message signing now rejects non-ASCII and other unsupported
   message text before approval. Thanks to @KirillCherikov for reporting.
 - Bugfix: Prevent duplicate WIF Store entries after restarting

--- a/shared/drv_entro.py
+++ b/shared/drv_entro.py
@@ -86,7 +86,7 @@ def bip85_derive(picked, index):
     else:
         raise ValueError(picked)
 
-    with stash.SensitiveValues() as sv:
+    with stash.SensitiveValues(enforce_delta=True) as sv:
         node = sv.derive_path(path)
         entropy = ngu.hmac.hmac_sha512(b'bip-entropy-from-k', node.privkey())
     


### PR DESCRIPTION
Fail closed before BIP-85 derivation reads the master secret in Delta Mode.

This prevents real-master entropy, including reserved duress-wallet indexes, from being derived and exposed.