### PR TITLE
Clarify dice-only hash secrecy warning

### DIFF
--- a/shared/seed.py
+++ b/shared/seed.py
@@ -84,7 +84,7 @@ You must enter at least 128 coin flips.'''
 DICE_ONLY_WARNING = '''\
 These dice rolls will be the only source of randomness for your seed. No hardware-generated randomness is mixed in.
 
-The hash shown while rolling is SECRET. Anyone who sees or photographs the final hash can recreate your wallet and steal the funds.
+The hash shown while rolling is SECRET. Anyone who sees or photographs one can recreate the wallet derived from the rolls entered so far and steal its funds.
 
 Keep the screen hidden from people and cameras. If you verify the hash elsewhere, use only a trusted offline device and erase all traces afterward.'''
 

--- a/testing/test_ephemeral.py
+++ b/testing/test_ephemeral.py
@@ -538,7 +538,7 @@ def test_ephemeral_dice_security_checks(reset_seed_words, goto_eph_seed_menu,
     title, warning = cap_story()
     assert title == 'WARNING'
     assert 'only source of randomness' in warning
-    assert 'final hash can recreate your wallet' in warning
+    assert 'wallet derived from the rolls entered so far' in warning
     press_select()
 
     for ch in '123456':

--- a/testing/test_ux.py
+++ b/testing/test_ux.py
@@ -232,7 +232,7 @@ def test_import_from_dice(count, nwords, goto_home, pick_menu_item, cap_story, n
     title, warning = cap_story()
     assert title == 'WARNING'
     assert 'only source of randomness' in warning
-    assert 'final hash can recreate your wallet' in warning
+    assert 'wallet derived from the rolls entered so far' in warning
     press_select()
     time.sleep(0.1)
 


### PR DESCRIPTION
## Summary

- clarify that any hash displayed during dice-only seed generation can recreate the wallet derived from the rolls entered so far
- update the corresponding master and temporary seed UX tests