### PR TITLE
EDGE testing: stabilize multiprocess state checks

### DIFF
--- a/testing/test_multisig.py
+++ b/testing/test_multisig.py
@@ -2773,6 +2773,7 @@ def test_chain_switching(use_mainnet, use_regtest, settings_get, settings_set,
     # Mk4 retains one character; selecting the number group overwrites it.
     renamed = "1234"
     enter_complex(renamed, apply=False, b39pass=False)
+    time.sleep(.1)
     res = settings_get("miniscript")
     assert res[0][0] == on_regtest
     assert res[1][0] == renamed

--- a/testing/test_teleport.py
+++ b/testing/test_teleport.py
@@ -1075,7 +1075,8 @@ def test_teleport_miniscript_sign(dev, taproot, policy, get_cc_key, bitcoind, us
 def test_teleport_multisig_signers_per_input(use_regtest, clear_miniscript, goto_home,
                                              make_myself_wallet, fake_ms_txn, try_sign,
                                              cap_story, need_keypress, cap_menu, cap_screen,
-                                             press_cancel):
+                                             press_cancel, reset_seed_words):
+    reset_seed_words()
     use_regtest()
     clear_miniscript()
     goto_home()


### PR DESCRIPTION
## Summary

- wait for the Q1 multisig rename to be committed before reading settings
- reset the simulator seed before constructing the Teleport multisig wallet
