### PR TITLE
EDGE: Wipe on duress-secret view/activate in Delta Mode

### DIFF
--- a/releases/Next-ChangeLog.md
+++ b/releases/Next-ChangeLog.md
@@ -33,6 +33,9 @@ This lists the new changes that have not yet been published in a normal release.
 - Bugfix: Reject non-ASCII BIP-39 passphrases (USB, saved-passphrase recall, and
   note/password lanes) instead of silently deriving a wallet incompatible with
   BIP-39-normalizing software.
+- Bugfix: In Delta Mode, wipe the seed if anyone tries to view or activate a duress
+  wallet's secret from the Trick PINs menu, instead of revealing it. Browsing the menu
+  itself still works, so Delta Mode continues to look like normal operation.
 
 # Mk Specific Changes
 

--- a/shared/trick_pins.py
+++ b/shared/trick_pins.py
@@ -803,6 +803,11 @@ so you may perform transactions with it.''')
         b, slot = tp.get_by_pin(pin)
         assert slot
 
+        # loading a duress wallet's secret is a secret-revealing action; in
+        # Delta Mode it would hand the coercer working keys, so wipe instead
+        from utils import wipe_if_deltamode
+        wipe_if_deltamode()
+
         # TC_BLANK_WALLET here would be nice, but no support working w/ fake empty secret
 
         # emulate stash.py encoding
@@ -881,6 +886,11 @@ Wallet is XPRV-based and derived from a fixed path.''' % pin
 
         ch = await ux_show_story(msg + '\n\nPress (6) to view associated secrets.', escape='6')
         if ch != '6': return
+
+        # viewing the duress wallet's seed words/XPRV reveals a live secret;
+        # in Delta Mode it would hand the coercer the keys, so wipe instead
+        from utils import wipe_if_deltamode
+        wipe_if_deltamode()
 
         b, s = tp.get_by_pin(pin)
         if s is None:

--- a/testing/test_se2.py
+++ b/testing/test_se2.py
@@ -936,6 +936,63 @@ def test_deltamode_toggle(get_deltamode, set_deltamode):
     assert get_deltamode() == False
 
 
+def test_deltamode_duress_secret_view_wipes(clear_all_tricks, new_trick_pin,
+        new_pin_confirmed, pick_menu_item, cap_story, need_keypress, press_select,
+        set_deltamode, get_deltamode, sim_exec, goto_trick_menu):
+    # In Delta Mode, browsing the Trick PINs menu is allowed (looks like normal
+    # operation), but attempting to *view* a duress wallet's seed or *activate* it must
+    # wipe the device rather than hand the coercer a live secret.
+    clear_all_tricks()
+
+    new_pin = '11-55'
+    new_trick_pin(new_pin, 'Duress Wallet', 'Goes directly to a specific duress wallet')
+    pick_menu_item('BIP-85 Wallet #1')
+    _, story = cap_story()
+    assert "functional 'duress' wallet" in story
+    press_select()
+    new_pin_confirmed(new_pin, 'BIP-85 Wallet #1', TC_WORD_WALLET, 1001)
+
+    # spy on the wipe (record the call on the fast_wipe referenced by the guard)
+    sim_exec('import callgate\n'
+             'callgate._w=[0]\n'
+             'def _spy(silent=True):\n'
+             '    callgate._w[0]+=1\n'
+             'callgate._fw=callgate.fast_wipe\n'
+             'callgate.fast_wipe=_spy\n'
+             'RV.write("spy ok")')
+    set_deltamode(True)
+    assert get_deltamode() == True
+
+    def wipe_count():
+        return int(sim_exec('import callgate; RV.write(str(callgate._w[0]))'))
+
+    # -- attempt to view the duress seed words via the (6) viewer -> wipe, no secret shown
+    goto_trick_menu()
+    pick_menu_item(f'↳{new_pin}')
+    pick_menu_item('↳Duress Wallet')
+    _, story = cap_story()
+    assert 'Press (6) to view associated' in story
+    need_keypress('6')
+    time.sleep(.5)
+    # the wipe fired (with the real fast_wipe the device reboots before rendering the
+    # secret; the spy only skips the reboot so the test can continue)
+    assert wipe_count() == 1, 'viewing duress secret in delta mode did not wipe'
+
+    # -- attempt to activate the duress wallet -> wipe again, secret never applied
+    goto_trick_menu()
+    pick_menu_item(f'↳{new_pin}')
+    pick_menu_item('Activate Wallet')
+    _, story = cap_story()
+    assert 'This will temporarily load' in story
+    press_select()
+    time.sleep(.5)
+    assert wipe_count() == 2, 'activating duress wallet in delta mode did not wipe'
+
+    # restore real fast_wipe and leave delta mode
+    sim_exec('import callgate; callgate.fast_wipe=callgate._fw')
+    set_deltamode(False)
+
+
 # TODO
 # - make trick and do login, check arrives right state?
 # - out of slots


### PR DESCRIPTION
## Problem

In Delta Mode, the Trick PINs management menu let a coercer (logged in with the delta PIN) reach live duress secrets without any wipe:

- **`duress_details`** (`shared/trick_pins.py:888-911`): "Press (6) to view associated secrets" reads the duress secret from the SE2 slot and renders the **full duress seed words / XPRV** on screen.
- **`activate_wallet`** (`shared/trick_pins.py:798-832`): loads the duress secret as the active temporary seed via `set_ephemeral_seed`.

Every other secret-revealing flow calls `wipe_if_deltamode()` (pwsave, teleport, Seed Vault, XOR restore, BIP-85, backups); these two paths were missed. The **master seed itself is safe** (duress wallets are hardened BIP-32 children), but the duress wallet's funds are exposed and the user's deniability collapses (the menu also enumerates trick-PIN policies).

## Fix

Keep menu browsing working — Delta Mode should look like normal operation, so we do **not** wipe on opening the menu — but call `wipe_if_deltamode()` at the two secret-revealing actions:

- before the (6) viewer reads the slot (`duress_details`)
- before `activate_wallet` applies the secret

Minimal diff: 2 guard calls in `shared/trick_pins.py`.

## Test

- **New** `test_deltamode_duress_secret_view_wipes`: browsing the Trick PINs menu works in delta mode, but viewing the duress secret via (6) and activating the wallet each trigger a wipe (asserted via a `fast_wipe` spy, since a real wipe reboots the sim). **Verified to fail pre-patch** (no wipe) and pass with the fix.
- Broader `test_se2.py` duress/deltamode/trick subset: 38 passed; the one failure (`test_se2_trick_backups`) is **pre-existing** (confirmed failing on unpatched code — unrelated backup-length assertion).

## Changelog

Added a `Next-ChangeLog.md` entry.