### PR TITLE
Fix uncaught AttributeError on non-object JSON in parse_msg_sign_request

### DIFF
--- a/releases/Next-ChangeLog.md
+++ b/releases/Next-ChangeLog.md
@@ -7,6 +7,9 @@ your addition and anything else already in this file.**
 
 # Shared Improvements - Both Mk and Q
 
+- Bugfix: Fix device crash when message-signing input is valid JSON but not an
+  object (NFC / QR / SD `.json` file). Thanks to [@Amiga500](https://github.com/Amiga500).
+
 - tbd
 
 

--- a/shared/msgsign.py
+++ b/shared/msgsign.py
@@ -312,6 +312,9 @@ def parse_msg_sign_request(data):
 
     try:
         data_dict = ujson.loads(data.strip())
+        if not isinstance(data_dict, dict):
+            # valid JSON, but not an object (e.g. 123, "str", null, [1,2])
+            raise ValueError("not a JSON object")
         text = data_dict.get("msg", None)
         if text is None:
             raise AssertionError("MSG required")

--- a/shared/msgsign.py
+++ b/shared/msgsign.py
@@ -314,7 +314,7 @@ def parse_msg_sign_request(data):
         data_dict = ujson.loads(data.strip())
         if not isinstance(data_dict, dict):
             # valid JSON, but not an object (e.g. 123, "str", null, [1,2])
-            raise ValueError("not a JSON object")
+            raise ValueError
         text = data_dict.get("msg", None)
         if text is None:
             raise AssertionError("MSG required")

--- a/testing/test_msg.py
+++ b/testing/test_msg.py
@@ -1133,4 +1133,36 @@ def test_verify_scanned_signed_msg(msg, scan_a_qr, need_keypress, goto_home, cap
     assert "Good signature by address" in story
     assert addr == addr_from_display_format(story.split("\n")[-1])
 
+
+@pytest.mark.parametrize('body,fail', [
+    ('123', False),  # valid JSON, int
+    ('"hello"', False),  # valid JSON, string
+    ('null', False),  # valid JSON, null
+    ('[1,2]', False),  # valid JSON, list
+    # all above treated as just message
+    ('{"nomsg": 1}', True),  # object but missing "msg" key
+])
+def test_sign_msg_json_not_object(body, fail, open_microsd, microsd_path, goto_home,
+                                  pick_menu_item, cap_story):
+
+    # valid JSON that is not an object (or lacks "msg") must produce a clean
+    # failure story, never a crash (yikes)
+    fname = 't-msgsign-bad.json'
+    with open_microsd(fname, 'wt') as sd:
+        sd.write(body)
+
+    goto_home()
+    pick_menu_item('Advanced/Tools')
+    pick_menu_item('File Management')
+    pick_menu_item('Sign Text File')
+    time.sleep(.1)
+    pick_menu_item(fname)
+    time.sleep(.1)
+    title, story = cap_story()
+    if fail:
+        assert not story.startswith('Ok to sign this?')
+        assert 'MSG required' in story or 'must be ascii' in story or 'too short' in story
+    else:
+        assert story.startswith('Ok to sign this?')
+
 # EOF


### PR DESCRIPTION
parse_msg_sign_request() assumed any JSON-parseable input is a dict. Input of 123, "str", null, or [1,2] parses fine but .get() raises AttributeError, which escapes the except ValueError fallback and propagates past approve_msg_sign (catches only AssertionError, ValueError) to the fatal handler → device crash via NFC / QR / SD .json file.

Fix: raise ValueError for non-dict JSON so it falls through to the existing line-based parsing path.

data_dict = ujson.loads(data.strip())
if not isinstance(data_dict, dict):
    # valid JSON, but not an object (e.g. 123, "str", null, [1,2])
    raise ValueError("not a JSON object")
text = data_dict.get("msg", None)

Behavior for valid JSON objects, dict-without-msg, and plain-text inputs is unchanged.
