### PR TITLE
EDGE: bugfix: reject foreign inputs from BIP322 proofs of reserves

### DIFF
--- a/releases/Next-ChangeLog.md
+++ b/releases/Next-ChangeLog.md
@@ -10,6 +10,8 @@ This lists the new changes that have not yet been published in a normal release.
 - Bugfix: Reject malformed PSBTs containing P2SH-P2WSH inputs with a missing or
   incorrect redeem script, preventing transactions with an unknown fee from
   proceeding to approval.
+- Bugfix: Reject foreign inputs from BIP-322 Proof of Reserves, including inputs
+  disguised with forged key-path metadata or partial signatures.
 - Bugfix: Restore the ability to view the device-generated seed before adding user
   entropy, which was available in the previous dice-roll workflow but was inadvertently
   removed in 5.6.1/1.5.1Q. The new **View TRNG Words** menu item displays the full

--- a/shared/psbt.py
+++ b/shared/psbt.py
@@ -2352,7 +2352,12 @@ class psbtObject(psbtProxy):
                 raise FatalPSBTIssue("i0: invalid BIP-322 'to_spend': not our key")
             if not self.por322_msg_challenge:
                 raise FatalPSBTIssue("Missing BIP-322 message challenge")
-            if any(not self.inputs[i].sp_idxs for i in range(1, self.num_inputs)):
+            if any(not self.inputs[i].sp_idxs or self.inputs[i].fully_signed
+                   for i in range(1, self.num_inputs)):
+                # every POR input past to_spend must be one we will actually sign;
+                # sp_idxs alone is not enough: forged keypaths (incl. zero-xfp
+                # placeholder) plus a partial sig can leave it populated while
+                # making a foreign input look fully signed
                 raise FatalPSBTIssue("Foreign inputs not allowed in BIP-322 Proof of Reserves")
 
         if not my_cnt:

--- a/testing/test_bip322.py
+++ b/testing/test_bip322.py
@@ -3,7 +3,7 @@
 # BIP-322 Message Signing and Proof of Reserves
 # NOTE: Run this module with and without --psbt2 to cover both PSBT versions.
 #
-import pytest, time, os, base64
+import pytest, time, os, base64, struct
 from ckcc_protocol.protocol import CCProtocolPacker
 from io import BytesIO
 from decimal import Decimal
@@ -353,6 +353,25 @@ def test_bip322_incomplete_psbt_bip32_paths(ins, bip322_txn, start_sign, cap_sto
         assert 'PSBT inputs do not contain any key path information.' in story
     else:
         assert "Foreign inputs not allowed in BIP-322 Proof of Reserves" in story
+
+
+def test_bip322_por_presigned_foreign_input(bip322_txn, start_sign, cap_story):
+    # Foreign UTXO (key from a different seed) carrying a forged zero-xfp keypath
+    # - rewritten to our master fingerprint on the fly - plus a partial signature,
+    # so the input looks "ours" and already signed; must still be rejected.
+    foreign_sec = BIP32Node.from_master_secret(b'\x77' * 32).subkey_for_path("0/0").sec()
+
+    def hack(psbt_in):
+        inp = psbt_in.inputs[1]
+        inp.bip32_paths = {foreign_sec: b"\x00" * 4 + struct.pack("<I", 0)}
+        inp.part_sigs[foreign_sec] = b"\x30" + 70 * b"a"
+
+    psbt, _ = bip322_txn([["p2wpkh", None, None], ["p2wpkh", None, 10000000]],
+                         witness_utxo=[1], psbt_hacker=hack)
+    start_sign(psbt)
+    title, story = cap_story()
+    assert title == "Failure"
+    assert "Foreign inputs not allowed in BIP-322 Proof of Reserves" in story
 
 
 def test_bip322_por_input0_bip32_paths_required(bip322_txn, start_sign, cap_story):


### PR DESCRIPTION
## Summary

- reject UTXO-bearing foreign inputs from BIP322 Proof of Reserves transactions
- update the existing missing-key-path coverage to require a hard failure
- document the bugfix in `releases/Next-ChangeLog.md`