### PR TITLE
EDGE: Fix SSSP block height reset DoS

### DIFF
--- a/releases/Next-ChangeLog.md
+++ b/releases/Next-ChangeLog.md
@@ -12,6 +12,8 @@ This lists the new changes that have not yet been published in a normal release.
   proceeding to approval.
 - Bugfix: Reject foreign inputs from BIP-322 Proof of Reserves, including inputs
   disguised with forged key-path metadata or partial signatures.
+- Bugfix: Add a block-height reset to Single-Signer Spending Policy's
+  **Last Violation** screen after policy bypass, matching CCC.
 - Bugfix: Restore the ability to view the device-generated seed before adding user
   entropy, which was available in the previous dice-roll workflow but was inadvertently
   removed in 5.6.1/1.5.1Q. The new **View TRNG Words** menu item displays the full

--- a/shared/ccc.py
+++ b/shared/ccc.py
@@ -366,7 +366,7 @@ def render_mag_value(mag):
         return '%d SATS' % mag
 
 
-class CCCConfigMenu(MenuSystem):
+class PolicyConfigMenuBase(MenuSystem):
     def __init__(self):
         items = self.construct()
         super().__init__(items)
@@ -374,6 +374,38 @@ class CCCConfigMenu(MenuSystem):
     def update_contents(self):
         tmp = self.construct()
         self.replace_items(tmp)
+
+    async def debug_last_fail(self, *a):
+        # debug for customers: why did we reject that last txn?
+        c = chains.current_chain()
+        def_bh = c.ccc_min_block
+        pol = self.policy_feature.get_policy()
+        bh = pol.get('block_h', None)
+        bh_clear = ''
+        msg = ''
+        escape = "4"
+        if bh is not None:
+            msg += '%s:\n\n%s\n\n' % (self.height_label, bh)
+            if bh != def_bh:
+                bh_clear = 'Press (1) to clear block height. '
+                escape += "1"
+
+        lfr = LastFailReason.get()
+        msg += ('The most recent policy check failed because of:\n\n%s\n\n'
+                '%sPress (4) to clear last fail reason.' % (lfr, bh_clear))
+        ch = await ux_show_story(msg, escape=escape)
+
+        if ch == '4':
+            LastFailReason.clear()
+            self.update_contents()
+        elif ch == '1':
+            if await ux_confirm("Reset block height to default value %d for %s?" % (def_bh, c.name)):
+                pol.update_policy_key(_quiet=True, _master_only=False, block_h=def_bh)
+
+
+class CCCConfigMenu(PolicyConfigMenuBase):
+    policy_feature = CCCFeature
+    height_label = 'CCC height'
 
     def construct(self):
         from wallet import MiniScriptWallet, make_miniscript_wallet_menu
@@ -410,35 +442,6 @@ class CCCConfigMenu(MenuSystem):
         items.append(MenuItem('Remove CCC', f=self.remove_ccc))
 
         return items
-
-    async def debug_last_fail(self, *a):
-        # debug for customers: why did we reject that last txn?
-        c = chains.current_chain()
-        def_bh = c.ccc_min_block
-        pol = CCCFeature.get_policy()
-        bh = pol.get('block_h', None)
-        bh_clear = ''
-        msg = ''
-        escape = "4"
-        if bh is not None:
-            msg += 'CCC height:\n\n%s\n\n' % bh
-            if bh != def_bh:
-                bh_clear = 'Press (1) to clear block height. '
-                escape += "1"
-
-        lfr = LastFailReason.get()
-        msg += ('The most recent policy check failed because of:\n\n%s\n\n'
-                '%sPress (4) to clear last fail reason.' % (lfr, bh_clear))
-        ch = await ux_show_story(msg, escape=escape)
-
-        if ch == '4':
-            LastFailReason.clear()
-            self.update_contents()
-        elif ch == '1':
-            if await ux_confirm("Reset block height to default value %d for %s?" % (def_bh, c.name)):
-                pol.update_policy_key(_quiet=True, _master_only=False, block_h=def_bh)
-
-
 
     async def remove_ccc(self, *a):
         # disable and remove feature
@@ -1209,14 +1212,9 @@ class SSSPCheckedMenuItem(MenuItem):
         sssp_spending_policy(self.polkey, set_value=(not was))
 
 
-class SSSPConfigMenu(MenuSystem):
-    def __init__(self):
-        items = self.construct()
-        super().__init__(items)
-
-    def update_contents(self):
-        tmp = self.construct()
-        self.replace_items(tmp)
+class SSSPConfigMenu(PolicyConfigMenuBase):
+    policy_feature = SSSPFeature
+    height_label = 'Last height'
 
     def construct(self):
         items = [
@@ -1277,23 +1275,6 @@ class SSSPConfigMenu(MenuSystem):
 
         pa.hobbled_mode = 2      # Truthy value to indicate they can escape easily
         goto_top_menu()
-
-    async def debug_last_fail(self, *a):
-        # debug for customers: why did we reject that last txn?
-        pol = SSSPFeature.get_policy()
-        bh = pol.get('block_h', None)
-        msg = ''
-        if bh:
-            msg += "Last height:\n\n%s\n\n" % bh
-
-        lfr = LastFailReason.get()
-        msg += 'The most recent policy check failed because of:\n\n%s\n\nPress (4) to clear.' \
-                    % lfr
-        ch = await ux_show_story(msg, escape='4')
-
-        if ch == '4':
-            LastFailReason.clear()
-            self.update_contents()
 
     async def remove_sssp(self, *a):
         # disable and remove feature

--- a/testing/test_sssp.py
+++ b/testing/test_sssp.py
@@ -438,6 +438,72 @@ def test_velocity(velocity_mi, setup_sssp, bitcoind, settings_set, pick_menu_ite
     )
 
 
+def test_reset_poisoned_block_height(setup_sssp, settings_set, settings_get,
+                                     pick_menu_item, press_select, start_sign,
+                                     end_sign, fake_txn, cap_story,
+                                     get_last_violation, goto_home, cap_menu,
+                                     press_cancel, sim_exec, goto_sssp_menu,
+                                     need_keypress):
+    settings_set("chain", "XRT")
+    setup_sssp("11-11", mag=2, vel='6 blocks (hour)')
+    pick_menu_item("ACTIVATE")
+    press_select()
+
+    poisoned_h = 499_913_672
+    poisoned = fake_txn(2, 2, input_amount=1_000_000, lock_time=poisoned_h)
+    start_sign(poisoned)
+    time.sleep(.1)
+    title, _ = cap_story()
+    assert title == 'OK TO SEND?'
+    assert end_sign()
+    assert settings_get("sssp")["pol"]["block_h"] == poisoned_h
+
+    normal_h = 100
+    normal = fake_txn(2, 2, input_amount=1_000_000, lock_time=normal_h)
+    start_sign(normal)
+    time.sleep(.1)
+    title, story = cap_story()
+    assert title == "Failure"
+    assert "Spending Policy violation." in story
+    assert get_last_violation() == "rewound (%d)" % normal_h
+    press_select()
+
+    goto_home()
+    assert "Settings" not in cap_menu()
+    pick_menu_item("Advanced/Tools")
+    assert "Spending Policy" not in cap_menu()
+    press_cancel()
+
+    rv = sim_exec("from pincodes import pa; from ccc import sssp_spending_policy; "
+                  "from actions import goto_top_menu; pa.hobbled_mode = False; "
+                  "sssp_spending_policy('en', set_value=False); goto_top_menu()")
+    assert 'Traceback' not in rv
+
+    goto_sssp_menu()
+    pick_menu_item("Last Violation")
+    time.sleep(.1)
+    _, story = cap_story()
+    assert "Last height:\n\n%d" % poisoned_h in story
+    assert "Press (1) to clear block height" in story
+    need_keypress("1")
+    time.sleep(.1)
+    _, story = cap_story()
+    assert "Reset block height to default value 0 for Bitcoin Regtest?" in story
+    press_select()
+    time.sleep(.1)
+    assert settings_get("sssp")["pol"]["block_h"] == 0
+
+    goto_sssp_menu()
+    pick_menu_item("ACTIVATE")
+    press_select()
+    start_sign(normal)
+    time.sleep(.1)
+    title, _ = cap_story()
+    assert title == 'OK TO SEND?'
+    assert end_sign()
+    assert settings_get("sssp")["pol"]["block_h"] == normal_h
+
+
 @pytest.mark.bitcoind
 @pytest.mark.parametrize("active", [True, False])
 def test_warnings(setup_sssp, bitcoind, settings_set, policy_sign, pick_menu_item,


### PR DESCRIPTION
An approved SSSP PSBT can persist an arbitrarily large height-like nLockTime in `block_h`, causing later legitimate transactions to fail with rewound or velocity violations.

Add the block-height recovery action already available in CCC's Last Violation screen. The reset remains behind SSSP's existing non-hobbled configuration gate: the bypass PIN and, when enabled, the first/last seed-word challenge. This closes the recovery asymmetry between CCC and SSSP.

Tested on the Mk5 and Q1 simulators.