### PR TITLE
Harden PSBTv2 parsing

### DIFF
--- a/releases/Next-ChangeLog.md
+++ b/releases/Next-ChangeLog.md
@@ -12,6 +12,10 @@ your addition and anything else already in this file.**
 
 - Enhancement: Support per-input required height and time locktimes in PSBTv2 transactions.
 
+- Bugfix: Harden PSBTv2 parsing by rejecting key data on singleton fields,
+  malformed global input/output count encodings, and files missing the required
+  global version.
+
 
 # Mk Specific Changes
 
@@ -25,4 +29,3 @@ your addition and anything else already in this file.**
 ## 1.5.3Q - 2026-09-xx
 
 - tbd
-

--- a/shared/psbt.py
+++ b/shared/psbt.py
@@ -344,7 +344,8 @@ class psbtProxy:
 # Track details of each output of PSBT
 #
 class psbtOutputProxy(psbtProxy):
-    no_keys = { PSBT_OUT_REDEEM_SCRIPT, PSBT_OUT_WITNESS_SCRIPT }
+    no_keys = { PSBT_OUT_REDEEM_SCRIPT, PSBT_OUT_WITNESS_SCRIPT, PSBT_OUT_AMOUNT,
+                PSBT_OUT_SCRIPT }
 
     blank_flds = ('unknown', 'subpaths', 'redeem_script', 'witness_script',
                   'is_change', 'num_our_keys', 'amount', 'script', 'attestation')
@@ -592,8 +593,10 @@ class psbtInputProxy(psbtProxy):
 
     # only part-sigs have a key to be stored.
     no_keys = { PSBT_IN_NON_WITNESS_UTXO, PSBT_IN_WITNESS_UTXO, PSBT_IN_SIGHASH_TYPE,
-                     PSBT_IN_REDEEM_SCRIPT, PSBT_IN_WITNESS_SCRIPT, PSBT_IN_FINAL_SCRIPTSIG,
-                     PSBT_IN_FINAL_SCRIPTWITNESS }
+                PSBT_IN_REDEEM_SCRIPT, PSBT_IN_WITNESS_SCRIPT, PSBT_IN_FINAL_SCRIPTSIG,
+                PSBT_IN_FINAL_SCRIPTWITNESS, PSBT_IN_PREVIOUS_TXID, PSBT_IN_OUTPUT_INDEX,
+                PSBT_IN_SEQUENCE, PSBT_IN_REQUIRED_TIME_LOCKTIME,
+                PSBT_IN_REQUIRED_HEIGHT_LOCKTIME }
 
     blank_flds = (
         'unknown', 'utxo', 'witness_utxo', 'sighash', 'redeem_script', 'witness_script',
@@ -1071,7 +1074,10 @@ class psbtInputProxy(psbtProxy):
 class psbtObject(psbtProxy):
     "Just? parse and store"
     short_values = { PSBT_GLOBAL_TX_MODIFIABLE }
-    no_keys = { PSBT_GLOBAL_UNSIGNED_TX }
+    no_keys = { PSBT_GLOBAL_UNSIGNED_TX, PSBT_GLOBAL_TX_VERSION,
+                PSBT_GLOBAL_FALLBACK_LOCKTIME, PSBT_GLOBAL_INPUT_COUNT,
+                PSBT_GLOBAL_OUTPUT_COUNT, PSBT_GLOBAL_TX_MODIFIABLE,
+                PSBT_GLOBAL_VERSION }
 
     def __init__(self):
         super().__init__()
@@ -1154,10 +1160,14 @@ class psbtObject(psbtProxy):
         elif kt == PSBT_GLOBAL_FALLBACK_LOCKTIME:
             self.fallback_locktime = unpack("<I", self.get(val))[0]
         elif kt == PSBT_GLOBAL_INPUT_COUNT:
-            self.num_inputs = deser_compact_size(BytesIO(self.get(val)))
+            raw = self.get(val)
+            self.num_inputs = deser_compact_size(BytesIO(raw))
+            assert raw == ser_compact_size(self.num_inputs), "invalid input count"
             self.has_gic = True
         elif kt == PSBT_GLOBAL_OUTPUT_COUNT:
-            self.num_outputs = deser_compact_size(BytesIO(self.get(val)))
+            raw = self.get(val)
+            self.num_outputs = deser_compact_size(BytesIO(raw))
+            assert raw == ser_compact_size(self.num_outputs), "invalid output count"
             self.has_goc = True
         elif kt == PSBT_GLOBAL_TX_MODIFIABLE:
             # bytes of length 1 (tx modifiable in short_values)
@@ -1506,9 +1516,9 @@ class psbtObject(psbtProxy):
             # verision is provided in PSBT - take it as given
             assert self.version in (0,2)
         else:
-            # PSBT version is not defined
-            # global unsigned tx is only allowed in v0
-            self.version = 2 if self.txn is None else 0
+            # PSBTv0 may omit its version, but PSBTv2 must specify version 2.
+            assert self.txn, "v2 requires global version"
+            self.version = 0
 
         self.is_v2 = self.version is not None and self.version >= 2
 

--- a/testing/test_sign.py
+++ b/testing/test_sign.py
@@ -7,7 +7,13 @@ import time, pytest, os, random, pdb, struct, base64, binascii, itertools, datet
 from ckcc_protocol.protocol import CCProtocolPacker, CCProtoError
 from binascii import b2a_hex, a2b_hex
 from psbt import (BasicPSBT, BasicPSBTInput, BasicPSBTOutput, PSBT_IN_REDEEM_SCRIPT,
-                  PSBT_GLOBAL_VERSION, PSBT_IN_WITNESS_UTXO, PSBT_OUT_AMOUNT)
+                  PSBT_GLOBAL_VERSION, PSBT_GLOBAL_TX_VERSION,
+                  PSBT_GLOBAL_FALLBACK_LOCKTIME, PSBT_GLOBAL_INPUT_COUNT,
+                  PSBT_GLOBAL_OUTPUT_COUNT, PSBT_GLOBAL_TX_MODIFIABLE,
+                  PSBT_IN_WITNESS_UTXO, PSBT_IN_PREVIOUS_TXID,
+                  PSBT_IN_OUTPUT_INDEX, PSBT_IN_SEQUENCE,
+                  PSBT_IN_REQUIRED_TIME_LOCKTIME, PSBT_IN_REQUIRED_HEIGHT_LOCKTIME,
+                  PSBT_OUT_AMOUNT, PSBT_OUT_SCRIPT)
 from io import BytesIO
 from pprint import pprint
 from decimal import Decimal
@@ -81,6 +87,66 @@ def test_psbt_duplicate_singleton_key(try_sign, fake_txn, scope):
         try_sign(psbt, accept=False)
 
     assert 'PSBT parse failed' in ee.value.args[0]
+
+
+@pytest.mark.parametrize('scope, ktype, value', [
+    ('global', PSBT_GLOBAL_TX_VERSION, struct.pack('<I', 2)),
+    ('global', PSBT_GLOBAL_FALLBACK_LOCKTIME, struct.pack('<I', 0)),
+    ('global', PSBT_GLOBAL_INPUT_COUNT, b'\x01'),
+    ('global', PSBT_GLOBAL_OUTPUT_COUNT, b'\x01'),
+    ('global', PSBT_GLOBAL_TX_MODIFIABLE, b'\x00'),
+    ('global', PSBT_GLOBAL_VERSION, struct.pack('<I', 2)),
+    ('input', PSBT_IN_PREVIOUS_TXID, bytes(32)),
+    ('input', PSBT_IN_OUTPUT_INDEX, struct.pack('<I', 0)),
+    ('input', PSBT_IN_SEQUENCE, struct.pack('<I', 0xffffffff)),
+    ('input', PSBT_IN_REQUIRED_TIME_LOCKTIME, struct.pack('<I', 500000000)),
+    ('input', PSBT_IN_REQUIRED_HEIGHT_LOCKTIME, struct.pack('<I', 1)),
+    ('output', PSBT_OUT_AMOUNT, struct.pack('<q', 1000)),
+    ('output', PSBT_OUT_SCRIPT, b'\x51'),
+])
+def test_psbt_singleton_rejects_key_data(try_sign, fake_txn, scope, ktype, value):
+    def add_key_data(psbt):
+        target = psbt
+        if scope == 'input':
+            target = psbt.inputs[0]
+        elif scope == 'output':
+            target = psbt.outputs[0]
+        target.unknown = [(bytes([ktype, 0]), value)]
+
+    psbt = fake_txn(1, 1, psbt_v2=True, psbt_hacker=add_key_data)
+
+    with pytest.raises(CCProtoError) as ee:
+        try_sign(psbt, accept=False)
+
+    assert 'PSBT parse failed' in ee.value.args[0]
+
+
+@pytest.mark.parametrize('ktype', [PSBT_GLOBAL_INPUT_COUNT, PSBT_GLOBAL_OUTPUT_COUNT])
+def test_psbt_v2_rejects_non_exact_global_count(try_sign, fake_txn, ktype):
+    def add_trailing_count_byte(psbt):
+        if ktype == PSBT_GLOBAL_INPUT_COUNT:
+            psbt.input_count = None
+        else:
+            psbt.output_count = None
+        psbt.unknown = [(bytes([ktype]), b'\x01\x00')]
+
+    psbt = fake_txn(1, 1, psbt_v2=True, psbt_hacker=add_trailing_count_byte)
+
+    with pytest.raises(CCProtoError) as ee:
+        try_sign(psbt, accept=False)
+
+    assert 'PSBT parse failed' in ee.value.args[0]
+
+
+def test_psbt_v2_requires_global_version(try_sign, fake_txn):
+    psbt = fake_txn(1, 1, psbt_v2=True,
+                    psbt_hacker=lambda p: setattr(p, 'version', None))
+
+    with pytest.raises(CCProtoError) as ee:
+        try_sign(psbt, accept=False)
+
+    assert 'Invalid PSBT' in ee.value.args[0]
+
 
 @pytest.mark.parametrize('fn', [
 	'data/2-of-2.psbt',


### PR DESCRIPTION
## Summary

- reject keydata on BIP370 singleton global, input, and output fields
- require exact canonical CompactSize encodings for global input/output counts
- require PSBTv2 to explicitly provide global version 2
- add focused regressions for all affected fields and validation boundaries
