### PR TITLE
Release notes and version bump for Mk4 5.6.1 / Q1 1.5.1Q

### DIFF
--- a/releases/Next-ChangeLog.md
+++ b/releases/Next-ChangeLog.md
@@ -4,14 +4,16 @@ This lists the new changes that have not yet been published in a normal release.
 
 # Shared Improvements - Both Mk and Q
 
-- Security Improvements to Entropy Generation: 
+- Improvements to Entropy Generation:
     - Master seed generation mixes entropy from both Secure Elements with
       the STM32 TRNG (previously TRNG only).
-    - RNG is seeded with the full 256-bit digest of entropy
+    - On every boot, RNG is seeded with the full 256-bit digest of entropy
       from both Secure Elements (previously truncated to 32 bits).
-    - libngu now uses a `SHA-256 Hash_DRBG` (NIST SP 800-90A)
-      instead of the Yasmarang PRNG.
-- Change: New master seeds now **require** extra user supplied entropy.
+    - libngu now uses a `SHA-256 Hash_DRBG` (NIST SP 800-90A) instead of the Yasmarang PRNG.
+    - RNG self-test proves `rng_get()` enters the hardware read path. Brick device otherwise.
+    - Makefile compile-time checks, verifying included code is expanded beyond
+      those in the Hotfix.
+- New master seeds now **require** extra user supplied entropy (dice, coin flips, keyboard mashing):
     - Choose key mashing (based on [Peter Todd's Push-Button RNG](https://petertodd.org/2014/push-button-rng)),
       physical dice rolls or physical coin flips.
     - TRNG, SE1 and SE2 randomness is also mixed into the generated seed.
@@ -24,7 +26,6 @@ This lists the new changes that have not yet been published in a normal release.
       delta and key identity are mixed in, but key identity receives no entropy credit.
       Users may continue mashing beyond 65 presses to contribute additional timing entropy.
     - Generated Temporary Seeds and generated CCC key C now require extra user supplied entropy.
-    - RNG self-test proving `rng_get()` enters the hardware read path. Brick device otherwise.
 - Dice-Only Enhancements: 
     - Dice-only seed generation now warns that no hardware randomness is
       included and the final hash shown on-screen must be kept secret.

--- a/releases/Next-ChangeLog.md
+++ b/releases/Next-ChangeLog.md
@@ -26,7 +26,7 @@ This lists the new changes that have not yet been published in a normal release.
       delta and key identity are mixed in, but key identity receives no entropy credit.
       Users may continue mashing beyond 65 presses to contribute additional timing entropy.
     - Generated Temporary Seeds and generated CCC key C now require extra user supplied entropy.
-- Dice-Only Enhancements: 
+- Dice-Only Enhancements:
     - Dice-only seed generation now warns that no hardware randomness is
       included and the final hash shown on-screen must be kept secret.
     - Temporary dice-only seeds now use the same warning and mandatory
@@ -98,4 +98,3 @@ This lists the new changes that have not yet been published in a normal release.
     - Limit multisig coordinator BBQr imports before JSON parsing to prevent memory
       exhaustion.
     - Revoke USB download access before staging PSBT and BBQr data in PSRAM.
-

--- a/releases/Next-ChangeLog.md
+++ b/releases/Next-ChangeLog.md
@@ -4,13 +4,14 @@ This lists the new changes that have not yet been published in a normal release.
 
 # Shared Improvements - Both Mk and Q
 
-- Security Improvement: Master seed generation mixes entropy from both Secure
-  Elements with the STM32 TRNG (previously TRNG only).
-- Security Improvement: RNG is seeded with the full 256-bit digest of entropy
-  from both Secure Elements (previously truncated to 32 bits).
-- Security Improvement: libngu now uses a SHA-256 Hash_DRBG (NIST SP 800-90A)
-  instead of the Yasmarang PRNG.
-- Change: New master seeds now require extra user supplied entropy.
+- Security Improvements to Entropy Generation: 
+    - Master seed generation mixes entropy from both Secure Elements with
+      the STM32 TRNG (previously TRNG only).
+    - RNG is seeded with the full 256-bit digest of entropy
+      from both Secure Elements (previously truncated to 32 bits).
+    - libngu now uses a `SHA-256 Hash_DRBG` (NIST SP 800-90A)
+      instead of the Yasmarang PRNG.
+- Change: New master seeds now **require** extra user supplied entropy.
     - Choose key mashing (based on [Peter Todd's Push-Button RNG](https://petertodd.org/2014/push-button-rng)),
       physical dice rolls or physical coin flips.
     - TRNG, SE1 and SE2 randomness is also mixed into the generated seed.
@@ -19,29 +20,33 @@ This lists the new changes that have not yet been published in a normal release.
       resolution (~8.33ns at 120MHz) before keypad debounce. Releases are ignored,
       repeating one key is valid, and at least 65 presses are required. The first
       press establishes the timing reference; each of the following 64 inter-press
-      gaps is conservatively credited with two bits. The full timing delta and key
-      identity are mixed in, but key identity receives no entropy credit. Users may
-      continue mashing beyond 65 presses to contribute additional timing entropy.
-- Enhancement: Dice-only seed generation now warns that no hardware randomness is
-  included and the final hash shown on-screen must be kept secret.
-- Change: Temporary dice-only seeds now use the same warning and mandatory
-  entropy checks as master dice-only seeds.
-- Change: Generated Temporary Seeds and generated CCC key C now require extra
-  user supplied entropy.
-- Bugfix: Detect RNG_SR_SEIS and RNG_SR_SECS, retry safely, and fail closed on persistent faults.
-- Bugfix: Prevent access to Seed Vault entries through Seed XOR restore in Delta Mode. Thanks to
-  Rety for reporting this.
-- Bugfix: Wipe seed in Delta Mode when saved BIP-39 passphrases are listed, instead of revealing them.
-- Bugfix: Block Key Teleport’s secret picker and CCC key-C import from Seed
-  Vault in Delta Mode.
-- Bugfix: Wipe seed before BIP-85 derivation in Delta Mode.
+      gaps is conservatively credited with two bits of entropy credit. The full timing
+      delta and key identity are mixed in, but key identity receives no entropy credit.
+      Users may continue mashing beyond 65 presses to contribute additional timing entropy.
+    - Generated Temporary Seeds and generated CCC key C now require extra user supplied entropy.
+    - RNG self-test proving `rng_get()` enters the hardware read path. Brick device otherwise.
+- Dice-Only Enhancements: 
+    - Dice-only seed generation now warns that no hardware randomness is
+      included and the final hash shown on-screen must be kept secret.
+    - Temporary dice-only seeds now use the same warning and mandatory
+      entropy checks as master dice-only seeds.
+- Delta Mode hardening:
+    - Wipe seed in Delta Mode when saved BIP-39 passphrases are listed, instead of revealing them.
+    - Block Key Teleport’s secret picker and CCC key-C import from Seed
+      Vault in Delta Mode.
+    - Prevent access to Seed Vault entries through Seed XOR restore in Delta Mode.
+      Thanks to "Rety" for reporting this.
+    - Wipe seed before BIP-85 derivation in Delta Mode.
+    - Prevent valid message signatures when using a Delta Mode PIN.
+- Bugfix: Detect `RNG_SR_SEIS` and `RNG_SR_SECS`, retry safely, and fail closed on persistent faults.
 - Bugfix: BIP-322 message signing now rejects non-ASCII and other unsupported
-  message text before approval. Thanks to @KirillCherikov for reporting.
+  message text before approval. Thanks to [@KirillCherikov](https://github.com/KirillCherikov) for reporting.
 - Bugfix: Prevent duplicate WIF Store entries after restarting
-- Change: Block `SIGHASH_SINGLE` and `SIGHASH_SINGLE|ANYONECANPAY` by default because they can leave later transaction outputs modifiable after signing. They remain available when Sighash Checks is set to Warn.
+- Change: Block `SIGHASH_SINGLE` and `SIGHASH_SINGLE|ANYONECANPAY` by default because they can
+  leave later transaction outputs modifiable after signing. They remain available when Sighash
+  Checks is set to Warn.
   Thanks to [@instagibbs](https://github.com/instagibbs) for reporting this issue.
 - Bugfix: Fixed PSBT uploads being mistaken for partial firmware uploads.
-- Bugfix: Prevent valid message signatures when using a Delta Mode PIN.
 - Bugfix: Harden callgate buffer validation against integer overflow and out-of-range access,
   following a finding in the [Karma-X security review](https://karma-x.io/blog/post/75/).
 - Bugfix: Reject out-of-range firmware highwater timestamps without triggering a
@@ -52,16 +57,20 @@ This lists the new changes that have not yet been published in a normal release.
   download (signed txn, visualization, backup), require an encrypted session,
   and are invalidated by any upload, newly staged transaction, or new session.
   Thanks to [@drk1wi](https://github.com/drk1wi).
-- Change: When a BIP-39 passphrase is active, View Seed Words now shows only the effective extended private key instead of the underlying seed words.
-- Change: Backup System, Clone Coldcard, and Key Teleport’s Full COLDCARD Backup now capture the wallet secret currently in effect, including temporary seeds and BIP-39 passphrase wallets, and warn before export.
-- Bugfix: View Seed Words and backup workflows incorrectly treated the master seed as the parent of every BIP-39 passphrase wallet. When a passphrase was applied to a temporary seed, they could not access that immediate parent seed.
-- Enhancement: RNG self-test proving rng_get() enter the hardware read path. Brick device otherwise.
-- Bugfix: a compromised USB host could rewrite the staged PSBT after review but
+- Change: When a BIP-39 passphrase is active, View Seed Words now shows only the effective
+  extended private key instead of the underlying seed words.
+    - Bugfix: View Seed Words and backup workflows incorrectly treated the master seed as the
+      parent of every BIP-39 passphrase wallet. When a passphrase was applied to a temporary seed,
+      they could not access that immediate parent seed.
+    - Change: Backup System, Clone Coldcard, and Key Teleport’s Full COLDCARD Backup now capture
+      the wallet secret currently in effect, including temporary seeds and BIP-39 passphrase
+      wallets, and warn before export.
+- Bugfix: a compromised USB host could rewrite the staged PSBT after review, but
   before signing, so the signature covered a different transaction than shown.
   Staged bytes are now re-verified before signing; any change aborts with
-  "Transaction modified". Thanks to FreeZ Agent for the report and PoC.
+  "Transaction modified". Thanks to "FreeZ Agent" for the report and PoC.
 - Bugfix: Reject duplicate cosigner keys, and cosigner keys the device already holds,
-  during multisig wallet enrollment. Thanks to drk1wi for reporting this.
+  during multisig wallet enrollment. Thanks to [@drk1wi](https://github.com/drk1wi) for reporting this.
 - Bugfix: Separate the SE1 check nonce from the PIN digest. Thanks to
   [@instagibbs](https://github.com/instagibbs) for reporting this issue.
 - Enhancement: Clone Coldcard now shows the restored seed's master fingerprint on the receiving
@@ -72,18 +81,20 @@ This lists the new changes that have not yet been published in a normal release.
 
 # Mk Specific Changes
 
-## 5.5.x - 2065-09-xx
+## 5.6.1 - 2026-08-18
 
-- tbd
+- all of the above.
 
 
 # Q Specific Changes
 
-## 1.4.xQ - 2065-09-xx
+## 1.5.1Q - 2026-08-18
 
-- Bugfix: Reject malformed multipart BBQrs that could include stale PSRAM bytes in decoded
-  results. Thanks to Piotr Duszynski for reporting this.
-- Bugfix: Reject control characters in BIP-21 payment metadata before display.
-- Bugfix: Limit multisig coordinator BBQr imports before JSON parsing to prevent memory
-  exhaustion.
-- Bugfix: Revoke USB download access before staging PSBT and BBQr data in PSRAM.
+- Bugfix: Reject malformed multipart BBQrs that could include stale PSRAM bytes
+  in decoded results. Thanks to [@drk1wi](https://github.com/drk1wi) for reporting this.
+- Hardening & Defence in depth:
+    - Reject control characters in BIP-21 payment metadata before display.
+    - Limit multisig coordinator BBQr imports before JSON parsing to prevent memory
+      exhaustion.
+    - Revoke USB download access before staging PSBT and BBQr data in PSRAM.
+

--- a/stm32/MK-Makefile
+++ b/stm32/MK-Makefile
@@ -19,7 +19,7 @@ LATEST_RELEASE = $(shell ls -t1 ../releases/*-mk-*.dfu ../releases/*-mk4-*.dfu |
 
 # Our version for this release.
 # - caution, the bootrom will not accept version < 3.0.0
-VERSION_STRING = 5.6.0
+VERSION_STRING = 5.6.1
 
 # keep near top, because defined default target (all)
 include shared.mk

--- a/stm32/Q1-Makefile
+++ b/stm32/Q1-Makefile
@@ -16,7 +16,7 @@ BOOTLOADER_DIR = q1-bootloader
 LATEST_RELEASE = $(shell ls -t1 ../releases/*-q1-*.dfu | head -1)
 
 # Our version for this release.
-VERSION_STRING = 1.5.0Q
+VERSION_STRING = 1.5.1Q
 
 # Remove this closer to shipping.
 #$(warning "Forcing debug build")


### PR DESCRIPTION
## Summary

- reorganize and edit the upcoming release notes
- bump Mk4 firmware version to 5.6.1
- bump Q1 firmware version to 1.5.1Q

## Validation

- `git diff --check` passes
