### PR TITLE
Change: use combined-source RNG for security-sensitive values

### DIFF
--- a/releases/Next-ChangeLog.md
+++ b/releases/Next-ChangeLog.md
@@ -4,6 +4,8 @@ This lists the new changes that have not yet been published in a normal release.
 
 # Shared Improvements - Both Mk and Q
 
+- Change: Use TRNG-seeded SHA-256 Hash-DRBG for backup passwords,
+  encryption salt/IV, and 2FA secrets; use raw TRNG for non-secret uses only.
 - Improvements to Entropy Generation:
     - Master seed generation mixes entropy from both Secure Elements with
       the STM32 TRNG (previously TRNG only).

--- a/shared/backups.py
+++ b/shared/backups.py
@@ -2,7 +2,7 @@
 #
 # backups.py - Save and restore backup data.
 #
-import compat7z, stash, ckcc, chains, gc, sys, bip39, uos, ngu
+import compat7z, stash, chains, gc, sys, bip39, uos, ngu
 from ubinascii import hexlify as b2a_hex
 from ubinascii import unhexlify as a2b_hex
 from utils import deserialize_secret, swab32, xfp2str
@@ -310,9 +310,8 @@ async def restore_from_dict(vals, raw):
 async def pick_backup_password(write_sflash=False, secret_opt=False, what="money for free"):
     # Pick a password: like bip39 but no checksum word
     #
-    b = bytearray(32)
     while 1:
-        ckcc.rng_bytes(b)
+        b = ngu.random.bytes(32)
         # b2a_words(32 bytes) gives 24 BIP39 words. Keep the leading 12 by dropping the tail,
         # which includes checksum bits; this is a wordlist password, not a valid BIP39 mnemonic.
         # * keep pwd as a string for the encryption/settings paths

--- a/shared/compat7z.py
+++ b/shared/compat7z.py
@@ -6,7 +6,7 @@
 # always does AES-256. Not really expecting to be able to read any 7z file, except
 # those we created ourselves.
 #
-import os, sys, ckcc, ngu
+import os, sys, ngu
 from ubinascii import hexlify as b2a_hex
 from ubinascii import unhexlify as a2b_hex
 from ubinascii import crc32
@@ -19,9 +19,7 @@ def masked_crc(bits):
     return crc32(bits) & 0xffffffff
 
 def urandom(l):
-    rv = bytearray(l)
-    ckcc.rng_bytes(rv)
-    return rv
+    return ngu.random.bytes(l)
 
 def encode_utf_16_le(s):
     # emulate: str.encode('utf-16-le')

--- a/shared/users.py
+++ b/shared/users.py
@@ -177,9 +177,7 @@ class Users:
     def pick_secret(cls, auth_mode):
         # always 10 bytes for no reason => 80 bits of entropy
         # return binary secret, and encoded value for new user to see
-        import ckcc
-        b = bytearray(10)
-        ckcc.rng_bytes(b)
+        b = ngu.random.bytes(10)
         picked = b32encode(b)
 
         if auth_mode == USER_AUTH_HMAC:


### PR DESCRIPTION

- use `ngu.random.bytes()` for 7z salt and IV generation, backup-password entropy, and generated 2FA/HMAC secrets
- keep `ckcc.rng_bytes()` for the non-secret flash and SD-card overwrite patterns
