### PR TITLE
EDGE: Reject non-ASCII BIP-39 passphrases at entry points

### DIFF
--- a/releases/Next-ChangeLog.md
+++ b/releases/Next-ChangeLog.md
@@ -30,6 +30,9 @@ This lists the new changes that have not yet been published in a normal release.
 - Bugfix: Reject PSBTv2 transactions with an out-of-range transaction version, matching
   the PSBTv0 parser. Previously a v2 PSBT with an invalid `nVersion` could be approved
   and signed, producing a transaction the network will not relay.
+- Bugfix: Reject non-ASCII BIP-39 passphrases (USB, saved-passphrase recall, and
+  note/password lanes) instead of silently deriving a wallet incompatible with
+  BIP-39-normalizing software.
 
 # Mk Specific Changes
 

--- a/shared/seed.py
+++ b/shared/seed.py
@@ -15,6 +15,7 @@ from ucollections import OrderedDict
 from menu import MenuItem, MenuSystem
 from utils import xfp2str, swab32
 from utils import deserialize_secret, problem_file_line, wipe_if_deltamode
+from utils import to_ascii_printable
 from uhashlib import sha256
 from ux import ux_show_story, the_ux, ux_dramatic_pause, ux_confirm, OK, X
 from ux import PressRelease, ux_input_text, show_qr_code, ux_clear_keys
@@ -1010,6 +1011,18 @@ def set_seed_value(words=None, encoded=None, chain=None):
         dis.busy_bar(False)
 
 
+async def validate_bip39_passphrase(pw):
+    try:
+        to_ascii_printable(pw, allow_tab_nl=False)
+    except AssertionError:
+        await ux_show_story(
+            "BIP-39 passphrase must use ASCII characters 32-126 (0x20-0x7e).",
+            title="Failure")
+        return False
+
+    return True
+
+
 async def calc_bip39_passphrase(pw, bypass_tmp=False):
     # Returns (new) encoded secret, new xfp, old xfp
     from glob import dis, settings
@@ -1027,6 +1040,9 @@ async def calc_bip39_passphrase(pw, bypass_tmp=False):
     return nv, xfp, current_xfp
 
 async def set_bip39_passphrase(pw, bypass_tmp=False, summarize_ux=True):
+    if not await validate_bip39_passphrase(pw):
+        return False
+
     nv, xfp, parent_xfp = await calc_bip39_passphrase(pw, bypass_tmp=bypass_tmp)
 
     ret = await set_ephemeral_seed(nv, summarize_ux=summarize_ux, bip39pw=pw,
@@ -1659,6 +1675,9 @@ class PassphraseMenu(MenuSystem):
 async def apply_pass_value(new_pp):
     # Apply provided BIP-39 passphrase to master or current active tmp seed
     # and go to top menu.
+    if not await validate_bip39_passphrase(new_pp):
+        return False
+
     nv, xfp, parent_xfp = await calc_bip39_passphrase(new_pp)
     xfp_str = xfp2str(xfp)
     parent_xfp_str = xfp2str(parent_xfp)

--- a/shared/usb.py
+++ b/shared/usb.py
@@ -12,7 +12,7 @@ from public_constants import (
 )
 from ustruct import pack, unpack_from
 from ckcc import watchpoint, is_simulator
-from utils import problem_file_line, call_later_ms, consteq, hkdf_expand
+from utils import problem_file_line, call_later_ms, consteq, hkdf_expand, to_ascii_printable
 from version import supports_hsm, is_devmode, MAX_TXN_LEN, MAX_UPLOAD_LEN
 from exceptions import FramingError, CCBusyError, HSMDenied, HSMCMDDisabled, SpendPolicyViolation
 from pincodes import pa
@@ -746,10 +746,10 @@ class USBHandler:
             assert self.encrypted_req, 'must encrypt'
             from auth import start_bip39_passphrase
             from glob import settings
-
             assert settings.get("words", True), 'no seed'
             assert len(args) < 400, 'too long'
             pw = str(args, 'utf8')
+            to_ascii_printable(pw, allow_tab_nl=False)
             assert len(pw), 'too short'
             assert len(pw) < 100, 'too long'
 

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -1797,7 +1797,7 @@ def scan_a_qr(sim_exec, is_q1):
         if not is_q1:
             raise pytest.xfail('needs scanner')
         assert isinstance(qr, str)
-        qr = qr.encode('ascii')
+        qr = qr.encode('utf8')
         rv = sim_exec(f'glob.SCAN._q.put_nowait({qr!r})')
         if 'Traceback' in rv: raise pytest.fail(rv)
 

--- a/testing/test_bip39pw.py
+++ b/testing/test_bip39pw.py
@@ -12,6 +12,7 @@ import json
 from mnemonic import Mnemonic
 from constants import simulator_fixed_xfp, simulator_fixed_words, simulator_fixed_tprv
 from helpers import xfp2str
+from charcodes import KEY_QR
 
 # add the BIP39 test vectors
 vectors = json.load(open('bip39-vectors.json'))['english']
@@ -138,7 +139,7 @@ def set_bip39_pw(dev, need_keypress, reset_seed_words, cap_story,
     return doit
 
 
-@pytest.mark.parametrize('pw', [ 
+@pytest.mark.parametrize('pw', [
     'a'*1000,   # way too big
     'a'*100,    # just too big
     ])
@@ -146,6 +147,73 @@ def test_b39_fails(dev, pw):
 
     with pytest.raises(CCProtoError):
         dev.send_recv(CCProtocolPacker.bip39_passphrase(pw), timeout=None)
+
+@pytest.mark.parametrize('pw', [
+    'café',         # NFC form
+    'café',        # NFD form
+    'emoji 🚀 inside',
+    'tab\tinside',
+    'line\nbreak',
+    ])
+def test_b39_non_ascii_or_non_printable_rejected(dev, pw):
+    # non-ASCII and non-printable passphrases are rejected at entry
+    with pytest.raises(CCProtoError) as e:
+        dev.send_recv(CCProtocolPacker.bip39_passphrase(pw), timeout=None)
+    assert 'ascii' in str(e.value)
+
+def test_b39_ascii_still_works(dev, set_bip39_pw, reset_seed_words):
+    # ASCII passphrases (with spaces) are unaffected
+    try:
+        set_bip39_pw('with some spaces')
+    finally:
+        reset_seed_words()
+
+def test_b39_non_ascii_qr_rejected(dev, is_q1, reset_seed_words, go_to_passphrase,
+                                   need_keypress, scan_a_qr, press_select, cap_story,
+                                   cap_menu, cap_screen):
+    if not is_q1:
+        raise pytest.skip("Q only")
+
+    reset_seed_words()
+    before = dev.send_recv(CCProtocolPacker.get_xpub("m"), timeout=None)
+
+    go_to_passphrase()
+    need_keypress(KEY_QR)
+
+    for _ in range(20):
+        if "Scan any QR" in cap_screen():
+            break
+        time.sleep(.1)
+    assert "Scan any QR" in cap_screen()
+
+    scan_a_qr('café 🚀')
+
+    for _ in range(20):
+        if "Your BIP-39 Passphrase" in cap_screen():
+            break
+        time.sleep(.1)
+    assert "Your BIP-39 Passphrase" in cap_screen()
+
+    press_select()
+
+    for _ in range(20):
+        title, story = cap_story()
+        if title == "Failure":
+            break
+        time.sleep(.1)
+
+    assert title == "Failure"
+    assert "ASCII characters 32-126" in story
+    assert dev.send_recv(CCProtocolPacker.get_xpub("m"), timeout=None) == before
+
+    press_select()
+
+    for _ in range(20):
+        menu = cap_menu()
+        if "Passphrase" in menu:
+            break
+        time.sleep(.1)
+    assert "Passphrase" in menu
 
 def test_b39p_refused(dev, press_cancel, pw='testing 123'):
     # user can refuse the passphrase (cancel)

--- a/testing/test_notes.py
+++ b/testing/test_notes.py
@@ -887,6 +887,29 @@ def test_top_import_u_typed_json(goto_notes, cap_menu, cap_story, need_keypress,
     goto_notes()
 
 
+@pytest.mark.parametrize("password", [False, True])
+def test_non_ascii_not_bip39_applicable(goto_notes, cap_menu, settings_set,
+                                        pick_menu_item, password):
+    note = {"title": "demo", "misc": "café" if not password else "x"}
+    if password:
+        note.update(password="café", user="user", site="example.com")
+
+    settings_set('secnap', True)
+    settings_set('notes', [note])
+    goto_notes()
+    pick_menu_item("1: demo")
+
+    expect = "View Password" if password else "View Note"
+    for _ in range(20):
+        menu = cap_menu()
+        if expect in menu:
+            break
+        time.sleep(.1)
+
+    assert expect in menu
+    assert "Apply as BIP-39 Passphrase" not in menu
+
+
 @pytest.mark.parametrize('bkpw', [True, False])
 def test_top_import_wrong_pw(bkpw, goto_notes, cap_menu, cap_story, need_keypress,
                              settings_set, need_some_notes, backup_notes, press_select,

--- a/testing/test_pwsave.py
+++ b/testing/test_pwsave.py
@@ -2,9 +2,11 @@
 #
 # tests for ../shared/pwsave.py
 #
-import pytest, time, os, shutil
+import pytest, time, os, shutil, json
+import pyaes
 from binascii import a2b_hex
-from constants import simulator_fixed_tprv
+from ckcc.protocol import CCProtocolPacker
+from constants import simulator_fixed_tprv, simulator_fixed_xfp
 
 
 @pytest.fixture
@@ -141,6 +143,40 @@ p=PassphraseSaver(); p._calc_key(cs); RV.write(b2a_hex(p.key)); cs.__exit__()'''
     assert isinstance(j, list)
     assert j[0]['pw']
     assert j[0]['xfp']
+
+def test_restore_non_ascii_rejected(dev, sim_exec, simulator_db_file,
+                                    garbage_collector, reset_seed_words,
+                                    go_to_passphrase, pick_menu_item, cap_menu,
+                                    cap_story, press_select):
+    reset_seed_words()
+    before = dev.send_recv(CCProtocolPacker.get_xpub("m"), timeout=None)
+
+    key = sim_exec('''\
+import files; from h import b2a_hex; from pwsave import PassphraseSaver; \
+cs = files.CardSlot().__enter__(); p = PassphraseSaver(); \
+p._calc_key(cs); RV.write(b2a_hex(p.key)); cs.__exit__()''')
+    records = [{"xfp": simulator_fixed_xfp, "pw": "café"}]
+    enc = pyaes.AESModeOfOperationCTR(a2b_hex(key), pyaes.Counter(0)).encrypt(
+        json.dumps(records).encode())
+    with open(simulator_db_file(), "wb") as fd:
+        fd.write(enc)
+    garbage_collector.append(simulator_db_file())
+
+    go_to_passphrase()
+    pick_menu_item("Restore Saved")
+    time.sleep(.2)
+    pick_menu_item(cap_menu()[0])
+    time.sleep(.2)
+    pick_menu_item("Restore")
+    time.sleep(.2)
+    title, story = cap_story()
+    assert title == "Failure"
+    assert "ASCII characters 32-126" in story
+    assert dev.send_recv(CCProtocolPacker.get_xpub("m"), timeout=None) == before
+
+    press_select()
+    time.sleep(.2)
+    assert "Restore" in cap_menu()
 
 def test_delete_one_by_one(go_to_passphrase, pick_menu_item, cap_menu,
                            cap_story, press_select, src_root_dir, sim_root_dir):


### PR DESCRIPTION
Require BIP-39 passphrases to use printable ASCII only (`0x20–0x7e`). Reject Unicode, tabs, and newlines across USB, saved-passphrase, QR, and Notes flows.