### PR TITLE
Reject out-of-range txn version on PSBTv2 path

### DIFF
--- a/releases/Next-ChangeLog.md
+++ b/releases/Next-ChangeLog.md
@@ -28,6 +28,9 @@ This lists the new changes that have not yet been published in a normal release.
   `psram_copy_file`/`psram_mmap_file` that allowed out-of-bounds PSRAM writes, reads,
   and mappings from a compromised USB host.
 - Bugfix: Hide Change Main PIN while a temporary seed or BIP-39 passphrase wallet is active.
+- Bugfix: Reject PSBTv2 transactions with an out-of-range transaction version, matching
+  the PSBTv0 parser. Previously a v2 PSBT with an invalid `nVersion` could be approved
+  and signed, producing a transaction the network will not relay.
 - Bugfix: Reject firmware images that extend past the world-checksum-covered
   flash region.
 

--- a/shared/psbt.py
+++ b/shared/psbt.py
@@ -1550,6 +1550,11 @@ class psbtObject(psbtProxy):
 
         if self.por322:
             assert self.txn_version in {0, 2}, TX_VER_ERR
+        else:
+            # reject out-of-range versions on both v0 and v2 paths (the
+            # parse_txn() check only runs for v0); keeps v2 from signing
+            # transactions the network will not relay
+            assert self.txn_version in {1, 2, 3}, TX_VER_ERR
 
         # time based relative locks
         tb_rel_locks = []

--- a/testing/test_sign.py
+++ b/testing/test_sign.py
@@ -2621,6 +2621,19 @@ def test_psbt_v2_global_quantities(way, fake_txn, start_sign, end_sign, cap_stor
     assert "failed" in story or "Invalid PSBT" in story or "Network fee bigger" in story
 
 
+@pytest.mark.parametrize("bad_ver", [4, -1, 100])
+def test_psbt_v2_bad_txn_version(bad_ver, fake_txn, start_sign, cap_story):
+    # PSBTv2 must reject an out-of-range transaction version, same as the v0 parser
+    # (parse_txn's `bad txn version` check only runs for v0). Otherwise a v2 PSBT with
+    # an invalid nVersion could be approved and signed into an unrelayable transaction.
+    # negative values are stored two's-complement (device parses txn_version as <i)
+    psbt = fake_txn(1, 1, segwit_in=True, psbt_v2=True,
+                    psbt_hacker=lambda p: setattr(p, 'txn_version', bad_ver & 0xffffffff))
+    start_sign(psbt)
+    title, story = cap_story()
+    assert "bad txn version" in story, story
+
+
 @pytest.mark.bitcoind
 @pytest.mark.parametrize("locktime", [
     0,  # zero default


### PR DESCRIPTION
## Problem

The `bad txn version` check (`txn_version in {0,1,2,3}`) lives in `parse_txn()` (`shared/psbt.py:1230`), which only runs for **PSBTv0**. On the **PSBTv2** path, `read_psbt()` (`psbt.py:2024-2026`) skips `parse_txn()`, so `PSBT_GLOBAL_TX_VERSION` (`psbt.py:1142`) was used **unvalidated**.

A v2 PSBT with `nVersion = 4` (or a negative value) flows into the sighash (`psbt.py:2346`, `2452`) and final serialization (`psbt.py:2561`): the device shows the normal "OK TO SEND?" review, the user approves, and the device signs a transaction the Bitcoin network will not relay — burning the fee and breaking the user's flow. The same payload on the v0 path is rejected at parse time.

## Fix

`validate()` already enforces PoR-specific versions (`psbt.py:1547-1552`: version 0 only for BIP-322, `{0,2}` for PoR txns) but had **no upper bound for ordinary transactions**. Add the matching non-PoR bound:

```python
else:
    assert self.txn_version in {1, 2, 3}, TX_VER_ERR
```

so both v0 and v2 reject out-of-range versions, while the BIP-322 PoR path (versions 0 and 2) is unchanged. Minimal diff: 5 lines in `validate()`; the redundant v0-only assert in `parse_txn()` is left in place.

## Tests

- **New** `test_psbt_v2_bad_txn_version` (versions 4, -1, 100): v2 PSBTs must be rejected with `bad txn version`. **Verified to fail pre-patch** (v2 reaches "OK TO SEND?") and pass with the fix.
- Full `test_bip322.py` suite (101 tests) passes — PoR version-0/2 path intact.
- Broader v2 signing tests pass (the only error is a pre-existing missing-bitcoind environment issue, unrelated).

## Changelog

Added a `Next-ChangeLog.md` entry.