### PR TITLE
bugfix: vdisk import bumps txn write count

### DIFF
--- a/releases/Next-ChangeLog.md
+++ b/releases/Next-ChangeLog.md
@@ -6,6 +6,8 @@ This lists the new changes that have not yet been published in a normal release.
 
 - Bugfix: Reject foreign inputs from BIP-322 Proof of Reserves, including inputs
   disguised with forged key-path metadata or partial signatures.
+- Bugfix: Detect and abort transaction signing if a Virtual Disk firmware import
+  overwrites the reviewed PSBT. Thanks to Huzaifa Jawaid.
 - Bugfix: Restore the ability to view the device-generated seed before adding user
   entropy, which was available in the previous dice-roll workflow but was inadvertently
   removed in 5.6.1/1.5.1Q. The new **View TRNG Words** menu item displays the full

--- a/shared/vdisk.py
+++ b/shared/vdisk.py
@@ -103,6 +103,12 @@ class VirtDisk:
         # copy file into another area of PSRAM where rest of system can use it
         assert sz <= MAX_UPLOAD_LEN       # too big
 
+        # C importer memcpy's into the TXN staging regions without going
+        # through the PSRAM wrapper — record it, and revoke any lease of
+        # those staged bytes, so post-review tampering can't hide
+        glob.ALLOWED_DOWNLOAD = None
+        glob.PSRAM.txn_write_count += 1
+
         # I could not resist doing this in C... since we already have the
         # data in memory, why mess around with file concepts?
         actual = VBLKDEV.copy_file(0, filename.split('/')[-1])

--- a/testing/test_vdisk.py
+++ b/testing/test_vdisk.py
@@ -9,6 +9,7 @@ import ndef
 from hashlib import sha256
 from txn import *
 from base64 import b64encode, b64decode, encodebytes
+from ckcc_protocol.protocol import CCProtocolPacker, CCProtoError
 
 
 def test_vd_basics(dev, virtdisk_path, is_simulator):
@@ -211,6 +212,46 @@ def test_virtdisk_signing(encoding, num_outs, partial, try_sign_virtdisk, fake_t
         assert _psbt == txn
     else:
         assert _txn == txn
+
+def test_virtdisk_import_invalidates_pending_psbt(
+        dev, fake_txn, start_sign, cap_story, virtdisk_path,
+        virtdisk_wipe, settings_set, sim_eval, need_keypress, press_cancel):
+    settings_set('vidsk', 2)         # enable + auto-consume
+    virtdisk_wipe()
+    time.sleep(.4)                   # let the vdisk monitor settle
+
+    start_sign(fake_txn(3, 3), finalize=True)
+    for _ in range(100):
+        title, _ = cap_story()
+        if title == 'OK TO SEND?':
+            break
+        time.sleep(.1)
+    else:
+        pytest.fail('no approval screen')
+
+    before = int(sim_eval("__import__('glob').PSRAM.txn_write_count"))
+
+    # A firmware import uses the native PSRAM copy and overwrites the pending
+    # transaction before its own authorization attempt is rejected as busy.
+    with open(virtdisk_path('replacement.dfu'), 'wb') as f:
+        f.write(bytes(0x50000))
+
+    for _ in range(50):
+        if int(sim_eval("__import__('glob').PSRAM.txn_write_count")) != before:
+            break
+        time.sleep(.1)
+    else:
+        pytest.fail('VirtDisk import did not invalidate staged PSRAM')
+
+    need_keypress('y')
+    with pytest.raises(CCProtoError, match='Transaction modified'):
+        while True:
+            time.sleep(.1)
+            done = dev.send_recv(CCProtocolPacker.get_signed_txn(), timeout=None)
+            if done is not None:
+                break
+
+    press_cancel()
 
 def test_virtdisk_oversized_psbt_rejected(press_select, virtdisk_path, cap_story, virtdisk_wipe,
                                           press_cancel, goto_home, sd_cards_eject,

--- a/unix/variant/sim_vdisk.py
+++ b/unix/variant/sim_vdisk.py
@@ -29,6 +29,18 @@ class SimBlockDev:
     def wipe(self):
         print("sim-virtdisk: wipe (not implemented)")
 
+    def copy_file(self, offset, filename):
+        # Match the native implementation: copy directly into the lower
+        # PSRAM mapping without going through PSRAMWrapper.write_at().
+        print("sim-virtdisk: read %s" % filename)
+        with open(SIMDIR_PATH + filename, 'rb') as f:
+            contents = f.read()
+
+        from glob import PSRAM
+        assert offset + len(contents) <= PSRAM.length
+        PSRAM._wr[offset:offset+len(contents)] = contents
+        return len(contents)
+
     @classmethod
     async def monitor_task(cls, self):
         # works, but hard to manage the atask
@@ -71,17 +83,6 @@ class SimulatedVirtDisk(vdisk.VirtDisk):
         #print("sim-virtdisk: CC unmounted; ready to view")
         for fn in written_files:
             self.ignore.add(fn.split('/')[-1])
-
-    def import_file(self, filename, sz):
-        # copy file into another area of PSRAM where rest of system can use it
-        print("sim-virtdisk: read %s" % filename)
-        with open(filename, 'rb') as f:
-            contents = f.read(sz)
-        from glob import PSRAM
-        runt = (4 - sz % 4)
-        sz = sz + runt
-        PSRAM.write_at(0, sz)[:] = contents + bytes(runt)
-        return sz
 
 vdisk.VirtDisk = SimulatedVirtDisk
 


### PR DESCRIPTION
The C VirtDisk importer (`ckcc.PSRAM.copy_file`, used only by `VirtDisk.import_file`) memcpy's into the PSRAM TXN staging regions without going through `PSRAMWrapper.write_at()`, so `txn_write_count` is not bumped. The pre-signing re-hash is gated on that counter, allowing a Virtual Disk firmware import to replace a reviewed PSBT while the guard takes its fast path.

**Fix:** bump the counter and revoke any PSRAM lease (`ALLOWED_DOWNLOAD`) in `VirtDisk.import_file` before calling `copy_file`. Bumping first also invalidates approval if the native copy fails after a partial write.

**Regression:** make the simulator model `copy_file` as the same direct lower-PSRAM write used on hardware, then drive the real auto-VirtDisk path: stage a PSBT, show its approval, drop a `.dfu` file, approve, and verify signing aborts with `Transaction modified`.

Precondition for exploit remains **Settings > Hardware On/Off > Virtual Disk = Enable & Auto** (`vidsk == 2`), not the shipped default.