### PR TITLE
bugfix: enable Secure Notes when notes exist but secnap flag missing …

### DIFF
--- a/shared/actions.py
+++ b/shared/actions.py
@@ -749,6 +749,12 @@ async def version_migration():
     # version 5.0.6 is installed
     settings.remove_key('vdsk')
 
+    # Secure notes gate moved from 'notes' key presence to 'secnap' opt-in
+    # flag in 5.4.1/1.3.1Q; keep feature enabled for pre-existing notes
+    if version.has_qwerty and not pa.is_deltamode():
+        if (settings.get('notes') is not None) and not settings.get('secnap'):
+            settings.set('secnap', True)
+
 async def version_migration_prelogin():
     # same, but for setting before login
     # these have moved into SE2 for Mk4 and so can be removed

--- a/shared/backups.py
+++ b/shared/backups.py
@@ -238,6 +238,11 @@ def restore_from_dict_ll(vals, raw):
         # above will be done in ftux
         need_ftux = True
 
+    # backups made before 5.4.1/1.3.1Q carry notes but predate 'secnap' flag
+    if version.has_qwerty and (settings.get('notes') is not None) \
+            and not settings.get('secnap'):
+        settings.set('secnap', True)
+
     # write out
     settings.save()
     dis.progress_bar_show(1)


### PR DESCRIPTION
Commit  8f86ed1c0ed2 ("deltamode & secure notes and passwords") add new op-in flag "secnap" 
which enabled if secure notes are present, but  older FW has no such flag, so after upgrade/restore
flag will be in it's default state secnap=false, so even if secure notes are present, they will be not visiable.
This is super inconvenient  behavior especially for non tech-savvy users. Let's enable secnap.

