### PR TITLE
bugfix: integer underflow in PSRAM virtual-disk file import (OOB write from hostile FAT metadata)

### DIFF
--- a/releases/Next-ChangeLog.md
+++ b/releases/Next-ChangeLog.md
@@ -16,6 +16,9 @@ This lists the new changes that have not yet been published in a normal release.
 - Bugfix: Simulator crashed on Bless Firmware, due to a desynced LED pipe. Thanks to
   [@hitechhayekian](https://github.com/hitechhayekian).
 - Bugfix: With an empty master wallet and an active temporary seed, keep imports and backup restores temporary instead of treating them as master-seed changes.
+- Bugfix: Reject PSRAM virtual-disk files whose FAT cluster chain covers more bytes than the
+  file size, fixing an integer underflow in `psram_copy_file`/`psram_mmap_file` that allowed
+  out-of-bounds PSRAM writes from a compromised USB host.
 
 # Mk Specific Changes
 

--- a/releases/Next-ChangeLog.md
+++ b/releases/Next-ChangeLog.md
@@ -17,8 +17,9 @@ This lists the new changes that have not yet been published in a normal release.
   [@hitechhayekian](https://github.com/hitechhayekian).
 - Bugfix: With an empty master wallet and an active temporary seed, keep imports and backup restores temporary instead of treating them as master-seed changes.
 - Bugfix: Reject PSRAM virtual-disk files whose FAT metadata is inconsistent with the
-  declared file size (oversized cluster chains, oversized fragment counts, or final
-  remainders exceeding the final fragment's capacity), fixing an integer underflow in
+  declared file size (oversized cluster chains, oversized fragment counts, spurious
+  trailing fragments, final remainders exceeding the final fragment's capacity, or
+  filesystems with more than one sector per cluster), fixing an integer underflow in
   `psram_copy_file`/`psram_mmap_file` that allowed out-of-bounds PSRAM writes, reads,
   and mappings from a compromised USB host.
 

--- a/releases/Next-ChangeLog.md
+++ b/releases/Next-ChangeLog.md
@@ -16,9 +16,11 @@ This lists the new changes that have not yet been published in a normal release.
 - Bugfix: Simulator crashed on Bless Firmware, due to a desynced LED pipe. Thanks to
   [@hitechhayekian](https://github.com/hitechhayekian).
 - Bugfix: With an empty master wallet and an active temporary seed, keep imports and backup restores temporary instead of treating them as master-seed changes.
-- Bugfix: Reject PSRAM virtual-disk files whose FAT cluster chain covers more bytes than the
-  file size, fixing an integer underflow in `psram_copy_file`/`psram_mmap_file` that allowed
-  out-of-bounds PSRAM writes from a compromised USB host.
+- Bugfix: Reject PSRAM virtual-disk files whose FAT metadata is inconsistent with the
+  declared file size (oversized cluster chains, oversized fragment counts, or final
+  remainders exceeding the final fragment's capacity), fixing an integer underflow in
+  `psram_copy_file`/`psram_mmap_file` that allowed out-of-bounds PSRAM writes, reads,
+  and mappings from a compromised USB host.
 
 # Mk Specific Changes
 

--- a/stm32/COLDCARD_MK4/psramdisk.c
+++ b/stm32/COLDCARD_MK4/psramdisk.c
@@ -607,6 +607,13 @@ mp_obj_t psram_mmap_file(mp_obj_t unused_self, mp_obj_t fname_in)
         mp_raise_ValueError(MP_ERROR_TEXT("unmountable"));
     }
 
+    // The USB host can rewrite the BPB, so a mountable filesystem might
+    // use more than one sector per cluster; the fragment math below works
+    // on 512-byte sectors, so refuse anything else.
+    if(vfs.fatfs.csize != 1) {
+        mp_raise_ValueError(MP_ERROR_TEXT("bad clus size"));
+    }
+
     // open the file directly
     FIL fp = {0};
     if(f_open(&vfs.fatfs, &fp, fname, FA_READ) != FR_OK) {
@@ -665,7 +672,10 @@ mp_obj_t psram_mmap_file(mp_obj_t unused_self, mp_obj_t fname_in)
             // final cluster might include some bytes past the EOF, but the
             // declared remainder must fit in this fragment's real capacity
             len = fp.obj.objsize - so_far;
-            if(len > capacity) {
+            if((len < 1) || (len > capacity)) {
+                // len==0: earlier fragments already cover the whole file, so
+                // this trailing fragment (e.g. chain of a zero-size file) is
+                // oversized metadata; reject it
                 mp_raise_ValueError(MP_ERROR_TEXT("bad file size"));
             }
         } else {
@@ -703,6 +713,13 @@ mp_obj_t psram_copy_file(mp_obj_t unused_self, mp_obj_t offset_in, mp_obj_t fnam
     FRESULT res = f_mount(&vfs.fatfs);
     if (res != FR_OK) {
         mp_raise_ValueError(MP_ERROR_TEXT("unmountable"));
+    }
+
+    // The USB host can rewrite the BPB, so a mountable filesystem might
+    // use more than one sector per cluster; the fragment math below works
+    // on 512-byte sectors, so refuse anything else.
+    if(vfs.fatfs.csize != 1) {
+        mp_raise_ValueError(MP_ERROR_TEXT("bad clus size"));
     }
 
     // open the file directly
@@ -771,7 +788,10 @@ mp_obj_t psram_copy_file(mp_obj_t unused_self, mp_obj_t offset_in, mp_obj_t fnam
             // final cluster might include some bytes past the EOF, but the
             // declared remainder must fit in this fragment's real capacity
             len = actual_len - so_far;
-            if(len > capacity) {
+            if((len < 1) || (len > capacity)) {
+                // len==0: earlier fragments already cover the whole file, so
+                // this trailing fragment (e.g. chain of a zero-size file) is
+                // oversized metadata; reject it
                 mp_raise_ValueError(MP_ERROR_TEXT("bad file size"));
             }
             // align4

--- a/stm32/COLDCARD_MK4/psramdisk.c
+++ b/stm32/COLDCARD_MK4/psramdisk.c
@@ -648,10 +648,19 @@ mp_obj_t psram_mmap_file(mp_obj_t unused_self, mp_obj_t fname_in)
         }
         uint32_t len = num_clusters*BLOCK_SIZE;
 
+        // hostile/corrupt FAT metadata could describe a cluster chain that
+        // covers more bytes than the file size; refuse the underflow below
+        if(so_far > fp.obj.objsize) {
+            mp_raise_ValueError(MP_ERROR_TEXT("bad file size"));
+        }
+
         if(i == num_used-1) {
             // final cluster might include some bytes past the EOF
             len = fp.obj.objsize - so_far;
         } else {
+            if(len > fp.obj.objsize - so_far) {
+                mp_raise_ValueError(MP_ERROR_TEXT("bad file size"));
+            }
             so_far += len;
         }
 
@@ -716,7 +725,9 @@ mp_obj_t psram_copy_file(mp_obj_t unused_self, mp_obj_t offset_in, mp_obj_t fnam
     if(((uint32_t)dest) % 4) mp_raise_ValueError(NULL);
     if(dest < PSRAM_BOT_BASE) mp_raise_ValueError(NULL);
     if(dest >= PSRAM_TOP_BASE) mp_raise_ValueError(NULL);
-    if(dest+actual_len+3 >= PSRAM_TOP_BASE) mp_raise_ValueError(NULL);
+    if((uint64_t)(uintptr_t)dest + actual_len + 3 >= (uint64_t)(uintptr_t)PSRAM_TOP_BASE) {
+        mp_raise_ValueError(NULL);
+    }
 
     uint32_t so_far = 0;
     DWORD *ptr = &mapping[1];
@@ -732,19 +743,31 @@ mp_obj_t psram_copy_file(mp_obj_t unused_self, mp_obj_t offset_in, mp_obj_t fnam
         }
         uint32_t len = num_clusters*BLOCK_SIZE;
 
+        // hostile/corrupt FAT metadata could describe a cluster chain that
+        // covers more bytes than the file size; refuse the underflow below
+        if(so_far > actual_len) {
+            mp_raise_ValueError(MP_ERROR_TEXT("bad file size"));
+        }
+
         if(i == num_used-1) {
             // final cluster might include some bytes past the EOF
             len = actual_len - so_far;
             // align4
             len = (len + 3) & ~0x3;
         } else {
+            if(len > actual_len - so_far) {
+                mp_raise_ValueError(MP_ERROR_TEXT("bad file size"));
+            }
             so_far += len;
+        }
+
+        // check bounds *before* writing (64-bit math to avoid wrap-around)
+        if((uint64_t)(uintptr_t)dest + len >= (uint64_t)(uintptr_t)PSRAM_TOP_BASE) {
+            mp_raise_ValueError(NULL);
         }
 
         memcpy(dest, spot, len);
         dest += len;
-
-        if(dest >= PSRAM_TOP_BASE) mp_raise_ValueError(NULL);
     }
     f_close(&fp);
 

--- a/stm32/COLDCARD_MK4/psramdisk.c
+++ b/stm32/COLDCARD_MK4/psramdisk.c
@@ -637,8 +637,14 @@ mp_obj_t psram_mmap_file(mp_obj_t unused_self, mp_obj_t fname_in)
 
     uint32_t so_far = 0;
     for(int i=0; i<num_used; i++) {
-        int num_clusters = *(ptr++);
+        uint32_t num_clusters = *(ptr++);
         uint32_t cluster = *(ptr++);
+
+        // num_clusters comes from hostile FAT metadata; validate it as u32
+        // before block_to_ptr() narrows it to uint16_t (65536 would wrap to 0)
+        if((num_clusters < 1) || (num_clusters > BLOCK_COUNT)) {
+            mp_raise_ValueError(MP_ERROR_TEXT("clstfck"));
+        }
 
         uint8_t *spot = block_to_ptr(clst2sect(&vfs.fatfs, cluster), num_clusters);
         if(!spot) {
@@ -646,7 +652,8 @@ mp_obj_t psram_mmap_file(mp_obj_t unused_self, mp_obj_t fname_in)
             //printf("0x%lx\n", clst2sect(&vfs.fatfs, cluster));
             mp_raise_ValueError(MP_ERROR_TEXT("clstfck"));
         }
-        uint32_t len = num_clusters*BLOCK_SIZE;
+        uint32_t capacity = num_clusters*BLOCK_SIZE;
+        uint32_t len = capacity;
 
         // hostile/corrupt FAT metadata could describe a cluster chain that
         // covers more bytes than the file size; refuse the underflow below
@@ -655,8 +662,12 @@ mp_obj_t psram_mmap_file(mp_obj_t unused_self, mp_obj_t fname_in)
         }
 
         if(i == num_used-1) {
-            // final cluster might include some bytes past the EOF
+            // final cluster might include some bytes past the EOF, but the
+            // declared remainder must fit in this fragment's real capacity
             len = fp.obj.objsize - so_far;
+            if(len > capacity) {
+                mp_raise_ValueError(MP_ERROR_TEXT("bad file size"));
+            }
         } else {
             if(len > fp.obj.objsize - so_far) {
                 mp_raise_ValueError(MP_ERROR_TEXT("bad file size"));
@@ -732,8 +743,14 @@ mp_obj_t psram_copy_file(mp_obj_t unused_self, mp_obj_t offset_in, mp_obj_t fnam
     uint32_t so_far = 0;
     DWORD *ptr = &mapping[1];
     for(int i=0; i<num_used; i++) {
-        int num_clusters = *(ptr++);
+        uint32_t num_clusters = *(ptr++);
         uint32_t cluster = *(ptr++);
+
+        // num_clusters comes from hostile FAT metadata; validate it as u32
+        // before block_to_ptr() narrows it to uint16_t (65536 would wrap to 0)
+        if((num_clusters < 1) || (num_clusters > BLOCK_COUNT)) {
+            mp_raise_ValueError(MP_ERROR_TEXT("clstfck"));
+        }
 
         uint8_t *spot = block_to_ptr(clst2sect(&vfs.fatfs, cluster), num_clusters);
         if(!spot) {
@@ -741,7 +758,8 @@ mp_obj_t psram_copy_file(mp_obj_t unused_self, mp_obj_t offset_in, mp_obj_t fnam
             //printf("0x%lx\n", clst2sect(&vfs.fatfs, cluster));
             mp_raise_ValueError(MP_ERROR_TEXT("clstfck"));
         }
-        uint32_t len = num_clusters*BLOCK_SIZE;
+        uint32_t capacity = num_clusters*BLOCK_SIZE;
+        uint32_t len = capacity;
 
         // hostile/corrupt FAT metadata could describe a cluster chain that
         // covers more bytes than the file size; refuse the underflow below
@@ -750,8 +768,12 @@ mp_obj_t psram_copy_file(mp_obj_t unused_self, mp_obj_t offset_in, mp_obj_t fnam
         }
 
         if(i == num_used-1) {
-            // final cluster might include some bytes past the EOF
+            // final cluster might include some bytes past the EOF, but the
+            // declared remainder must fit in this fragment's real capacity
             len = actual_len - so_far;
+            if(len > capacity) {
+                mp_raise_ValueError(MP_ERROR_TEXT("bad file size"));
+            }
             // align4
             len = (len + 3) & ~0x3;
         } else {


### PR DESCRIPTION
## Summary

`psram_copy_file()` and `psram_mmap_file()` (`stm32/COLDCARD_MK4/psramdisk.c`, shared by Q1 via symlink) trust FAT metadata of the PSRAM virtual disk, which is exposed over USB Mass Storage and therefore fully writable by a compromised USB host.

The final fragment length is computed as:

```c
len = actual_len - so_far;   // uint32_t arithmetic
```

where `actual_len = fp.obj.objsize` (directory entry size field) and `so_far` is the sum of the bytes covered by previous cluster-chain fragments. FatFs' `CREATE_LINKMAP` follows the cluster chain to EOC **without validating it against `objsize`**, so a crafted FAT (chain covering more bytes than `objsize`, e.g. on a `.dfu`/`.psbt` file dropped by the host) makes `so_far > actual_len` and `len` underflows to ~4 GB. The subsequent `memcpy(dest, spot, len)` then writes attacker-influenced data out of bounds:

- the pre-write check `dest + actual_len + 3 >= PSRAM_TOP_BASE` is insufficient and can itself wrap around for `objsize` near 4 GB;
- the `dest >= PSRAM_TOP_BASE` check happened **after** the `memcpy` — too late.

Realistic impact: corruption of everything staged in PSRAM (PSBT/firmware staging areas) and device crash via BusFault. SRAM and flash sit below `0x90000000`, so the forward-only copy does not reach them; no credible path to code execution was identified (hence moderate severity), but it is a deterministic host-triggered memory corruption reachable without user confirmation when Virtual Disk is in "Enable & Auto" mode.

## Fix

- Reject cluster chains whose coverage exceeds the file size (`so_far > actual_len`, and per-fragment `len > remaining`) before the subtraction — no more underflow.
- Verify destination bounds with 64-bit arithmetic **before** each `memcpy`, eliminating both the post-hoc check and the wrap-around.
- Same guard applied to `psram_mmap_file()`, which hands attacker-influenced (address, length) tuples to MicroPython.

## Verification

Logic validated with a standalone host harness replicating the fixed loop: legit single/multi-fragment files pass; hostile chains (oversized coverage, `objsize` near 4 GB, degenerate zero-size) are all rejected. A full firmware build was not possible in the authoring environment (no ARM toolchain / uninitialized submodules) — a run through `repro-build.sh` before merge would be appreciated.