### PR TITLE
bugfix: require unique multisig names

### DIFF
--- a/releases/Next-ChangeLog.md
+++ b/releases/Next-ChangeLog.md
@@ -75,6 +75,7 @@ This lists the new changes that have not yet been published in a normal release.
 - Bugfix: Reject duplicate cosigner keys, and cosigner keys the device already holds,
   during multisig wallet enrollment. Thanks to [@drk1wi](https://github.com/drk1wi) for reporting this.
 - Bugfix: Reject backup files that request excessive password-derivation work.
+- Bugfix: Reject duplicate multisig wallet names.
 - Bugfix: Separate the SE1 check nonce from the PIN digest. Thanks to
   [@instagibbs](https://github.com/instagibbs) for reporting this issue.
 - Bugfix: Clear volatile application data when the seed is wiped.

--- a/shared/hsm.py
+++ b/shared/hsm.py
@@ -223,7 +223,7 @@ class ApprovalRule:
         # if specified, 'wallet' must be an existing multisig wallet's name
         if self.wallet and self.wallet != '1':
             names = [ms.name for ms in MultisigWallet.get_all()]
-            assert self.wallet in names, "unknown MS wallet: "+self.wallet
+            assert names.count(self.wallet) == 1, "unknown or ambiguous MS wallet: "+self.wallet
 
         # patterns must be valid
         for p in self.patterns:

--- a/shared/multisig.py
+++ b/shared/multisig.py
@@ -356,6 +356,10 @@ class MultisigWallet(WalletABC):
         return cls.iter_wallets()
 
     @classmethod
+    def name_is_used(cls, name, exclude_idx=-1):
+        return any(cls.iter_wallets(name=name, not_idx=exclude_idx))
+
+    @classmethod
     def exists(cls):
         # are there any wallets defined?
         return bool(settings.get('multisig', False))
@@ -374,6 +378,7 @@ class MultisigWallet(WalletABC):
     def commit(self):
         # data to save
         # - important that this fails immediately when nvram overflows
+        assert not self.name_is_used(self.name, self.storage_idx), 'duplicate wallet name'
         obj = self.serialize()
 
         v = settings.get('multisig', [])
@@ -431,8 +436,13 @@ class MultisigWallet(WalletABC):
                 return None, ["key order"], 1
             elif self.name == c.name:
                 return None, [], 1
+            elif self.name_is_used(self.name, c.storage_idx):
+                return None, ['name already exists'], 1
             else:
                 return c, ['name'], 0
+
+        if self.name_is_used(self.name, self.storage_idx):
+            return None, ['name already exists'], 1
 
         similar = MultisigWallet.find_candidates(lst)
         if not similar:

--- a/shared/multisig.py
+++ b/shared/multisig.py
@@ -360,6 +360,20 @@ class MultisigWallet(WalletABC):
         return any(cls.iter_wallets(name=name, not_idx=exclude_idx))
 
     @classmethod
+    def make_unique_name(cls, base):
+        assert 1 <= len(base) <= 20
+        names = [rec[0] for rec in settings.get('multisig', [])]
+        if base not in names:
+            return base
+
+        prefix = base + ' #'
+        nums = [int(n[len(prefix):]) for n in names
+                if n.startswith(prefix) and n[len(prefix):].isdigit()]
+        name = prefix + str(max([1] + nums) + 1)
+        assert len(name) <= 20
+        return name
+
+    @classmethod
     def exists(cls):
         # are there any wallets defined?
         return bool(settings.get('multisig', False))
@@ -780,7 +794,7 @@ class MultisigWallet(WalletABC):
 
         if not name:
             # provide a default name
-            name = '%d-of-%d' % (M, N)
+            name = cls.make_unique_name('%d-of-%d' % (M, N))
 
         try:
             name = to_ascii_printable(name)
@@ -1041,7 +1055,7 @@ class MultisigWallet(WalletABC):
 
         cls.check_unique_cosigner_keys(xpubs)
 
-        name = 'PSBT-%d-of-%d' % (M, N)
+        name = cls.make_unique_name('PSBT-%d-of-%d' % (M, N))
         # this will always create sortedmulti multisig (BIP-67)
         # because BIP-174 came years after wide spread acceptance of BIP-67 policy
         ms = cls(name, (M, N), xpubs, chain_type=expect_chain, addr_fmt=af)
@@ -1819,7 +1833,7 @@ async def ondevice_multisig_create(mode='p2wsh', addr_fmt=AF_P2WSH, is_qr=False,
         return
 
     if for_ccc:
-        secret, ccc_ms_count = for_ccc
+        secret, _ = for_ccc
         # Always include 2 keys from CCC: own master (key A) and key C
         # - force them to same derivation.
         acct = await ux_enter_bip32_index('CCC Account Number:')
@@ -1892,11 +1906,9 @@ async def ondevice_multisig_create(mode='p2wsh', addr_fmt=AF_P2WSH, is_qr=False,
 
     if for_ccc:
         name = "Coldcard Co-sign" if version.has_qwerty else "CCC"
-        if ccc_ms_count:
-            # make name unique for each CCC wallet, but they can edit
-            name += " #%d" % (ccc_ms_count+1)
     else:
         name = 'CC-%d-of-%d' % (M, N)
+    name = MultisigWallet.make_unique_name(name)
 
     ms = MultisigWallet(name, (M, N), xpubs, chain_type=chain.ctype, addr_fmt=addr_fmt)
 

--- a/shared/ownership.py
+++ b/shared/ownership.py
@@ -228,6 +228,8 @@ class OwnershipCache:
             res = list(MultisigWallet.iter_wallets(name=named_wal))
             if not res:
                 raise UnknownAddressExplained("Wallet '%s' not defined." % named_wal)
+            if len(res) > 1:
+                raise UnknownAddressExplained("Wallet '%s' is ambiguous." % named_wal)
 
             # only return desired named wallet, no other wallets are searched
             return res

--- a/testing/test_multisig.py
+++ b/testing/test_multisig.py
@@ -985,8 +985,8 @@ def test_overflow(N, import_ms_wallet, clear_ms, press_select, cap_story, mk_num
 
     clear_ms()
     M = N
-    name = 'a'*20       # longest possible
     for count in range(1, 10):
+        name = ('a'*19) + str(count)       # unique, longest possible
         keys = import_ms_wallet(M, N, name=name, addr_fmt='p2wsh', unique=count, accept=0,
                                     common="m/45h/0h/34h")
 
@@ -1011,6 +1011,42 @@ def test_overflow(N, import_ms_wallet, clear_ms, press_select, cap_story, mk_num
 
     press_select()
     clear_ms()
+
+
+def test_unique_wallet_names(clear_ms, make_multisig, offer_ms_import, press_select,
+                             press_cancel, settings_get, OK):
+    clear_ms()
+    M, N = 2, 3
+    name = 'same-name'
+
+    def config(unique, wallet_name=name):
+        keys = make_multisig(M, N, unique=unique)
+        rv = 'name: %s\npolicy: %d / %d\nformat: P2WSH\n\n' % (wallet_name, M, N)
+        return rv + '\n'.join('%s: %s' % (xfp2str(xfp), sk.hwif(as_private=False))
+                              for xfp, _, sk in keys)
+
+    _, story = offer_ms_import(config(1))
+    assert 'Create new multisig wallet' in story
+    press_select()
+    time.sleep(.1)
+
+    _, story = offer_ms_import(config(2))
+    assert 'Duplicate wallet. name already exists' in story
+    assert ('%s to approve' % OK) not in story
+    press_cancel()
+
+    other_name = 'other-name'
+    _, story = offer_ms_import(config(2, other_name))
+    assert 'Create new multisig wallet' in story
+    press_select()
+    time.sleep(.1)
+
+    # Renaming the first wallet must not overwrite the second or delete the first.
+    _, story = offer_ms_import(config(1, other_name))
+    assert 'Duplicate wallet. name already exists' in story
+    assert ('%s to approve' % OK) not in story
+    press_cancel()
+    assert [rec[0] for rec in settings_get('multisig')] == [name, other_name]
 
 @pytest.fixture
 def test_make_example_file(microsd_path, make_multisig):

--- a/testing/test_ownership.py
+++ b/testing/test_ownership.py
@@ -656,6 +656,40 @@ def test_named_wallet_search_fail(load_shared_mod, goto_home, pick_menu_item, nf
     assert "Wallet 'unknown' not defined." in story
 
 
+def test_named_wallet_search_ambiguous(clear_ms, import_ms_wallet, settings_get,
+                                       settings_set, load_shared_mod, goto_home,
+                                       pick_menu_item, nfc_write, cap_story,
+                                       sim_root_dir):
+    name = 'ambiguous'
+    clear_ms()
+    import_ms_wallet(2, 3, name=name, accept=True)
+
+    wallets = settings_get('multisig')
+    assert len(wallets) == 1
+    settings_set('multisig', wallets + wallets)
+
+    addr = fake_address(AF_P2WSH, True)
+    addr = "%s?wallet=%s" % (addr, name)
+    cc_ndef = load_shared_mod('cc_ndef', '../shared/ndef.py')
+    n = cc_ndef.ndefMaker()
+    n.add_text(addr)
+    ccfile = n.bytes()
+
+    goto_home()
+    pick_menu_item('Advanced/Tools')
+    pick_menu_item('NFC Tools')
+    pick_menu_item('Verify Address')
+    with open('%s/debug/nfc-addr.ndef' % sim_root_dir, 'wb') as f:
+        f.write(ccfile)
+    nfc_write(ccfile)
+
+    time.sleep(1)
+    title, story = cap_story()
+    clear_ms()
+    assert title == 'Unknown Address'
+    assert "Wallet '%s' is ambiguous." % name in story
+
+
 @pytest.mark.parametrize('valid', [True, False])
 @pytest.mark.parametrize('method', ["qr", "nfc"])
 @pytest.mark.parametrize('wname', ["msnm", "Longer Wallet Name"])


### PR DESCRIPTION
Reject duplicate multisig wallet names at enrollment and storage boundaries. Auto-generated names receive a numeric suffix, while ambiguous legacy names fail closed in HSM policy validation and ownership lookup.