### PR TITLE
bugfix: hide main PIN change for temporary wallets

### DIFF
--- a/releases/Next-ChangeLog.md
+++ b/releases/Next-ChangeLog.md
@@ -22,6 +22,7 @@ This lists the new changes that have not yet been published in a normal release.
   filesystems with more than one sector per cluster), fixing an integer underflow in
   `psram_copy_file`/`psram_mmap_file` that allowed out-of-bounds PSRAM writes, reads,
   and mappings from a compromised USB host.
+- Bugfix: Hide Change Main PIN while a temporary seed or BIP-39 passphrase wallet is active.
 
 # Mk Specific Changes
 

--- a/shared/flow.py
+++ b/shared/flow.py
@@ -151,7 +151,7 @@ with the Coldcard.''',
 # Mostly pre-login values here.
 LoginPrefsMenu = [
     #         xxxxxxxxxxxxxxxx
-    MenuItem('Change Main PIN', f=main_pin_changer),
+    MenuItem('Change Main PIN', f=main_pin_changer, predicate=is_not_tmp),
     NonDefaultMenuItem('Trick PINs', 'tp', menu=TrickPinMenu.make_menu, predicate=has_real_secret),
     NonDefaultMenuItem('Set Nickname', 'nick', prelogin=True, f=pick_nickname),
     NonDefaultMenuItem('Scramble Keys', 'rngk', prelogin=True, f=pick_scramble, default_value=0),

--- a/testing/test_change_pins.py
+++ b/testing/test_change_pins.py
@@ -181,4 +181,10 @@ def test_main_pin(goto_pin_options, pick_menu_item, cap_story, cap_screen,
     change_pin(new_pin, DEF_PIN, 'Main PIN')
     verify_pin_set(DEF_PIN)
 
+
+def test_main_pin_hidden_with_passphrase(set_bip39_pw, goto_pin_options, cap_menu):
+    set_bip39_pw('temporary wallet')
+    goto_pin_options()
+    assert 'Change Main PIN' not in cap_menu()
+
 # EOF


### PR DESCRIPTION
## Summary

- hide **Change Main PIN** while a temporary seed or BIP-39 passphrase wallet is active

