### PR TITLE
EDGE: Validate wrapped-segwit redeem script contents

### DIFF
--- a/releases/Next-ChangeLog.md
+++ b/releases/Next-ChangeLog.md
@@ -7,6 +7,9 @@ This lists the new changes that have not yet been published in a normal release.
 - New Feature: Added USB ncry v3 authenticated encryption with direction-separated keys and replay protection
 - Enhancement: Warn when a transaction's block-height `nLockTime` is more than
   ten years beyond the Bitcoin block height known to the firmware.
+- Bugfix: Reject malformed PSBTs containing P2SH-P2WSH inputs with a missing or
+  incorrect redeem script, preventing transactions with an unknown fee from
+  proceeding to approval.
 - Bugfix: Restore the ability to view the device-generated seed before adding user
   entropy, which was available in the previous dice-roll workflow but was inadvertently
   removed in 5.6.1/1.5.1Q. The new **View TRNG Words** menu item displays the full

--- a/shared/psbt.py
+++ b/shared/psbt.py
@@ -1034,8 +1034,12 @@ class psbtInputProxy(psbtProxy):
                 redeem_script = self.get(ks)
 
             native_v0 = (self.af == AF_P2WSH)
-            if self.witness_script and not native_v0 and not self.redeem_script:
-                raise FatalPSBTIssue('Missing redeem script for input #%d' % my_idx)
+            if self.witness_script and not native_v0:
+                expect = b'\x00\x20' + ngu.hash.sha256s(self.get(self.witness_script))
+                if not self.redeem_script or self.get(self.redeem_script) != expect:
+                    # redeem script is the only proof the UTXO is really segwit;
+                    # without it the input amount (and fee) cannot be verified
+                    raise FatalPSBTIssue('Missing/bad redeem script for input #%d' % my_idx)
 
             if not native_v0 and (len(redeem_script) == 22) and \
                     redeem_script[0] == 0 and redeem_script[1] == 20:

--- a/testing/test_multisig.py
+++ b/testing/test_multisig.py
@@ -1213,7 +1213,28 @@ def test_missing_p2sh_p2wsh_redeem_script_rejected(clear_miniscript, import_ms_w
                        inp_addr_fmt="p2sh-p2wsh", hack_psbt=remove_redeem_script)
     with pytest.raises(CCProtoError) as exc:
         try_sign(psbt, False)
-    assert "Missing redeem script for input #0" in str(exc.value)
+    assert "Missing/bad redeem script for input #0" in str(exc.value)
+
+
+def test_junk_p2sh_p2wsh_redeem_script_rejected(clear_miniscript, import_ms_wallet,
+                                                 fake_ms_txn, try_sign):
+    # present-but-wrong redeem script: input would still be signed as segwit
+    # while its amount (and the fee) cannot be verified - must be rejected
+    clear_miniscript()
+    M, N = 2, 3
+    keys = import_ms_wallet(M, N, addr_fmt="p2sh-p2wsh", accept=True)
+
+    def junk_redeem_script(psbt):
+        # valid shape for a P2WSH wrapper, but not sha256 of the witness script
+        psbt.inputs[0].redeem_script = b'\x00\x20' + b'\x11' * 32
+
+    psbt = fake_ms_txn(1, 1, M, keys, fee=99_000_000,
+                       inp_addr_fmt="p2sh-p2wsh", hack_psbt=junk_redeem_script)
+
+    with pytest.raises(CCProtoError) as exc:
+        try_sign(psbt, False)
+
+    assert "Missing/bad redeem script for input #0" in str(exc.value)
 
 @pytest.mark.veryslow
 @pytest.mark.unfinalized


### PR DESCRIPTION
## Summary

- reject P2SH-P2WSH inputs that omit their redeem script
- keep malformed inputs fail-closed; no redeem script is derived or synthesized
- cover the reported high-fee malformed PSBT with a focused regression test

## Testing

- missing-redeem regression (PSBTv0 and PSBTv2): 2 passed
- sparse and wrapped WIF Store paths (PSBTv0 and PSBTv2): 8 passed
- adjacent witness-UTXO policy tests: 3 passed
- ordinary 1-of-1 multisig signing: 2 passed
- `git diff --check`