### PR TITLE
Keep TRNG words together on Q

### DIFF
--- a/shared/seed.py
+++ b/shared/seed.py
@@ -793,11 +793,12 @@ async def view_trng_words(_menu, _idx, item):
     from ux import ux_render_words
 
     words = bip39.b2a_words(item.arg).split(' ')
+    # Keep all story lines: their count makes the 24-word grid start on a fresh Q screen.
     msg = ('These 24 words encode the full 256-bit device seed (STM32 TRNG + SE1 + SE2) '
            'before user entropy is mixed in.\n\nAll 256 bits are used, even for a 12-word wallet.'
            '\n\nUse them to verify dice-roll or coin-flip mixing.\n\nKEEP SECRET: Anyone with '
            'these words and your complete user entropy can recreate your wallet seed.'
-           '\n\n%s' % ux_render_words(words))
+           '\n\nScroll to see TRNG words.\n\n%s' % ux_render_words(words))
     try:
         await ux_show_story(msg, title='TRNG Words', sensitive=True)
     finally:

--- a/testing/test_ux.py
+++ b/testing/test_ux.py
@@ -473,7 +473,8 @@ def test_new_wallet(nwords, goto_home, pick_menu_item, cap_story, expect_ftux,
 
 @pytest.mark.parametrize('nwords', [12, 24])
 def test_view_trng_words_verifies_dice_mix(nwords, pick_menu_item, cap_menu, cap_story, unit_test,
-                                           press_select, need_keypress, seed_story_to_words, is_q1):
+                                           press_select, need_keypress, seed_story_to_words, is_q1,
+                                           cap_screen, press_down):
     unit_test('devtest/clear_seed.py')
     pick_menu_item('New Seed Words')
     pick_menu_item(f'{nwords} Words')
@@ -489,6 +490,14 @@ def test_view_trng_words_verifies_dice_mix(nwords, pick_menu_item, cap_menu, cap
     assert 'All 256 bits are used' in body
     assert 'STM32 TRNG + SE1 + SE2' in body
     assert 'KEEP SECRET' in body
+    assert 'Scroll to see TRNG words.' in body
+
+    if is_q1:
+        press_down()
+        press_down()
+        time.sleep(0.1)
+        shown = {int(n) for n in re.findall(r'(?<!\d)(\d{1,2}):', cap_screen())}
+        assert shown == set(range(1, 25))
 
     press_select()
     time.sleep(0.1)


### PR DESCRIPTION
## Summary

- align the TRNG word grid to a Q page boundary by adding a short scroll prompt
- keep the existing single-story UX shared by Q and Mk4/Mk5
- verify all 24 numbered words appear together on the Q screen
- cover both 12- and 24-word wallet flows

## Testing

- Q headless simulator: test_view_trng_words_verifies_dice_mix (12 and 24 words): 2 passed

No changelog entry because this patches unreleased functionality.

By submitting this work I agree to the Individual Contributor License Agreement (CLA).