### PR TITLE
EDGE: Warn for far-future block-height nLockTime

### DIFF
--- a/releases/Next-ChangeLog.md
+++ b/releases/Next-ChangeLog.md
@@ -5,6 +5,8 @@ This lists the new changes that have not yet been published in a normal release.
 # Shared Improvements - Both Mk and Q
 
 - New Feature: Added USB ncry v3 authenticated encryption with direction-separated keys and replay protection
+- Enhancement: Warn when a transaction's block-height `nLockTime` is more than
+  ten years beyond the Bitcoin block height known to the firmware.
 - Bugfix: Restore the ability to view the device-generated seed before adding user
   entropy, which was available in the previous dice-roll workflow but was inadvertently
   removed in 5.6.1/1.5.1Q. The new **View TRNG Words** menu item displays the full

--- a/shared/psbt.py
+++ b/shared/psbt.py
@@ -51,6 +51,7 @@ psbt_tmp256 = bytearray(256)
 # transaction version error
 TX_VER_ERR = "bad txn version"
 NO_KEY_ERR = "None of the keys involved in this transaction belong to this Coldcard"
+MAX_FUTURE_BLOCKS = const(10 * 365 * 144)
 
 def build_bip322_to_spend(msg_hash, message_challenge):
     to_spend = CTransaction()
@@ -2414,6 +2415,13 @@ class psbtObject(psbtProxy):
                 msg = "This tx can only be spent after "
                 if self.lock_time < NLOCK_IS_TIME:
                     msg += "block height of %d" % self.lock_time
+
+                    min_block = chains.current_chain().ccc_min_block
+                    if min_block and self.lock_time > (min_block + MAX_FUTURE_BLOCKS):
+                        self.warnings.append((
+                            "Distant Locktime",
+                            "Unusually distant block-height locktime (10+ years)."
+                        ))
                 else:
                     try:
                         dt = datetime_from_timestamp(self.lock_time)

--- a/testing/test_sign.py
+++ b/testing/test_sign.py
@@ -2976,6 +2976,28 @@ def test_locktime_ux(use_regtest, bitcoind_d_sim_watch, start_sign, end_sign,
     assert txid == story_txid
 
 
+@pytest.mark.parametrize("extra_blocks,warn", [(0, False), (1, True)])
+def test_far_future_locktime_warning(
+        extra_blocks, warn, use_mainnet, sim_exec, fake_txn, start_sign,
+        end_sign, cap_story):
+    use_mainnet()
+    min_block = int(sim_exec(
+        "import chains; RV.write(str(chains.current_chain().ccc_min_block))"))
+    locktime = min_block + (10 * 365 * 144) + extra_blocks
+
+    start_sign(fake_txn(1, 1, lock_time=locktime))
+    time.sleep(0.1)
+    title, story = cap_story()
+
+    assert title == "OK TO SEND?"
+    assert "Abs Locktime" in story
+    assert "block height of %d" % locktime in story
+    assert ("Distant Locktime" in story) is warn
+    assert ("Unusually distant block-height locktime (10+ years)." in story) is warn
+
+    end_sign(accept=False)
+
+
 def test_relative_locktime_summary_is_bounded(fake_txn, start_sign, cap_story, press_cancel):
     num_each = 125
     max_lock = num_each


### PR DESCRIPTION
## Summary
- warn when a mainnet block-height `nLockTime` is more than ten years beyond the block height known to the firmware
- retain the existing absolute-locktime information in the approval story
- document the enhancement in `Next-ChangeLog.md`

## Tests
- `pytest test_sign.py --headless --sim -q -s -k far_future_locktime_warning` (2 passed)
- same focused test with `--psbt2` (2 passed)