### PR TITLE
Bugfix: reject invalid highwater values

### DIFF
--- a/releases/Next-ChangeLog.md
+++ b/releases/Next-ChangeLog.md
@@ -39,6 +39,8 @@ This lists the new changes that have not yet been published in a normal release.
 - Bugfix: Prevent valid message signatures when using a Delta Mode PIN.
 - Bugfix: Harden callgate buffer validation against integer overflow and out-of-range access,
   following a finding in the [Karma-X security review](https://karma-x.io/blog/post/75/).
+- Bugfix: Reject out-of-range firmware highwater timestamps without triggering a
+  bootloader assertion.
 - Bugfix: USB `dwld` allowed readback of arbitrary staged PSRAM content (uploaded
   PSBT, multisig enroll file), also across sessions and over plaintext links.
   Downloads are now limited to the single most recent result produced for

--- a/stm32/bootloader/dispatch.c
+++ b/stm32/bootloader/dispatch.c
@@ -681,7 +681,7 @@ firewall_dispatch(int method_num, uint8_t *buf_io, int len_in,
                     if(buf_io[0] < 0x10 || buf_io[0] >= 0x40) {
                         // bad data
                         rv = ERANGE;
-                    } if(check_is_downgrade(buf_io, NULL)) {
+                    } else if(check_is_downgrade(buf_io, NULL)) {
                         // already at a higher version?
                         rv = EAGAIN;
                     } else {

--- a/stm32/mk4-bootloader/dispatch.c
+++ b/stm32/mk4-bootloader/dispatch.c
@@ -466,7 +466,7 @@ firewall_dispatch(int method_num, uint8_t *buf_io, int len_in,
                     if(buf_io[0] < 0x10 || buf_io[0] >= 0x40) {
                         // bad data
                         rv = ERANGE;
-                    } if(check_is_downgrade(buf_io, NULL)) {
+                    } else if(check_is_downgrade(buf_io, NULL)) {
                         // already at a higher version?
                         rv = EAGAIN;
                     } else {


### PR DESCRIPTION
Prevent out-of-range highwater timestamps from continuing into downgrade/OTP handling and triggering a bootloader assertion. Applies to both bootloader dispatcher variants.

No tests run (control-flow-only change).