### PR TITLE
Fix descriptor checksum bypass: reject descriptors with multiple '#' …

### DIFF
--- a/releases/Next-ChangeLog.md
+++ b/releases/Next-ChangeLog.md
@@ -7,6 +7,9 @@ your addition and anything else already in this file.**
 
 # Shared Improvements - Both Mk and Q
 
+- Bugfix: Reject descriptors with multiple `#` characters, which silently bypassed
+  checksum verification on import. Thanks to [@Amiga500](https://github.com/Amiga500).
+
 - tbd
 
 

--- a/shared/descriptor.py
+++ b/shared/descriptor.py
@@ -142,11 +142,14 @@ class Descriptor:
     @staticmethod
     def checksum_check(desc_w_checksum , csum_required=False):
         try:
-            desc, checksum = desc_w_checksum.split("#")
+            desc, checksum = desc_w_checksum.split("#", 1)
         except ValueError:
             if csum_required:
                 raise ValueError("Missing descriptor checksum")
             return desc_w_checksum, None
+        if "#" in checksum:
+            # never allow multiple '#' to bypass checksum verification
+            raise ValueError("Too many '#' in descriptor")
         calc_checksum = descriptor_checksum(desc)
         if calc_checksum != checksum:
             raise WrongCheckSumError("Wrong checksum %s, expected %s" % (checksum, calc_checksum))


### PR DESCRIPTION
checksum_check() used split("#") without maxsplit: two or more # → ValueError("too many values to unpack") → swallowed by the same handler as "no checksum present" → raw input returned unverified under csum_required=False.

Fix: split("#", 1) + reject any # remaining in the checksum portion.

desc, checksum = desc_w_checksum.split("#", 1)
...
if "#" in checksum:
    # never allow multiple '#' to bypass checksum verification
    raise ValueError("Too many '#' in descriptor")

Well-formed inputs (no checksum, or exactly one # with valid checksum) are unchanged; desc#checksum#junk now raises instead of bypassing.