### PR TITLE
bugfix: bound Base58Check decoded length

### DIFF
--- a/releases/Next-ChangeLog.md
+++ b/releases/Next-ChangeLog.md
@@ -79,6 +79,7 @@ This lists the new changes that have not yet been published in a normal release.
 - Bugfix: CCC velocity policies created by older firmware now enforce the
   current chain's minimum block height before co-signing.
 - Bugfix: USB backup restore now respects the Spending Policy's Related Keys setting.
+- Bugfix: Reject overlong Base58Check payloads before decoding beyond the destination buffer.
 
 # Mk Specific Changes
 

--- a/testing/test_unit.py
+++ b/testing/test_unit.py
@@ -15,6 +15,18 @@ def test_remote_exec(sim_exec):
 def test_codecs(sim_execfile):
     assert sim_execfile('devtest/segwit_addr.py') == ''
 
+def test_b58decode_rejects_overlong_decoded_size(sim_exec):
+    result = sim_exec("""\
+import ngu
+try:
+    ngu.codecs.b58_decode('1' * 133)
+except ValueError:
+    RV.write('rejected')
+else:
+    RV.write('accepted')
+""")
+    assert result == 'rejected'
+
 def test_public(sim_execfile):
     "verify contents of public 'dump' file"
     import bech32


### PR DESCRIPTION
## Summary

- bump `libngu` from `5d04106a` to `2f7fc12`, including the decoded-size bound from switck/libngu#69 and its upstream tests
- reject decoded Base58Check sizes that cannot fit the destination buffer before pointer arithmetic
- add a focused simulator regression test through `ngu.codecs.b58_decode()`
- add a one-line Next changelog entry

## Validation

- `python3 -m py_compile testing/test_unit.py`
- `git diff --check`
- libngu compiled Hash-DRBG and RNG backend tests pass

The aggregate libngu desktop test target then stops at its existing `need virtualenv` check, so the simulator integration test was not executed in this checkout.