### PR TITLE
bugfix: invalidate dwld leases before Q1 PSRAM staging

### DIFF
--- a/releases/Next-ChangeLog.md
+++ b/releases/Next-ChangeLog.md
@@ -85,3 +85,4 @@ This lists the new changes that have not yet been published in a normal release.
 - Bugfix: Reject control characters in BIP-21 payment metadata before display.
 - Bugfix: Limit multisig coordinator BBQr imports before JSON parsing to prevent memory
   exhaustion.
+- Bugfix: Revoke USB download access before staging PSBT and BBQr data in PSRAM.

--- a/shared/auth.py
+++ b/shared/auth.py
@@ -1102,6 +1102,9 @@ async def sign_psbt_file(filename, force_vdisk=False, slot_b=None, just_read=Fal
     from glob import dis
     from ux import the_ux
 
+    # file staging replaces any previously leased PSRAM contents
+    glob.ALLOWED_DOWNLOAD = None
+
     tmp_buf = bytearray(4096)
 
     # copy file into PSRAM

--- a/shared/bbqr.py
+++ b/shared/bbqr.py
@@ -367,6 +367,9 @@ class BBQrPsramStorage(BBQrStorage):
     def alloc_buf(self, upper_bound):
         # using first part of PSRAM
 
+        import glob
+        glob.ALLOWED_DOWNLOAD = None
+
         if upper_bound >= MAX_TXN_LEN:
             raise QRDecodeExplained("Too big")
 

--- a/shared/ux_q1.py
+++ b/shared/ux_q1.py
@@ -1206,7 +1206,10 @@ async def show_bbqr_codes(type_code, data, msg, already_hex=False):
     from bbqr import TYPE_LABELS, int2base36, b32encode, num_qr_needed
     from glob import PSRAM, dis
     from ux import ux_wait_keydown
+    import glob
     import uqr
+
+    glob.ALLOWED_DOWNLOAD = None
 
     assert type_code in TYPE_LABELS
 

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -698,6 +698,32 @@ def press_select(dev, has_qwerty):
     f = functools.partial(_press_select, dev, has_qwerty)
     return f
 
+
+@pytest.fixture
+def remote_backup_lease(dev, settings_set, press_select):
+    def doit():
+        settings_set('bkpw',
+                     'charge bottom tired when romance blind treat afford bus salute degree anchor')
+
+        assert dev.send_recv(CCProtocolPacker.start_backup()) is None
+        press_select()
+
+        done = None
+        for _ in range(100):
+            time.sleep(.05)
+            done = dev.send_recv(CCProtocolPacker.get_backup_file(), timeout=5000)
+            if done:
+                break
+        assert done
+
+        ll, sha = done
+        backup = dev.download_file(ll, sha, file_number=0)
+        assert backup[0:2] == b'7z'
+        return ll
+
+    return doit
+
+
 @pytest.fixture
 def enter_mash_entropy(pick_menu_item, press_select, need_keypress):
     def doit():

--- a/testing/test_bbqr.py
+++ b/testing/test_bbqr.py
@@ -8,6 +8,7 @@ from binascii import a2b_hex
 from bbqr import split_qrs, join_qrs
 from charcodes import KEY_QR
 from base64 import b32decode, b32encode
+from ckcc_protocol.protocol import CCProtocolPacker, CCProtoError
 
 # All tests in this file are exclusively meant for Q
 #
@@ -242,6 +243,7 @@ def test_show_bbqr_contents(src, cap_screen_qr, sim_exec, render_bbqr, load_shar
     assert data2 == data
     assert ft == 'B'
 
+
 @pytest.mark.bitcoind
 @pytest.mark.reexport
 @pytest.mark.parametrize('size', [ 2, 10 ] )
@@ -430,6 +432,24 @@ def test_bbqr_storage_guards_unit(sim_exec):
         "ty, sz, buf = st.finalize()\n"
         "RV.write(b'%r %d %r' % (ty, sz, bytes(buf)[0:sz]))")
     assert resp == "'U' 34 %r" % (b'A'*15 + b'B'*15 + b'C'*4)
+
+
+def test_scan_bbqr_revokes_download_lease(remote_backup_lease, split_scan_bbqr,
+                                          cap_story, dev, press_cancel):
+    remote_backup_lease()
+
+    msg = b'private scanner payload ' * 25
+    split_scan_bbqr(msg, 'U', max_version=10, encoding='2')
+    time.sleep(.5)
+
+    title, story = cap_story()
+    assert title == 'Simple Text'
+    assert msg[:50].decode() in story
+
+    with pytest.raises(CCProtoError) as exc:
+        dev.send_recv(CCProtocolPacker.download(0, 256, 0))
+    assert 'not allowed' in str(exc.value)
+    press_cancel()
 
 
 def test_bbqr_psram_reset_unit(sim_exec):

--- a/testing/test_notes.py
+++ b/testing/test_notes.py
@@ -8,6 +8,7 @@ from charcodes import *
 from constants import AF_CLASSIC, AF_P2WPKH_P2SH, AF_P2WPKH, simulator_fixed_words
 from bbqr import split_qrs
 from ckcc.protocol import CCProtocolPacker
+from ckcc_protocol.protocol import CCProtoError
 from bip32 import BIP32Node
 from mnemonic import Mnemonic
 
@@ -569,6 +570,22 @@ def test_top_export(way, encrypted, settings_set, settings_remove, need_some_pas
     obj = json.loads(data)
     assert obj.keys() == {'coldcard_notes'}
     assert obj['coldcard_notes'] == notes
+
+
+def test_qr_export_revokes_download_lease(remote_backup_lease, settings_set, settings_get,
+                                          need_some_notes, backup_notes, dev, press_select):
+    settings_set('notes', [])
+    need_some_notes('Private note', 'not for the USB host')
+    notes = settings_get('notes')
+    remote_backup_lease()
+
+    data, _, _ = backup_notes('qr')
+    assert json.loads(data)['coldcard_notes'] == notes
+
+    with pytest.raises(CCProtoError) as exc:
+        dev.send_recv(CCProtocolPacker.download(0, 256, 0))
+    assert 'not allowed' in str(exc.value)
+    press_select()
 
 
 def test_sort_by_title(goto_notes, pick_menu_item, cap_story, need_keypress, settings_get,

--- a/testing/test_teleport.py
+++ b/testing/test_teleport.py
@@ -13,6 +13,7 @@ from constants import *
 from test_ephemeral import SEEDVAULT_TEST_DATA
 from test_backup import make_big_notes
 from test_hobble import set_hobble
+from ckcc_protocol.protocol import CCProtocolPacker, CCProtoError
 
 # All tests in this file are exclusively meant for Q
 #
@@ -656,7 +657,8 @@ def test_teleport_big_ms(make_myself_wallet, clear_ms, fake_ms_txn, try_sign, ca
 def test_teleport_file_psbt_uses_loaded_file(make_myself_wallet, clear_ms, fake_ms_txn, cap_story,
                                              need_keypress, cap_menu, pick_menu_item, grab_payload,
                                              rx_complete, set_master_key, goto_home, settings_get,
-                                             settings_set, open_microsd, import_ms_wallet, press_cancel):
+                                             settings_set, open_microsd, import_ms_wallet, press_cancel,
+                                             remote_backup_lease, dev):
     clear_ms()
     M, N = 2, 4
     keys = import_ms_wallet(M, N, name='ms-tp', unique=11, accept=True,
@@ -666,6 +668,7 @@ def test_teleport_file_psbt_uses_loaded_file(make_myself_wallet, clear_ms, fake_
     fname = 'ms-tp.psbt'
     open_microsd(fname, 'wb').write(psbt)
 
+    remote_backup_lease()
     goto_home()
     pick_menu_item('Advanced/Tools')
     pick_menu_item('File Management')
@@ -677,6 +680,9 @@ def test_teleport_file_psbt_uses_loaded_file(make_myself_wallet, clear_ms, fake_
         pass
 
     m = cap_menu()
+    with pytest.raises(CCProtoError) as exc:
+        dev.send_recv(CCProtocolPacker.download(0, 256, 0))
+    assert 'not allowed' in str(exc.value)
     assert len(m) == N
     target = next(i for i in m if 'YOU' not in i)
     target_xfp = str2xfp(target[1:9])


### PR DESCRIPTION
Clear stale USB `dwld` leases before Q1 reuses PSRAM for Teleport file staging, incoming BBQr data, or outbound BBQr frames. This prevents a host with a previous backup/result lease from reading replacement contents.
