### PR TITLE
bugfix: clear PSRAM on fast wipe

### DIFF
--- a/releases/Next-ChangeLog.md
+++ b/releases/Next-ChangeLog.md
@@ -77,6 +77,7 @@ This lists the new changes that have not yet been published in a normal release.
 - Bugfix: Reject backup files that request excessive password-derivation work.
 - Bugfix: Separate the SE1 check nonce from the PIN digest. Thanks to
   [@instagibbs](https://github.com/instagibbs) for reporting this issue.
+- Bugfix: Clear volatile application data when the seed is wiped.
 - Enhancement: Clone Coldcard now shows the restored seed's master fingerprint on the receiving
   Coldcard and asks for confirmation before installing it.
 - Bugfix: CCC velocity policies created by older firmware now enforce the

--- a/stm32/mk4-bootloader/dispatch.c
+++ b/stm32/mk4-bootloader/dispatch.c
@@ -563,6 +563,9 @@ firewall_dispatch(int method_num, uint8_t *buf_io, int len_in,
                 mcu_key_clear(NULL);
                 oled_show(screen_wiped);
 
+                psram_wipe();
+                wipe_all_sram();
+
                 LOCKUP_FOREVER();
             }
             rv = EPERM;

--- a/stm32/mk4-bootloader/storage.c
+++ b/stm32/mk4-bootloader/storage.c
@@ -23,6 +23,7 @@
 #include "stm32l4xx_hal.h"
 #include "constant_time.h"
 #include "storage.h"
+#include "psram.h"
 
 // Number of flash pages to write-protect (ie. our size in flash pages)
 // - written into FLASH->WRP1AR
@@ -825,6 +826,9 @@ fast_wipe(void)
     // - lots of other code can and will detect a missing MCU key as "blank"
     // - and the check value on main seed will be garbage now
     mcu_key_clear(NULL);
+
+    // clear volatile application data that would survive the warm reset
+    psram_wipe();
 
     NVIC_SystemReset();
 


### PR DESCRIPTION
Clear all PSRAM before a fast-wipe reset. Also clear PSRAM before application SRAM on the non-resetting wipe path.

Tested affected bootloader objects for Mk4/Mk5 and Q1.