### PR TITLE
require scrolling to reveal passphrase

### DIFF
--- a/releases/Next-ChangeLog.md
+++ b/releases/Next-ChangeLog.md
@@ -93,6 +93,7 @@ This lists the new changes that have not yet been published in a normal release.
 
 ## 1.5.1Q - 2026-08-18
 
+- Security Improvement: Require scrolling to reveal locally entered BIP-39 passphrases.
 - Bugfix: Reject malformed multipart BBQrs that could include stale PSRAM bytes
   in decoded results. Thanks to [@drk1wi](https://github.com/drk1wi) for reporting this.
 - Hardening & Defence in depth:

--- a/shared/seed.py
+++ b/shared/seed.py
@@ -1632,7 +1632,8 @@ async def apply_pass_value(new_pp):
 
     msg = ('Above is the master key fingerprint of the new wallet'
            ' created by adding passphrase to %s.'
-           '\n\nPassphrase: %s'
+           '\n\nScroll down to view and verify your passphrase.'
+           '\n\n\nPassphrase: %s'
            '\n\nPress %s to abort, %s to use the new wallet, (1) to apply'
            ' and save to MicroSD for future.') % (msg, new_pp, X, OK)
 

--- a/testing/test_bip39pw.py
+++ b/testing/test_bip39pw.py
@@ -246,7 +246,8 @@ def test_bip39_add_nums(target, backspaces, pick_menu_item, cap_story, is_q1,
 ])
 def test_bip39_complex(target, pick_menu_item, cap_story, goto_home,
                        press_select, enter_complex, restore_main_seed,
-                       verify_ephemeral_secret_ui, go_to_passphrase):
+                       verify_ephemeral_secret_ui, go_to_passphrase,
+                       cap_screen, is_q1, press_down, press_right):
     go_to_passphrase()
 
     from mnemonic import Mnemonic
@@ -255,6 +256,22 @@ def test_bip39_complex(target, pick_menu_item, cap_story, goto_home,
     expect = BIP32Node.from_master_secret(seed, netcode="XTN")
 
     enter_complex(target, apply=True)
+    scroll_down = press_down if is_q1 else press_right
+
+    for _ in range(3):
+        screen = cap_screen()
+        assert 'Passphrase:' not in screen
+        if 'Scroll down to' in screen:
+            break
+        scroll_down()
+        time.sleep(.01)
+    else:
+        pytest.fail('passphrase scroll notice not shown')
+
+    scroll_down()
+    time.sleep(.01)
+    assert 'Passphrase:' in cap_screen()
+
     press_select()
     time.sleep(.1)
     verify_ephemeral_secret_ui(xpub=expect.hwif(), is_b39pw=True)


### PR DESCRIPTION
Locally entered BIP-39 passphrases could appear on Q's initial confirmation screen. Add a scroll notice and spacing so the passphrase is revealed only after scrolling.

Adds viewport regression coverage.