### PR TITLE
bugfix: reject oversized SegWit HRPs

### DIFF
--- a/releases/Next-ChangeLog.md
+++ b/releases/Next-ChangeLog.md
@@ -80,6 +80,7 @@ This lists the new changes that have not yet been published in a normal release.
   current chain's minimum block height before co-signing.
 - Bugfix: USB backup restore now respects the Spending Policy's Related Keys setting.
 - Bugfix: Reject overlong Base58Check payloads before decoding beyond the destination buffer.
+- Bugfix: Reject SegWit addresses with oversized HRPs instead of returning an unterminated buffer.
 
 # Mk Specific Changes
 


### PR DESCRIPTION
## Summary

- bump `libngu` from `2f7fc12` to `4d9af84`
- include the Bech32 fix that rejects HRPs which cannot fit the detailed decoder’s 20-byte output buffer
- include libngu’s upstream regression test for a 20-character HRP
- add one Next changelog line

## Validation

- `git diff --check`
- change is limited to the libngu gitlink and one changelog line