### PR TITLE
EDGE: PSBTv2 per input required lock time calculation

### DIFF
--- a/releases/Next-ChangeLog.md
+++ b/releases/Next-ChangeLog.md
@@ -4,6 +4,8 @@ This lists the new changes that have not yet been published in a normal release.
 
 # Shared Improvements - Both Mk and Q
 
+- Enhancement: Support per-input required height and time locktimes in PSBTv2 transactions.
+
 - New Feature: Added USB ncry v3 authenticated encryption with direction-separated keys and replay protection
 - Enhancement: Warn when a transaction's block-height `nLockTime` is more than
   ten years beyond the Bitcoin block height known to the firmware.

--- a/shared/psbt.py
+++ b/shared/psbt.py
@@ -700,7 +700,7 @@ class psbtInputProxy(psbtProxy):
         'unknown', 'witness_utxo', 'sighash', 'redeem_script', 'witness_script', 'sp_idxs',
         'fully_signed', 'af', 'is_miniscript', "subpaths", 'utxo', 'utxo_spk',
         'amount', 'previous_txid', 'part_sigs', 'added_sigs',  'prevout_idx', 'sequence',
-        'req_time_locktime', 'req_height_locktime',
+        'req_time', 'req_height',
         'taproot_merkle_root', 'taproot_script_sigs', 'taproot_scripts',
         'taproot_subpaths', 'taproot_internal_key', 'taproot_key_sig', 'tr_added_sigs',
         'ik_idx', 'musig_pubkeys', 'musig_pubnonces', 'musig_part_sigs', 'musig_agg_idx',
@@ -744,8 +744,8 @@ class psbtInputProxy(psbtProxy):
         #self.previous_txid = None
         #self.prevout_idx = None
         #self.sequence = None
-        #self.req_time_locktime = None
-        #self.req_height_locktime = None
+        #self.req_time = None
+        #self.req_height = None
 
         # === musig ===
         #self.musig_pubkeys = None
@@ -1266,9 +1266,9 @@ class psbtInputProxy(psbtProxy):
         elif kt == PSBT_IN_SEQUENCE:
             self.sequence = unpack("<I", self.get(val))[0]
         elif kt == PSBT_IN_REQUIRED_TIME_LOCKTIME:
-            self.req_time_locktime = unpack("<I", self.get(val))[0]
+            self.req_time = unpack("<I", self.get(val))[0]
         elif kt == PSBT_IN_REQUIRED_HEIGHT_LOCKTIME:
-            self.req_height_locktime = unpack("<I", self.get(val))[0]
+            self.req_height = unpack("<I", self.get(val))[0]
         elif kt == PSBT_IN_MUSIG2_PARTICIPANT_PUBKEYS:
             self.musig_pubkeys = self.musig_pubkeys or []
             self.musig_pubkeys.append((key, val))
@@ -1369,11 +1369,11 @@ class psbtInputProxy(psbtProxy):
             if self.sequence is not None:
                 wr(PSBT_IN_SEQUENCE, pack("<I", self.sequence))
 
-            if self.req_time_locktime is not None:
-                wr(PSBT_IN_REQUIRED_TIME_LOCKTIME, pack("<I", self.req_time_locktime))
+            if self.req_time is not None:
+                wr(PSBT_IN_REQUIRED_TIME_LOCKTIME, pack("<I", self.req_time))
 
-            if self.req_height_locktime is not None:
-                wr(PSBT_IN_REQUIRED_HEIGHT_LOCKTIME, pack("<I", self.req_height_locktime))
+            if self.req_height is not None:
+                wr(PSBT_IN_REQUIRED_HEIGHT_LOCKTIME, pack("<I", self.req_height))
 
         if self.unknown:
             for k, v in self.unknown:
@@ -1843,6 +1843,12 @@ class psbtObject(psbtProxy):
 
         self.validate_unkonwn(self, "global namespace")
 
+        # BIP-370 tx-level locktime, derived from per-input required locktimes
+        lt_required = False
+        height_possible = True
+        time_possible = True
+        max_height = 0
+        max_time = 0
         inp_have_subpath = False
         for i in self.inputs:
             if i.subpaths or i.taproot_subpaths:
@@ -1852,17 +1858,28 @@ class psbtObject(psbtProxy):
                 # v2 requires inclusion
                 assert i.prevout_idx is not None
                 assert i.previous_txid
-                if i.req_time_locktime is not None:
-                    assert i.req_time_locktime >= NLOCK_IS_TIME
-                if i.req_height_locktime is not None:
-                    assert 0 < i.req_height_locktime < NLOCK_IS_TIME
+                if i.req_time is not None:
+                    assert i.req_time >= NLOCK_IS_TIME
+                if i.req_height is not None:
+                    assert 0 < i.req_height < NLOCK_IS_TIME
+
+                if i.req_time is not None or i.req_height is not None:
+                    lt_required = True
+                    if i.req_height is None:
+                        height_possible = False
+                    elif i.req_height > max_height:
+                        max_height = i.req_height
+                    if i.req_time is None:
+                        time_possible = False
+                    elif i.req_time > max_time:
+                        max_time = i.req_time
             else:
                 # v0 requires exclusion
                 assert i.prevout_idx is None
                 assert i.previous_txid is None
                 assert i.sequence is None
-                assert i.req_time_locktime is None
-                assert i.req_height_locktime is None
+                assert i.req_time is None
+                assert i.req_height is None
 
             if i.witness_script:
                 assert i.witness_script[1] >= 30
@@ -1915,6 +1932,13 @@ class psbtObject(psbtProxy):
 
 
             self.validate_unkonwn(i, "input")
+
+        if lt_required:
+            assert height_possible or time_possible, "incompatible locktime requirements"
+            # v2 only: _lock_time normally comes from the unsigned tx (v0);
+            # here it is computed from per-input required locktimes and so
+            # always wins over the global fallback locktime (BIP-370)
+            self._lock_time = max_height if height_possible else max_time
 
         null_data_op_return = False
         for o in self.outputs:

--- a/testing/psbt.py
+++ b/testing/psbt.py
@@ -137,8 +137,8 @@ class BasicPSBTInput(PSBTSection):
         self.previous_txid = None        # v2
         self.prevout_idx = None          # v2
         self.sequence = None             # v2
-        self.req_time_locktime = None    # v2
-        self.req_height_locktime = None  # v2
+        self.req_time = None    # v2
+        self.req_height = None  # v2
         self.musig_pubkeys = {}
         self.musig_pubnonces = {}
         self.musig_part_sigs = {}
@@ -167,8 +167,8 @@ class BasicPSBTInput(PSBTSection):
              a.previous_txid == b.previous_txid and \
              a.prevout_idx == b.prevout_idx and \
              a.sequence == b.sequence and \
-             a.req_time_locktime == b.req_time_locktime and \
-             a.req_height_locktime == b.req_height_locktime and \
+             a.req_time == b.req_time and \
+             a.req_height == b.req_height and \
              a.musig_pubkeys == b.musig_pubkeys and \
              a.musig_pubnonces == b.musig_pubnonces and \
              a.musig_part_sigs == b.musig_part_sigs and \
@@ -219,9 +219,9 @@ class BasicPSBTInput(PSBTSection):
         elif kt == PSBT_IN_SEQUENCE:
             self.sequence = struct.unpack("<I", val)[0]
         elif kt == PSBT_IN_REQUIRED_TIME_LOCKTIME:
-            self.req_time_locktime = struct.unpack("<I", val)[0]
+            self.req_time = struct.unpack("<I", val)[0]
         elif kt == PSBT_IN_REQUIRED_HEIGHT_LOCKTIME:
-            self.req_height_locktime = struct.unpack("<I", val)[0]
+            self.req_height = struct.unpack("<I", val)[0]
         elif kt == PSBT_IN_TAP_SCRIPT_SIG:
             assert len(key) == 64, "PSBT_IN_TAP_SCRIPT_SIG key length != 64"
             assert len(val) in (64, 65), "PSBT_IN_TAP_SCRIPT_SIG signature length != 64 or 65"
@@ -311,10 +311,10 @@ class BasicPSBTInput(PSBTSection):
                 wr(PSBT_IN_OUTPUT_INDEX, struct.pack("<I", self.prevout_idx))
             if self.sequence is not None:
                 wr(PSBT_IN_SEQUENCE, struct.pack("<I", self.sequence))
-            if self.req_time_locktime is not None:
-                wr(PSBT_IN_REQUIRED_TIME_LOCKTIME, struct.pack("<I", self.req_time_locktime))
-            if self.req_height_locktime is not None:
-                wr(PSBT_IN_REQUIRED_HEIGHT_LOCKTIME, struct.pack("<I", self.req_height_locktime))
+            if self.req_time is not None:
+                wr(PSBT_IN_REQUIRED_TIME_LOCKTIME, struct.pack("<I", self.req_time))
+            if self.req_height is not None:
+                wr(PSBT_IN_REQUIRED_HEIGHT_LOCKTIME, struct.pack("<I", self.req_height))
 
         if self.musig_pubkeys:
             for agg_k, pk_lst in self.musig_pubkeys.items():
@@ -706,8 +706,8 @@ class BasicPSBT:
                 inp.prevout_idx = None
                 inp.previous_txid = None
                 inp.sequence = None
-                inp.req_time_locktime = None
-                inp.req_height_locktime = None
+                inp.req_time = None
+                inp.req_height = None
 
             tx_outs = []
             for out in self.outputs:

--- a/testing/test_multisig.py
+++ b/testing/test_multisig.py
@@ -1125,8 +1125,8 @@ def fake_ms_txn(pytestconfig):
                 psbt.inputs[i].previous_txid = supply.hash
                 psbt.inputs[i].prevout_idx = 0
                 psbt.inputs[i].sequence = seq
-                # psbt.inputs[i].req_time_locktime = None
-                # psbt.inputs[i].req_height_locktime = None
+                # psbt.inputs[i].req_time = None
+                # psbt.inputs[i].req_height = None
 
             spendable = CTxIn(COutPoint(supply.sha256, 0), nSequence=seq)
             txn.vin.append(spendable)

--- a/testing/test_sign.py
+++ b/testing/test_sign.py
@@ -3147,6 +3147,151 @@ def test_far_future_locktime_warning(
     end_sign(accept=False)
 
 
+@pytest.mark.parametrize("is_multi", [False, True])
+@pytest.mark.parametrize("lock_field, lock_value", [
+    ("req_height", 800000),
+    ("req_time", 1513209600),
+])
+def test_psbt_v2_required_locktime_fields_sign(is_multi, lock_field, lock_value,
+                                               fake_txn, fake_ms_txn, import_ms_wallet,
+                                               clear_miniscript, start_sign, end_sign,
+                                               cap_story):
+    def add_required_locktime(psbt):
+        psbt.inputs[0].sequence = 0xfffffffd
+        setattr(psbt.inputs[0], lock_field, lock_value)
+
+    if not is_multi:
+        psbt = fake_txn(1, 1, addr_fmt="p2wpkh", psbt_v2=True,
+                        psbt_hacker=add_required_locktime)
+    else:
+        clear_miniscript()
+        M = 2
+        N = 3
+        keys = import_ms_wallet(M, N, accept=True)
+        psbt = fake_ms_txn(1, 1, M, keys, psbt_v2=True,
+                           hack_psbt=add_required_locktime)
+
+    start_sign(psbt, finalize=not is_multi)
+    title, story = cap_story()
+    assert title == "OK TO SEND?"
+    assert "TX LOCKTIMES" in story
+    assert "Abs Locktime" in story
+
+    signed = end_sign(accept=True, finalize=not is_multi)
+    if not is_multi:
+        tx = CTransaction()
+        tx.deserialize(BytesIO(signed))
+        assert tx.nLockTime == lock_value
+        assert tx.vin[0].nSequence == 0xfffffffd
+
+
+def test_psbt_v2_required_locktime_taproot(fake_txn, start_sign, end_sign):
+    required = 800000
+
+    def hack(psbt):
+        psbt.inputs[0].sequence = 0xfffffffd
+        psbt.inputs[0].req_height = required
+
+    psbt = fake_txn(1, 1, addr_fmt="p2tr", psbt_v2=True, psbt_hacker=hack)
+    start_sign(psbt, finalize=True)
+    signed = end_sign(accept=True, finalize=True)
+    tx = CTransaction()
+    tx.deserialize(BytesIO(signed))
+    assert tx.nLockTime == required
+
+
+@pytest.mark.parametrize("lock_field, values", [
+    ("req_height", [700000, 800000, 750000]),
+    ("req_time", [1600000000, 1700000000, 1650000000]),
+])
+def test_psbt_v2_required_locktime_max(lock_field, values, fake_txn, start_sign,
+                                       end_sign):
+    def hack(psbt):
+        for i, value in enumerate(values):
+            psbt.inputs[i].sequence = 0xfffffffd
+            setattr(psbt.inputs[i], lock_field, value)
+
+        # The final input intentionally has no required locktime.
+
+    psbt = fake_txn(len(values) + 1, 1, addr_fmt="p2wpkh", psbt_v2=True,
+                    psbt_hacker=hack)
+    start_sign(psbt, finalize=True)
+    signed = end_sign(accept=True, finalize=True)
+    tx = CTransaction()
+    tx.deserialize(BytesIO(signed))
+    assert tx.nLockTime == max(values)
+
+
+def test_psbt_v2_required_locktime_both_prefers_height(fake_txn, start_sign,
+                                                       end_sign):
+    heights = [810000, 830000]
+    times = [1700000000, 1690000000]
+
+    def hack(psbt):
+        for i in range(len(heights)):
+            psbt.inputs[i].sequence = 0xfffffffd
+            psbt.inputs[i].req_height = heights[i]
+            psbt.inputs[i].req_time = times[i]
+
+    psbt = fake_txn(len(heights), 1, addr_fmt="p2wpkh", psbt_v2=True,
+                    psbt_hacker=hack)
+    start_sign(psbt, finalize=True)
+    signed = end_sign(accept=True, finalize=True)
+    tx = CTransaction()
+    tx.deserialize(BytesIO(signed))
+    assert tx.nLockTime == max(heights)
+
+
+def test_psbt_v2_required_locktime_incompatible(fake_txn, start_sign, cap_story,
+                                                press_cancel):
+    def hack(psbt):
+        psbt.inputs[0].sequence = 0xfffffffd
+        psbt.inputs[0].req_height = 800000
+        psbt.inputs[1].sequence = 0xfffffffd
+        psbt.inputs[1].req_time = 1700000000
+
+    psbt = fake_txn(2, 1, addr_fmt="p2wpkh", psbt_v2=True, psbt_hacker=hack)
+    start_sign(psbt, finalize=True)
+    time.sleep(.1)
+    title, story = cap_story()
+    assert title == "Failure"
+    assert "incompatible locktime requirements" in story
+    press_cancel()
+
+
+def test_psbt_v2_fallback_locktime(fake_txn, start_sign, end_sign):
+    fallback = 750000
+
+    def hack(psbt):
+        psbt.inputs[0].sequence = 0xfffffffd
+        psbt.fallback_locktime = fallback
+
+    psbt = fake_txn(1, 1, addr_fmt="p2wpkh", psbt_v2=True, psbt_hacker=hack)
+    start_sign(psbt, finalize=True)
+    signed = end_sign(accept=True, finalize=True)
+    tx = CTransaction()
+    tx.deserialize(BytesIO(signed))
+    assert tx.nLockTime == fallback
+
+
+def test_psbt_v2_required_locktime_overrides_fallback(fake_txn, start_sign,
+                                                      end_sign):
+    fallback = 750000
+    required = 800000
+
+    def hack(psbt):
+        psbt.inputs[0].sequence = 0xfffffffd
+        psbt.inputs[0].req_height = required
+        psbt.fallback_locktime = fallback
+
+    psbt = fake_txn(1, 1, addr_fmt="p2wpkh", psbt_v2=True, psbt_hacker=hack)
+    start_sign(psbt, finalize=True)
+    signed = end_sign(accept=True, finalize=True)
+    tx = CTransaction()
+    tx.deserialize(BytesIO(signed))
+    assert tx.nLockTime == required
+
+
 def test_relative_locktime_summary_is_bounded(fake_txn, start_sign, cap_story, press_cancel):
     num_each = 125
     max_lock = num_each

--- a/testing/txn.py
+++ b/testing/txn.py
@@ -193,8 +193,8 @@ def fake_txn(dev, pytestconfig):
                     psbt.inputs[i].previous_txid = supply.hash
                     psbt.inputs[i].prevout_idx = 0
                     psbt.inputs[i].sequence = seq
-                    # psbt.inputs[i].req_time_locktime = None
-                    # psbt.inputs[i].req_height_locktime = None
+                    # psbt.inputs[i].req_time = None
+                    # psbt.inputs[i].req_height = None
             else:
                 assert i != 0, 'cant dup first input'
                 txn.vin.append(txn.vin[-1])


### PR DESCRIPTION
Derives the PSBTv2 transaction locktime from per-input required height/time locktimes per BIP-370. Covers maximum selection, incompatible requirements, height preference, and fallback behavior.