### PR TITLE
Warn for far-future block-height nLockTime

### DIFF
--- a/releases/Next-ChangeLog.md
+++ b/releases/Next-ChangeLog.md
@@ -4,6 +4,8 @@ This lists the new changes that have not yet been published in a normal release.
 
 # Shared Improvements - Both Mk and Q
 
+- Enhancement: Warn when a transaction's block-height `nLockTime` is more than
+  ten years beyond the Bitcoin block height known to the firmware.
 - Bugfix: Reject foreign inputs from BIP-322 Proof of Reserves, including inputs
   disguised with forged key-path metadata or partial signatures.
 - Bugfix: Detect and abort transaction signing if a Virtual Disk firmware import

--- a/shared/psbt.py
+++ b/shared/psbt.py
@@ -38,6 +38,7 @@ from public_constants import (
 # transaction version error
 TX_VER_ERR = "bad txn version"
 NO_KEY_ERR = "None of the keys involved in this transaction belong to this Coldcard"
+MAX_FUTURE_BLOCKS = const(10 * 365 * 144)
 
 # single sha256 of b'BIP0322-signed-message'
 BIP322_TAG_HASH = b'te\x84\xa1\x87/\xa1\x00AUN\xff\xa08\xd6\x12IB\xddy\xb4\xe5\x8aL\xda\x18N\x13\xdb\xe6,I'
@@ -1597,6 +1598,13 @@ class psbtObject(psbtProxy):
                 msg = "This tx can only be spent after "
                 if self.lock_time < NLOCK_IS_TIME:
                     msg += "block height of %d" % self.lock_time
+
+                    min_block = chains.current_chain().ccc_min_block
+                    if min_block and self.lock_time > (min_block + MAX_FUTURE_BLOCKS):
+                        self.warnings.append((
+                            "Distant Locktime",
+                            "Unusually distant block-height locktime (10+ years)."
+                        ))
                 else:
                     try:
                         dt = datetime_from_timestamp(self.lock_time)

--- a/testing/test_sign.py
+++ b/testing/test_sign.py
@@ -2710,6 +2710,28 @@ def test_locktime_ux(use_regtest, bitcoind_d_sim_watch, start_sign, end_sign,
     assert txid == story_txid
 
 
+@pytest.mark.parametrize("extra_blocks,warn", [(0, False), (1, True)])
+def test_far_future_locktime_warning(
+        extra_blocks, warn, use_mainnet, sim_exec, fake_txn, start_sign,
+        end_sign, cap_story):
+    use_mainnet()
+    min_block = int(sim_exec(
+        "import chains; RV.write(str(chains.current_chain().ccc_min_block))"))
+    locktime = min_block + (10 * 365 * 144) + extra_blocks
+
+    start_sign(fake_txn(1, 1, lock_time=locktime))
+    time.sleep(0.1)
+    title, story = cap_story()
+
+    assert title == "OK TO SEND?"
+    assert "Abs Locktime" in story
+    assert "block height of %d" % locktime in story
+    assert ("Distant Locktime" in story) is warn
+    assert ("Unusually distant block-height locktime (10+ years)." in story) is warn
+
+    end_sign(accept=False)
+
+
 @pytest.mark.bitcoind
 @pytest.mark.parametrize("num_ins", [1, 4, 11])
 @pytest.mark.parametrize("differ", [True, False])


### PR DESCRIPTION
## Summary
- warn when a mainnet block-height `nLockTime` is more than ten years beyond the block height known to the firmware
- retain the existing absolute-locktime information in the approval story
- document the enhancement in `Next-ChangeLog.md`

## Tests
- `pytest test_sign.py --headless --sim -q -s -k far_future_locktime_warning` (2 passed)
- same focused test with `--psbt2` (2 passed)