### PR TITLE
bugfix: limit backup KDF rounds

### DIFF
--- a/releases/Next-ChangeLog.md
+++ b/releases/Next-ChangeLog.md
@@ -72,6 +72,7 @@ This lists the new changes that have not yet been published in a normal release.
   "Transaction modified". Thanks to "FreeZ Agent" for the report and PoC.
 - Bugfix: Reject duplicate cosigner keys, and cosigner keys the device already holds,
   during multisig wallet enrollment. Thanks to [@drk1wi](https://github.com/drk1wi) for reporting this.
+- Bugfix: Reject backup files that request excessive password-derivation work.
 - Bugfix: Separate the SE1 check nonce from the PIN digest. Thanks to
   [@instagibbs](https://github.com/instagibbs) for reporting this issue.
 - Enhancement: Clone Coldcard now shows the restored seed's master fingerprint on the receiving

--- a/shared/compat7z.py
+++ b/shared/compat7z.py
@@ -438,8 +438,9 @@ class Builder(object):
 
         first, second = rv.read(2)
         self.rounds_pow = first & 0x3f
+        assert self.rounds_pow <= 19  # excessive KDF rounds
 
-        assert first & 0xc0 == 0xc0, "require salt+iv"
+        assert first & 0xc0 == 0xc0  # require salt+iv
 
         salt_len = ((second >> 4) & 0xf) + 1
         iv_len = (second & 0xf) + 1

--- a/testing/test_backup.py
+++ b/testing/test_backup.py
@@ -1024,4 +1024,33 @@ def test_check_file_headers_errors(microsd_path, src_root_dir, verify_backup_fil
     title, story = cap_story()
     assert "Trailing header has wrong CRC" in story
 
+
+def test_excessive_kdf_rounds(microsd_path, src_root_dir, verify_backup_file):
+    from binascii import crc32 as host_crc32
+
+    fname = "backup.7z"
+    fn = microsd_path(fname)
+
+    with open(f'{src_root_dir}/docs/backup.7z', "rb") as f:
+        corrupted = bytearray(f.read())
+
+    sh_offset, sh_size = struct.unpack_from('<QQ', corrupted, 12)
+    th_start = 0x20 + sh_offset
+    th_end = th_start + sh_size
+    marker = b'\x07\x0b\x01\x00\x01\x24\x06\xf1\x07\x01'
+    props_len_at = corrupted.index(marker, th_start, th_end) + len(marker)
+    assert corrupted[props_len_at] < 0x80
+    rounds_at = props_len_at + 1
+    corrupted[rounds_at] = (corrupted[rounds_at] & 0xc0) | 20
+
+    struct.pack_into('<L', corrupted, 28,
+                     host_crc32(corrupted[th_start:th_end]) & 0xffffffff)
+    struct.pack_into('<L', corrupted, 8,
+                     host_crc32(corrupted[12:32]) & 0xffffffff)
+    with open(fn, "wb") as f:
+        f.write(corrupted)
+
+    with pytest.raises(AssertionError):
+        verify_backup_file(fname)
+
 # EOF


### PR DESCRIPTION
Reject backup headers that request more than `2^19` KDF rounds before password derivation begins. This retains compatibility with the standard 7-Zip work factor while preventing crafted restores from requesting excessive work.

Includes a CRC-valid malformed-header regression case using KDF power 20.