### PR TITLE
bugfix: reject BIP-21 display control characters

### DIFF
--- a/releases/Next-ChangeLog.md
+++ b/releases/Next-ChangeLog.md
@@ -71,3 +71,4 @@ This lists the new changes that have not yet been published in a normal release.
 
 - Bugfix: Reject malformed multipart BBQrs that could include stale PSRAM bytes in decoded
   results. Thanks to Piotr Duszynski for reporting this.
+- Bugfix: Reject control characters in BIP-21 payment metadata before display.

--- a/shared/ux_q1.py
+++ b/shared/ux_q1.py
@@ -12,7 +12,7 @@ from decoders import decode_qr_result
 from ubinascii import hexlify as b2a_hex
 from ubinascii import b2a_base64
 
-from utils import problem_file_line, show_single_address
+from utils import problem_file_line, show_single_address, is_printable
 from public_constants import MSG_SIGNING_MAX_LENGTH
 from glob import numpad         # may be None depending on import order, careful
 
@@ -1133,6 +1133,8 @@ async def ux_visualize_bip21(proto, addr, args):
     for fn in ['label', 'message', 'lightning']:
         if fn in args:
             val = args.pop(fn)
+            if not is_printable(val):
+                val = '(corrupt)'
             msg += '%s%s: %s\n' % (fn[0].upper(), fn[1:], val)
 
     if args:

--- a/shared/ux_q1.py
+++ b/shared/ux_q1.py
@@ -1138,7 +1138,8 @@ async def ux_visualize_bip21(proto, addr, args):
             msg += '%s%s: %s\n' % (fn[0].upper(), fn[1:], val)
 
     if args:
-        msg += 'And values for: ' + ', '.join(args)
+        msg += 'And values for: ' + \
+               ', '.join(k if is_printable(k) else '(corrupt)' for k in args)
         msg += "\n"
 
     msg += '\nPress (1) to verify ownership.'

--- a/testing/test_ux.py
+++ b/testing/test_ux.py
@@ -1695,6 +1695,26 @@ def test_bip21_metadata_control_chars(field, scan_a_qr, cap_story, goto_home,
     press_cancel()
 
 
+def test_bip21_parameter_name_control_chars(scan_a_qr, cap_story, goto_home,
+                                             need_keypress, press_cancel):
+    addr = 'mtHSVByP9EYZmB26jASDdPVm19gvpecb5R'
+    fake_addr = 'tb1qupyd58ndsh7lut0et0vtrq432jvu9jtdyws9n9'
+    bad_key = OUT_CTRL_ADDRESS + fake_addr
+    url = 'bitcoin:%s?amount=1&%s=1' % (addr, bad_key)
+
+    goto_home()
+    need_keypress(KEY_QR)
+    time.sleep(.1)
+    scan_a_qr(url)
+    time.sleep(.5)
+
+    title, body = cap_story()
+    assert title == 'Payment Address'
+    assert 'And values for: (corrupt)' in body
+    assert fake_addr not in body
+    press_cancel()
+
+
 @pytest.mark.onetime
 def test_dump_menutree(sim_execfile):
     # saves to ../unix/work/menudump.txt

--- a/testing/test_ux.py
+++ b/testing/test_ux.py
@@ -1675,6 +1675,26 @@ def test_bip21_amount_display_corrupt(amount, scan_a_qr, cap_story, goto_home,
     press_cancel()
 
 
+@pytest.mark.parametrize('field', ['label', 'message', 'lightning'])
+def test_bip21_metadata_control_chars(field, scan_a_qr, cap_story, goto_home,
+                                       need_keypress, press_cancel):
+    addr = 'mtHSVByP9EYZmB26jASDdPVm19gvpecb5R'
+    fake_addr = 'tb1qupyd58ndsh7lut0et0vtrq432jvu9jtdyws9n9'
+    url = 'bitcoin:%s?%s=Pay%%20to%%3A%%0A%%02%s' % (addr, field, fake_addr)
+
+    goto_home()
+    need_keypress(KEY_QR)
+    time.sleep(.1)
+    scan_a_qr(url)
+    time.sleep(.5)
+
+    title, body = cap_story()
+    assert title == 'Payment Address', title
+    assert '%s: (corrupt)' % field.title() in body
+    assert fake_addr not in body
+    press_cancel()
+
+
 @pytest.mark.onetime
 def test_dump_menutree(sim_execfile):
     # saves to ../unix/work/menudump.txt


### PR DESCRIPTION
Reject non-printable BIP-21 label, message, and lightning values before Q story rendering. Includes scan-flow regression coverage.