### PR TITLE
bugfix: harden temporary wallet write guards

### DIFF
--- a/releases/Next-ChangeLog.md
+++ b/releases/Next-ChangeLog.md
@@ -11,6 +11,7 @@ This lists the new changes that have not yet been published in a normal release.
   verification of dice-roll or coin-flip mixing.
 - Bugfix: Simulator crashed on Bless Firmware, due to a desynced LED pipe. Thanks to
   [@hitechhayekian](https://github.com/hitechhayekian).
+- Bugfix: With an empty master wallet and an active temporary seed, keep imports and backup restores temporary instead of treating them as master-seed changes.
 
 # Mk Specific Changes
 

--- a/shared/actions.py
+++ b/shared/actions.py
@@ -1478,7 +1478,9 @@ async def restore_backup_dev(*a):
     if fn:
         words = False if fn[-3:] == ".7z" else None
         import backups
-        await backups.restore_complete(fn, not pa.is_secret_blank(), words)
+        # A temporary wallet makes master writes no-op, despite the restore reporting success.
+        # Route the backup to another temporary wallet whenever any secret is active.
+        await backups.restore_complete(fn, pa.has_secrets(), words)
 
 async def bkpw_override(*A):
     # allows user to:

--- a/shared/actions.py
+++ b/shared/actions.py
@@ -1409,7 +1409,9 @@ async def import_xprv(_1, _2, item):
 
     ephemeral = item.arg
     if not ephemeral:
-        assert pa.is_secret_blank() # "must not have secret"
+        # A blank SE can still have a temporary wallet active.
+        # Permanent imports require no active secret.
+        assert not pa.has_secrets()
 
     def contains_xprv(fname):
         # just check if likely to be valid; not full check

--- a/shared/auth.py
+++ b/shared/auth.py
@@ -1228,13 +1228,12 @@ class RemoteRestoreBackup(UserAuthorizedAction):
     def to_tmp(self):
         # conversion to "temporary" argument of "restore_complete" function
         from pincodes import pa
-        if pa.is_secret_blank() and not self.force_tmp:
-            # no master secret & not forcing tmp
-            # will load backup as master seed
+        # A temporary wallet makes master writes no-op, so only select master restore
+        # when no secret is active and the caller did not force temporary mode.
+        if not pa.has_secrets() and not self.force_tmp:
             return False, "master"
 
-        # has master secret --> load backup as tmp
-        # secret is blank but user forcing tmp
+        # A master/temporary secret is active, or the caller forced temporary mode.
         return True, "temporary"
 
     async def interact(self):

--- a/shared/backups.py
+++ b/shared/backups.py
@@ -143,6 +143,8 @@ def restore_from_dict_ll(vals, raw):
     # - low-level version, factored out for better testing
     from glob import dis
 
+    assert not pa.tmp_value, "temporary seed active"
+
     need_ftux = False
 
     #print("Restoring from: %r" % vals)

--- a/shared/seed.py
+++ b/shared/seed.py
@@ -977,6 +977,8 @@ def xprv_to_encoded_secret(xprv):
 def set_seed_value(words=None, encoded=None, chain=None):
     # Save the seed words (or other encoded private key) into secure element.
     # BIP-39 passphrase is not set at this point (empty string).
+    assert not pa.tmp_value, "temporary seed active"
+
     if words:
         nv = seed_words_to_encoded_secret(words)
     else:

--- a/shared/tapsigner.py
+++ b/shared/tapsigner.py
@@ -31,7 +31,9 @@ async def import_tapsigner_backup_file(_1, _2, item):
     ephemeral = item.arg
     if not ephemeral:
         from pincodes import pa
-        assert pa.is_secret_blank()  # "must not have secret"
+        # A blank SE can still have a temporary wallet active.
+        # Permanent imports require no active secret.
+        assert not pa.has_secrets()
 
     origin = "from "
     label = "TAPSIGNER encrypted backup file"

--- a/shared/teleport.py
+++ b/shared/teleport.py
@@ -306,7 +306,7 @@ async def kt_accept_values(dtype, raw):
     - `p` - binary PSBT to be signed
     - `b` - complete system backup file (text, internal format)
     '''
-    from flow import has_se_secrets, goto_top_menu
+    from flow import has_secrets, goto_top_menu
     from pincodes import pa
 
     enc = None
@@ -416,7 +416,8 @@ async def kt_accept_values(dtype, raw):
 
     from seed import set_ephemeral_seed, set_seed_value
 
-    if not has_se_secrets():
+    # A temporary wallet still counts as a secret when the SE is blank.
+    if not has_secrets():
         # unit has nothing, so this will be the master seed
         set_seed_value(encoded=enc)
         ok = True

--- a/shared/xor_seed.py
+++ b/shared/xor_seed.py
@@ -190,7 +190,8 @@ async def xor_all_done(data, force_tmp, done_cb):
 
             enc = SecretStash.encode(seed_phrase=seed)
 
-            if pa.is_secret_blank() and not force_tmp:
+            # A temporary wallet still counts as a secret when the SE is blank.
+            if not pa.has_secrets() and not force_tmp:
                 # save it since they have no other secret
                 set_seed_value(encoded=enc)
                 # update menu contents now that wallet defined
@@ -268,7 +269,8 @@ or press (2) for 18 words XOR.''' % OK, escape="12")
     from glob import dis
 
     escape = ""
-    if not pa.is_secret_blank():
+    # Warn when either a stored or temporary secret is active.
+    if pa.has_secrets():
         msg = ("Since you have a seed already on this Coldcard, the reconstructed XOR seed will be "
                "temporary and not saved. Wipe the seed first if you want to commit the new value "
                "into the secure element.")

--- a/testing/seedless_tests.py
+++ b/testing/seedless_tests.py
@@ -1,11 +1,12 @@
 # (c) Copyright 2024 by Coinkite Inc. This file is covered by license found in COPYING-CC.
 #
-import pytest, pdb, time, random, os
+import pytest, pdb, time, random, os, shutil
 from charcodes import KEY_CANCEL, KEY_QR
-from core_fixtures import _pick_menu_item, _press_select
+from core_fixtures import _pick_menu_item, _press_select, _press_cancel, _word_menu_entry
 from core_fixtures import _need_keypress, _sim_exec, _cap_story
 from run_sim_tests import ColdcardSimulator, clean_sim_data
 from ckcc_protocol.client import ColdcardDevice
+from ckcc_protocol.protocol import CCProtocolPacker
 
 
 def test_status_bar_rewrite_after_restore_master():
@@ -67,5 +68,45 @@ def test_seedless_qr_import_bad_checksum():
 
         title, story = _cap_story(device)
         assert 'checksum fail' in story
+    finally:
+        sim.stop()
+
+
+def test_tmp_backup_restore_on_seedless():
+    clean_sim_data()
+    backup = os.path.realpath('./data/ckcc-backup.txt')
+    shutil.copy(backup, os.path.realpath('../unix/work/MicroSD/ckcc-backup.txt'))
+
+    sim = ColdcardSimulator(args=["--q1", "-l"], headless=True)
+    sim.start(start_wait=3)
+    device = ColdcardDevice(is_simulator=True)
+    try:
+        _pick_menu_item(device, True, "Advanced/Tools")
+        _pick_menu_item(device, True, "Temporary Seed")
+        _need_keypress(device, "4")
+        _pick_menu_item(device, True, "Import Words")
+        _pick_menu_item(device, True, "12 Words")
+        _word_menu_entry(device, True, ["abandon"] * 11 + ["about"])
+        time.sleep(.5)
+        assert "New temporary master key is in effect now." in _cap_story(device)[1]
+        _press_select(device, True)
+
+        _pick_menu_item(device, True, "Advanced/Tools")
+        _pick_menu_item(device, True, "Danger Zone")
+        _pick_menu_item(device, True, "I Am Developer.")
+        _pick_menu_item(device, True, "Restore Bkup")
+        _pick_menu_item(device, True, "ckcc-backup.txt")
+        time.sleep(.2)
+        assert "load backup as temporary seed" in _cap_story(device)[1]
+        _press_cancel(device, True)
+        time.sleep(2.2)
+
+        with open(backup, "rb") as fd:
+            file_len, sha = device.upload_file(fd.read())
+        device.send_recv(CCProtocolPacker.restore_backup(file_len, sha, plaintext=True),
+                         timeout=None)
+        time.sleep(.2)
+        assert "Restore uploaded backup as a temporary seed?" in _cap_story(device)[1]
+        _press_cancel(device, True)
     finally:
         sim.stop()


### PR DESCRIPTION
## Summary

- require that no master or temporary secret is active before permanent XPRV import
- apply the same precondition to permanent TAPSIGNER backup import
- use the active-secret check for developer and CKCC/USB backup restores
- use the active-secret check when receiving Key Teleport secret material
- use the active-secret check for Seed XOR completion and its temporary-seed warning
- reject low-level master seed writes and full master restores while a temporary wallet is active
- document why checking only whether the secure-element slot is blank is insufficient
- add one changelog entry describing the affected empty-master plus temporary-seed state
- add a seedless regression test covering both developer and CKCC backup restore prompts with a temporary seed active

No Main PIN changes are included as those are opened here https://github.com/Coldcard/firmware/pull/767