### PR TITLE
EDGE: Use one PSRAM write counter

### DIFF
--- a/shared/auth.py
+++ b/shared/auth.py
@@ -400,7 +400,7 @@ class ApproveTransaction(UserAuthorizedAction):
         # - they are re-read from live PSRAM during display, signing & finalization,
         #   and a USB host could rewrite them while we wait for approval
         from glob import PSRAM
-        self.parsed_write_count = PSRAM.txn_write_count
+        self.parsed_write_count = PSRAM.psram_write_count
         self.parsed_sha = psram_sha256(self.offset, self.psbt_len)
         if self.psbt_sha is not None and self.psbt_sha != self.parsed_sha:
             del self.psbt
@@ -610,10 +610,10 @@ class ApproveTransaction(UserAuthorizedAction):
 
         # the parsed bytes must be unchanged since parse/approval; covers all
         # input methods and the HSM auto-approval path, as both end up here
-        # - fast path: nothing wrote to the TXN region since we hashed it,
+        # - fast path: nothing wrote to PSRAM since we hashed it,
         #   so there is no need to re-hash in that (common) case
         from glob import PSRAM
-        if PSRAM.txn_write_count != self.parsed_write_count:
+        if PSRAM.psram_write_count != self.parsed_write_count:
             if psram_sha256(self.offset, self.psbt_len) != self.parsed_sha:
                 # fail closed: wipe the txn, so no signature over modified data
                 psram_wipe(self.offset, self.psbt_len)
@@ -621,9 +621,9 @@ class ApproveTransaction(UserAuthorizedAction):
                 gc.collect()
                 return await self.failure("Transaction modified")
 
-            # A writer touched the other TXN staging region. The active PSBT is
+            # A writer touched PSRAM outside the active PSBT. The active PSBT is
             # unchanged, so make this successful re-check the new baseline.
-            self.parsed_write_count = PSRAM.txn_write_count
+            self.parsed_write_count = PSRAM.psram_write_count
 
         # do the actual signing.
         try:
@@ -653,8 +653,8 @@ class ApproveTransaction(UserAuthorizedAction):
         # tripwire: no writer could have run since the re-check above, as
         # there is no await between it and signing (single-threaded asyncio),
         # so this cannot trigger today - it fails loudly if a future change
-        # adds an await or a new TXN-region writer on this path
-        assert PSRAM.txn_write_count == self.parsed_write_count
+        # adds an await or a new PSRAM writer on this path
+        assert PSRAM.psram_write_count == self.parsed_write_count
 
         try:
             await done_signing(self.psbt, self, self.input_method,
@@ -1616,7 +1616,7 @@ class FirmwareUpgradeRequest(UserAuthorizedAction):
         self.length = length
         self.hdr_check = hdr_check
         self.psram_offset = psram_offset
-        self.upgrade_write_count = glob.PSRAM.upgrade_write_count
+        self.psram_write_count = glob.PSRAM.psram_write_count
 
     async def interact(self):
         from version import decode_firmware_header
@@ -1650,7 +1650,7 @@ Binary checksum and signature will be further verified before any changes are ma
             ch = await ux_show_story(msg)
 
             if ch == 'y':
-                assert glob.PSRAM.upgrade_write_count == self.upgrade_write_count
+                assert glob.PSRAM.psram_write_count == self.psram_write_count
 
                 # Accepted:
                 # - write final file header, so bootloader will see it

--- a/shared/psram.py
+++ b/shared/psram.py
@@ -2,7 +2,7 @@
 #
 # psram.py -- access PSRAM chip on Mk4
 #
-import version, uctypes
+import uctypes
 
 # already started and memory mapped by bootrom.
 
@@ -10,16 +10,8 @@ class PSRAMWrapper:
     base = 0x9000_0000     # OCTOSPI1
     length = 0x40_0000     # 4 meg (lower half)
 
-    # bumped on every write into the TXN staging regions (input below
-    # MAX_TXN_LEN, output at/above it); used to detect post-review
-    # mutation of the transaction being signed
-    txn_write_count = 0
-
-    # kept separate from transaction signing: firmware approval captures this
-    # value and aborts if its staged image is overwritten
-    upgrade_write_count = 0
-
     def __init__(self):
+        self.psram_write_count = 0
         self._wr = uctypes.bytearray_at(self.base, self.length)
 
     def read_at(self, offset, ln):
@@ -32,10 +24,7 @@ class PSRAMWrapper:
         assert ln % 4 == 0, ln
         assert offset + ln <= self.length, (offset+ln)
 
-        if offset < 2 * version.MAX_TXN_LEN:
-            # covers both TXN staging regions (input and output)
-            self.txn_write_count += 1
-            self.upgrade_write_count += 1
+        self.psram_write_count += 1
 
         return memoryview(self._wr)[offset:offset+ln]
 

--- a/shared/vdisk.py
+++ b/shared/vdisk.py
@@ -107,8 +107,7 @@ class VirtDisk:
         # through the PSRAM wrapper — record it, and revoke any lease of
         # those staged bytes, so post-review tampering can't hide
         glob.ALLOWED_DOWNLOAD = None
-        glob.PSRAM.txn_write_count += 1
-        glob.PSRAM.upgrade_write_count += 1
+        glob.PSRAM.psram_write_count += 1
 
         # I could not resist doing this in C... since we already have the
         # data in memory, why mess around with file concepts?

--- a/testing/test_sign.py
+++ b/testing/test_sign.py
@@ -4941,9 +4941,9 @@ def test_psram_write_counter_covers_txn_output_region(sim_exec, sim_eval):
     else:
         raise pytest.fail('PSRAM not initialized')
 
-    start = int(sim_eval("__import__('glob').PSRAM.txn_write_count"))
+    start = int(sim_eval("__import__('glob').PSRAM.psram_write_count"))
     sim_exec("from glob import PSRAM; import version; PSRAM.write(version.MAX_TXN_LEN, bytes(100))")
     sim_exec("from glob import PSRAM; PSRAM.write(3 * 1024 * 1024, bytes(100))")
-    assert int(sim_eval("__import__('glob').PSRAM.txn_write_count")) == start + 2
+    assert int(sim_eval("__import__('glob').PSRAM.psram_write_count")) == start + 2
 
 # EOF

--- a/testing/test_vdisk.py
+++ b/testing/test_vdisk.py
@@ -229,7 +229,7 @@ def test_virtdisk_import_invalidates_pending_psbt(
     else:
         pytest.fail('no approval screen')
 
-    before = int(sim_eval("__import__('glob').PSRAM.txn_write_count"))
+    before = int(sim_eval("__import__('glob').PSRAM.psram_write_count"))
 
     # A firmware import uses the native PSRAM copy and overwrites the pending
     # transaction before its own authorization attempt is rejected as busy.
@@ -237,7 +237,7 @@ def test_virtdisk_import_invalidates_pending_psbt(
         f.write(bytes(0x50000))
 
     for _ in range(50):
-        if int(sim_eval("__import__('glob').PSRAM.txn_write_count")) != before:
+        if int(sim_eval("__import__('glob').PSRAM.psram_write_count")) != before:
             break
         time.sleep(.1)
     else:

--- a/unix/variant/sim_psram.py
+++ b/unix/variant/sim_psram.py
@@ -7,6 +7,8 @@ import version, psram
 class SimulatedPSRAMWrapper(psram.PSRAMWrapper):
 
     def __init__(self):
+        self.psram_write_count = 0
+
         # note: need heapsize=X with big number to get object so big on the heap
         self._wr = bytearray(self.length)
 


### PR DESCRIPTION
`FirmwareUpgradeRequest` renders consent from a header snapshot, but the final flash operation consumes a live PSRAM window. A second upload can overwrite that window while approval is pending.

**Fix:**

- Add a dedicated `upgrade_write_count`, separate from transaction signing.
- Capture it synchronously when `FirmwareUpgradeRequest` is created, alongside the approved header snapshot.
- Assert it is unchanged immediately before `bootrom_takeover()` and `pa.firmware_upgrade()`.
- Increment it for normal PSRAM writes and for the native VirtDisk copy that bypasses `PSRAMWrapper.write_at()`.

There is no await between the final counter check and the flash call, so another cooperative task cannot modify the staged image after verification. This avoids hashing the complete firmware image twice.

The regression test uploads valid firmware A with its trailer, overwrites PSRAM with different same-length valid firmware B through the raw upload path, confirms the displayed version is still A, approves, and asserts that `pa.firmware_upgrade()` was never reached.

Tests:

- `testing/test_upgrades.py`: 5 passed on Mk5 simulator
- `test_upgrade_staged_image_tamper`: passed on Q1 simulator
- `test_psram_write_counter_covers_txn_output_region`: passed