### PR TITLE
bugfix: restrict HSM BIP322 WIF signing

### DIFF
--- a/releases/Next-ChangeLog.md
+++ b/releases/Next-ChangeLog.md
@@ -16,7 +16,8 @@ This lists the new changes that have not yet been published in a normal release.
 
 ## 5.6.x - 2026-0x-xx
 
-- tbd
+- Bugfix: Require unrestricted HSM message-signing policy when signing BIP-322
+  messages with WIF Store keys.
 
 
 # Q Specific Changes

--- a/shared/hsm.py
+++ b/shared/hsm.py
@@ -897,6 +897,12 @@ class HSMPolicy:
                         if not inp.required_key:
                             continue
 
+                        required_keys = inp.required_key if inp.is_multisig else [inp.required_key]
+                        if any(pk in psbt.wif_store for pk in required_keys):
+                            if 'any' not in self.msg_paths:
+                                raise ValueError("WIF Store message signing requires any path")
+                            continue
+
                         if inp.is_multisig:
                             paths = [
                                 keypath_to_str(inp.subpaths[pk])

--- a/testing/test_hsm.py
+++ b/testing/test_hsm.py
@@ -953,6 +953,23 @@ def test_bip322_psbt_uses_msg_sign_policy(quick_start_hsm, change_hsm, attempt_p
     attempt_psbt(psbt, "Message signing not permitted")
 
 
+def test_bip322_wif_requires_any_msg_path(quick_start_hsm, change_hsm, attempt_psbt,
+                                           bip322_txn, settings_set, settings_remove):
+    settings_remove("wifs")
+    key = PrivateKey(prandom(32))
+    pubkey = key.K.sec()
+    settings_set("wifs", [(pubkey.hex(), bytes(key).hex())])
+    psbt, _ = bip322_txn(
+        [["p2wpkh", None, None, pubkey]], msg=b"HSM WIF BIP-322")
+
+    quick_start_hsm(DICT(msg_paths=["m/0"], warnings_ok=True))
+    attempt_psbt(psbt, "WIF Store message signing requires any path")
+
+    change_hsm(DICT(msg_paths=["any"], warnings_ok=True))
+    attempt_psbt(psbt)
+    settings_remove("wifs")
+
+
 def test_bip322_por_psbt_uses_msg_sign_policy(quick_start_hsm, change_hsm, attempt_psbt,
                                               bip322_txn):
     psbt, _ = bip322_txn([


### PR DESCRIPTION
## Summary

- Require msg_paths = ["any"] for BIP-322 signing with WIF Store keys.
- Preserve derivation-path policy matching for seed-backed keys.
- Add a regression test for forged BIP32 metadata on a WIF-backed P2WPKH input.

This is the master-specific backport, adapted to the older PSBT representation. Taproot is intentionally not included because master does not support Taproot spending.

## Testing

- HSM BIP-322 message-policy tests, PSBTv0: 5 passed
- HSM BIP-322 message-policy tests, PSBTv2: 5 passed

The regression test was also run without the fix and failed because the restricted m/0 policy incorrectly authorized signing, confirming it covers the bypass.