### PR TITLE
Bugfix: limit multisig BBQr JSON size

### DIFF
--- a/releases/Next-ChangeLog.md
+++ b/releases/Next-ChangeLog.md
@@ -83,3 +83,5 @@ This lists the new changes that have not yet been published in a normal release.
 - Bugfix: Reject malformed multipart BBQrs that could include stale PSRAM bytes in decoded
   results. Thanks to Piotr Duszynski for reporting this.
 - Bugfix: Reject control characters in BIP-21 payment metadata before display.
+- Bugfix: Limit multisig coordinator BBQr imports before JSON parsing to prevent memory
+  exhaustion.

--- a/shared/multisig.py
+++ b/shared/multisig.py
@@ -1646,7 +1646,10 @@ async def ms_coordinator_qr(af_str, my_xfp, chain):
     from ux_q1 import QRScannerInteraction, decode_qr_result, QRDecodeExplained
 
     def convertor(got):
-        file_type, _, data = decode_qr_result(got, expect_bbqr=True)
+        file_type, file_size, data = decode_qr_result(got, expect_bbqr=True)
+        if file_size > 1100:
+            raise QRDecodeExplained('Multisig export is too large')
+
         if isinstance(data, bytes):
             # we expect BBQr, but simple QR also possible here
             data = data.decode()

--- a/testing/test_multisig.py
+++ b/testing/test_multisig.py
@@ -1831,6 +1831,34 @@ def test_make_airgapped(addr_fmt, acct_num, M_N, goto_home, cap_story, pick_menu
     press_cancel()
     press_cancel()
 
+
+def test_reject_oversized_airgapped_xpub_qr(goto_home, pick_menu_item, need_keypress,
+                                             press_select, scan_a_qr, cap_screen,
+                                             clear_ms, is_q1):
+    if not is_q1:
+        pytest.skip("needs scanner")
+
+    clear_ms()
+    goto_home()
+    pick_menu_item('Settings')
+    pick_menu_item('Multisig Wallets')
+    pick_menu_item('Create Airgapped')
+    need_keypress(KEY_QR)
+    time.sleep(.1)
+    press_select()
+
+    oversized = json.dumps({'junk': 'x' * 1100})
+    assert len(oversized) > 1100
+    _, parts = split_qrs(oversized, 'J', max_version=20)
+    for part in parts:
+        scan_a_qr(part)
+
+    time.sleep(.5)
+    assert 'Multisig export is too large' in cap_screen()
+
+    press_select()
+
+
 @pytest.mark.unfinalized
 @pytest.mark.bitcoind
 @pytest.mark.parametrize('addr_style', ["legacy", "p2sh-segwit", "bech32"])


### PR DESCRIPTION
Reject oversized Q1 multisig coordinator BBQr imports before decoding or JSON parsing. The 1,100-byte limit matches the existing MicroSD multisig-export limit and prevents crafted BBQr payloads from exhausting the MicroPython heap.