### PR TITLE
EDGE: bugfix: bound firmware to world checksum

### DIFF
--- a/cli/signit.py
+++ b/cli/signit.py
@@ -329,7 +329,7 @@ def doit(keydir, outfn=None, build_dir=None, high_water=False,
     else:
         # new value for Mk4 and later: limited only by final binary size, not SPI flash
         assert FW_MIN_LENGTH <= hdr.firmware_length <= FW_MAX_LENGTH_MK4, hdr.firmware_length
-        USB_MAX_LEN = 1472 * 1024
+        USB_MAX_LEN = FW_MAX_LENGTH_MK4
 
     assert hdr.firmware_length <= USB_MAX_LEN, \
         "too big for our USB upgrades: %d = %d bytes too big" % (

--- a/releases/Next-ChangeLog.md
+++ b/releases/Next-ChangeLog.md
@@ -36,6 +36,8 @@ This lists the new changes that have not yet been published in a normal release.
 - Bugfix: In Delta Mode, wipe the seed if anyone tries to view or activate a duress
   wallet's secret from the Trick PINs menu, instead of revealing it. Browsing the menu
   itself still works, so Delta Mode continues to look like normal operation.
+- Bugfix: Reject firmware images that extend past the world-checksum-covered
+  flash region.
 
 # Mk Specific Changes
 

--- a/shared/actions.py
+++ b/shared/actions.py
@@ -211,7 +211,7 @@ async def microsd_upgrade(menu, label, item):
     from glob import dis, PSRAM
     from files import dfu_parse
     from utils import check_firmware_hdr
-    from sigheader import FW_HEADER_OFFSET, FW_HEADER_SIZE, FW_MAX_LENGTH_MK4
+    from sigheader import FW_HEADER_OFFSET, FW_HEADER_SIZE, FW_MAX_DFU_SIZE_MK4
 
     if version.has_battery:
         import battery
@@ -222,7 +222,7 @@ async def microsd_upgrade(menu, label, item):
             return
 
     force_vdisk = item.arg
-    fn = await file_picker(suffix='.dfu', min_size=0x7800, max_size=FW_MAX_LENGTH_MK4,
+    fn = await file_picker(suffix='.dfu', min_size=0x7800, max_size=FW_MAX_DFU_SIZE_MK4,
                            force_vdisk=force_vdisk)
 
     if not fn: return

--- a/stm32/sigheader.h
+++ b/stm32/sigheader.h
@@ -49,9 +49,13 @@ typedef struct {
 // - but practical limit for our-protocol USB upgrades: 786432 (or else settings damaged)
 #define FW_MAX_LENGTH        (0x100000 - 0x8000)
 
-// Mk4/Q1: 2MB less 128k bootrom and 512k LFS2.
-// Leave one 512-byte block for the DFU wrapper.
-#define FW_MAX_LENGTH_MK4        (0x200000 - 0x20000 - 0x80000 - 512)
+// Mk4/Q1: 2MB less 128k bootrom and 512k LFS2, so firmware stays
+// inside the world-checksum-covered flash region. 4k aligned.
+#define FW_MAX_LENGTH_MK4        (0x200000 - 0x20000 - 0x80000)
+
+// Max .dfu file size for the MicroSD file picker: above limit, plus the
+// bootloader element (BL_FLASH_SIZE) and DFU wrapper of a -factory.dfu image.
+#define FW_MAX_DFU_SIZE_MK4      (FW_MAX_LENGTH_MK4 + 0x1c000 + 0x400)
 
 // Arguments to be used w/ python's struct module.
 #define FWH_PY_FORMAT      "<I8s8sIIII8s20s64s"

--- a/stm32/sigheader.h
+++ b/stm32/sigheader.h
@@ -49,8 +49,9 @@ typedef struct {
 // - but practical limit for our-protocol USB upgrades: 786432 (or else settings damaged)
 #define FW_MAX_LENGTH        (0x100000 - 0x8000)
 
-// .. for Mk4: 2Mbytes, less bootrom of 128k.
-#define FW_MAX_LENGTH_MK4        (0x200000 - 0x20000)
+// Mk4/Q1: 2MB less 128k bootrom and 512k LFS2.
+// Leave one 512-byte block for the DFU wrapper.
+#define FW_MAX_LENGTH_MK4        (0x200000 - 0x20000 - 0x80000 - 512)
 
 // Arguments to be used w/ python's struct module.
 #define FWH_PY_FORMAT      "<I8s8sIIII8s20s64s"

--- a/stm32/sigheader.py
+++ b/stm32/sigheader.py
@@ -33,8 +33,9 @@ FW_MIN_LENGTH = (256*1024)
 # - but practical limit for our-protocol USB upgrades: 786432 (or else settings damaged)
 FW_MAX_LENGTH = (0x100000 - 0x8000)
 
-# .. for Mk4: 2Mbytes, less bootrom of 128k.
-FW_MAX_LENGTH_MK4 = (0x200000 - 0x20000)
+# Mk4/Q1: 2MB less 128k bootrom and 512k LFS2.
+# Leave one 512-byte block for the DFU wrapper.
+FW_MAX_LENGTH_MK4 = (0x200000 - 0x20000 - 0x80000 - 512)
 
 # Arguments to be used w/ python's struct module.
 FWH_PY_FORMAT = "<I8s8sIIII8s20s64s"

--- a/stm32/sigheader.py
+++ b/stm32/sigheader.py
@@ -33,9 +33,13 @@ FW_MIN_LENGTH = (256*1024)
 # - but practical limit for our-protocol USB upgrades: 786432 (or else settings damaged)
 FW_MAX_LENGTH = (0x100000 - 0x8000)
 
-# Mk4/Q1: 2MB less 128k bootrom and 512k LFS2.
-# Leave one 512-byte block for the DFU wrapper.
-FW_MAX_LENGTH_MK4 = (0x200000 - 0x20000 - 0x80000 - 512)
+# Mk4/Q1: 2MB less 128k bootrom and 512k LFS2, so firmware stays
+# inside the world-checksum-covered flash region. 4k aligned.
+FW_MAX_LENGTH_MK4 = (0x200000 - 0x20000 - 0x80000)
+
+# Max .dfu file size for the MicroSD file picker: above limit, plus the
+# bootloader element (BL_FLASH_SIZE) and DFU wrapper of a -factory.dfu image.
+FW_MAX_DFU_SIZE_MK4 = (FW_MAX_LENGTH_MK4 + 0x1c000 + 0x400)
 
 # Arguments to be used w/ python's struct module.
 FWH_PY_FORMAT = "<I8s8sIIII8s20s64s"


### PR DESCRIPTION
Reject firmware past the world-checksum-covered flash boundary and align the signing limit.

Tested: Mk4 and Q1 verifier builds.