### PR TITLE
bugfix: Reject duplicate singleton PSBT keys

### DIFF
--- a/releases/Next-ChangeLog.md
+++ b/releases/Next-ChangeLog.md
@@ -6,6 +6,7 @@ This lists the new changes that have not yet been published in a normal release.
 
 - Enhancement: Warn when a transaction's block-height `nLockTime` is more than
   ten years beyond the Bitcoin block height known to the firmware.
+- Bugfix: Reject duplicate singleton keys in PSBT maps
 - Bugfix: Add a block-height reset to Single-Signer Spending Policy's
   **Last Violation** screen after policy bypass, matching CCC.
 - Bugfix: Reject foreign inputs from BIP-322 Proof of Reserves, including inputs

--- a/shared/psbt.py
+++ b/shared/psbt.py
@@ -214,6 +214,7 @@ class psbtProxy:
 
     def parse(self, fd):
         self.fd = fd
+        seen_singletons = 0
 
         while 1:
             ks = deser_compact_size(fd)
@@ -225,6 +226,11 @@ class psbtProxy:
             assert vs is not None, 'eof'
 
             kt = key[0]
+
+            if len(key) == 1:
+                mask = 1 << kt
+                assert not (seen_singletons & mask), 'duplicate key'
+                seen_singletons |= mask
 
             if kt in self.no_keys:
                 assert len(key) == 1        # not expecting key

--- a/testing/test_sign.py
+++ b/testing/test_sign.py
@@ -6,7 +6,8 @@
 import time, pytest, os, random, pdb, struct, base64, binascii, itertools, datetime
 from ckcc_protocol.protocol import CCProtocolPacker, CCProtoError
 from binascii import b2a_hex, a2b_hex
-from psbt import BasicPSBT, BasicPSBTInput, BasicPSBTOutput, PSBT_IN_REDEEM_SCRIPT
+from psbt import (BasicPSBT, BasicPSBTInput, BasicPSBTOutput, PSBT_IN_REDEEM_SCRIPT,
+                  PSBT_GLOBAL_VERSION, PSBT_IN_WITNESS_UTXO, PSBT_OUT_AMOUNT)
 from io import BytesIO
 from pprint import pprint
 from decimal import Decimal
@@ -59,6 +60,27 @@ def test_psbt_parse_fails(try_sign, fn):
 
     msg = ee.value.args[0]
     assert ('PSBT parse failed' in msg) or ('Invalid PSBT' in msg)
+
+@pytest.mark.parametrize('scope', ['global', 'input', 'output'])
+def test_psbt_duplicate_singleton_key(try_sign, fake_txn, scope):
+    def add_duplicate(psbt):
+        if scope == 'global':
+            psbt.unknown = [
+                (bytes([PSBT_GLOBAL_VERSION]), struct.pack('<I', psbt.version))
+            ]
+        elif scope == 'input':
+            inp = psbt.inputs[0]
+            inp.unknown = [(bytes([PSBT_IN_WITNESS_UTXO]), inp.witness_utxo)]
+        else:
+            out = psbt.outputs[0]
+            out.unknown = [(bytes([PSBT_OUT_AMOUNT]), struct.pack('<q', out.amount))]
+
+    psbt = fake_txn(1, 1, psbt_v2=True, segwit_in=True, psbt_hacker=add_duplicate)
+
+    with pytest.raises(CCProtoError) as ee:
+        try_sign(psbt, accept=False)
+
+    assert 'PSBT parse failed' in ee.value.args[0]
 
 @pytest.mark.parametrize('fn', [
 	'data/2-of-2.psbt',


### PR DESCRIPTION
Port [the `public/new_edge` fix](https://github.com/Coldcard/firmware/commit/eceb19160bbc83dcbf1c9cb80a3c152a276b09b9) to `master`: reject duplicate singleton keys in PSBT global, input, and output maps as required by BIP-174.

Key-data-bearing entries remain out of scope because tracking arbitrary keys would add unbounded memory overhead on a constrained hardware wallet. Security-relevant entries are independently validated or ignored, so duplicates cannot override the amounts, fees, scripts, or sighash policy presented for approval.